### PR TITLE
#SB-200: Make a profile for the strongbox-web-core that keeps Jetty running

### DIFF
--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -451,6 +451,26 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>block-jetty</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${version.jetty}</version>
+
+                        <configuration>
+                            <daemon>false</daemon>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Implemented.

To be invoked with:
mvn clean package -Pblock-jetty
(in the strongbox-web-core module).
