### PR TITLE
#SB-309: Convert the VersionValidator classes into a Spring-based implementation

### DIFF
--- a/strongbox-resources/strongbox-storage-resources/strongbox-storage-api-resources/src/main/resources/META-INF/spring/strongbox-storage-api-context.xml
+++ b/strongbox-resources/strongbox-storage-resources/strongbox-storage-api-resources/src/main/resources/META-INF/spring/strongbox-storage-api-context.xml
@@ -35,6 +35,17 @@
         <property name="resolvers" ref="resolvers"/>
     </bean>
 
+    <!-- Version versionValidators -->
+    <bean id="releaseVersionValidator" class="org.carlspring.strongbox.storage.validation.version.ReleaseVersionValidator"/>
+    <bean id="snapshotVersionValidator" class="org.carlspring.strongbox.storage.validation.version.SnapshotVersionValidator"/>
+    <bean id="redeploymentValidator" class="org.carlspring.strongbox.storage.validation.version.RedeploymentValidator"/>
+
+    <util:set id="versionValidators" set-class="java.util.LinkedHashSet">
+        <ref bean="releaseVersionValidator"/>
+        <ref bean="snapshotVersionValidator"/>
+        <ref bean="redeploymentValidator"/>
+    </util:set>
+
     <bean id="versionValidatorService" class="org.carlspring.strongbox.services.impl.VersionValidatorServiceImpl" />
 
     <bean id="artifactMetadataService" class="org.carlspring.strongbox.services.impl.ArtifactMetadataServiceImpl" />

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/VersionValidatorService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/VersionValidatorService.java
@@ -10,6 +10,6 @@ import java.util.Set;
 public interface VersionValidatorService
 {
 
-    Set<VersionValidator> getValidators();
+    Set<VersionValidator> getVersionValidators();
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/VersionValidatorServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/VersionValidatorServiceImpl.java
@@ -2,12 +2,11 @@ package org.carlspring.strongbox.services.impl;
 
 import org.carlspring.strongbox.services.VersionValidatorService;
 import org.carlspring.strongbox.storage.validation.version.VersionValidator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.LinkedHashSet;
-import java.util.ServiceLoader;
 import java.util.Set;
-
-import org.springframework.stereotype.Component;
 
 /**
  * @author mtodorov
@@ -17,27 +16,23 @@ public class VersionValidatorServiceImpl
         implements VersionValidatorService
 {
 
-    private Set<VersionValidator> validators = new LinkedHashSet<>();
+    @Autowired
+    private Set<VersionValidator> versionValidators = new LinkedHashSet<>();
 
 
     public VersionValidatorServiceImpl()
     {
-        ServiceLoader<VersionValidator> versionValidators = ServiceLoader.load(VersionValidator.class);
-        for (VersionValidator versionValidator : versionValidators)
-        {
-            validators.add(versionValidator);
-        }
     }
 
     @Override
-    public Set<VersionValidator> getValidators()
+    public Set<VersionValidator> getVersionValidators()
     {
-        return validators;
+        return versionValidators;
     }
 
-    public void setValidators(Set<VersionValidator> validators)
+    public void setVersionValidators(Set<VersionValidator> versionValidators)
     {
-        this.validators = validators;
+        this.versionValidators = versionValidators;
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/RedeploymentValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/RedeploymentValidator.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.storage.validation.version;
 
-import org.carlspring.strongbox.storage.repository.Repository;
-
 import org.apache.maven.artifact.Artifact;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.springframework.stereotype.Component;
 
 /**
  * @author mtodorov
  */
+@Component
 public class RedeploymentValidator implements VersionValidator
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/ReleaseVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/ReleaseVersionValidator.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.storage.validation.version;
 
-import org.carlspring.strongbox.storage.repository.Repository;
-
 import org.apache.maven.artifact.Artifact;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.springframework.stereotype.Component;
 
 /**
  * @author stodorov
  */
+@Component
 public class ReleaseVersionValidator
         implements VersionValidator
 {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/SnapshotVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/version/SnapshotVersionValidator.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.storage.validation.version;
 
-import org.carlspring.strongbox.storage.repository.Repository;
-
 import org.apache.maven.artifact.Artifact;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.springframework.stereotype.Component;
 
 /**
  * @author stodorov
  */
+@Component
 public class SnapshotVersionValidator
         implements VersionValidator
 {

--- a/strongbox-storage/strongbox-storage-api/src/main/resources/META-INF/services/org.carlspring.strongbox.storage.validation.version.VersionValidator
+++ b/strongbox-storage/strongbox-storage-api/src/main/resources/META-INF/services/org.carlspring.strongbox.storage.validation.version.VersionValidator
@@ -1,3 +1,0 @@
-org.carlspring.strongbox.storage.validation.version.RedeploymentValidator
-org.carlspring.strongbox.storage.validation.version.ReleaseVersionValidator
-org.carlspring.strongbox.storage.validation.version.SnapshotVersionValidator

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
@@ -1,12 +1,12 @@
 package org.carlspring.strongbox.storage.validation.version;
 
 import org.carlspring.strongbox.services.VersionValidatorService;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
 import static junit.framework.TestCase.assertFalse;
 
 /**
@@ -24,7 +24,7 @@ public class VersionValidatorServiceTest
     @Test
     public void testValidationService()
     {
-        assertFalse(versionValidatorService.getValidators().isEmpty());
+        assertFalse(versionValidatorService.getVersionValidators().isEmpty());
     }
 
 }

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactManagementServiceImpl.java
@@ -187,7 +187,7 @@ public class ArtifactManagementServiceImpl
             {
                 Artifact artifact = ArtifactUtils.convertPathToArtifact(path);
 
-                final Set<VersionValidator> validators = versionValidatorService.getValidators();
+                final Set<VersionValidator> validators = versionValidatorService.getVersionValidators();
                 for (VersionValidator validator : validators)
                 {
                     validator.validate(repository, artifact);


### PR DESCRIPTION
Dropped the ServiceLoader implementation in favour of Spring.