### PR TITLE
#SB-338: When returning an artifact for download, add it's checksums to the HTTP headers

### DIFF
--- a/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
@@ -201,6 +201,22 @@ public class ArtifactClient
         return response.readEntity(InputStream.class);
     }
 
+    public Response getResourceWithResponse(String path)
+            throws ArtifactTransportException,
+                   IOException
+    {
+        Client client = ClientBuilder.newClient();
+
+        String url = getContextBaseUrl() + (!path.startsWith("/") ? "/" : "") + path;
+
+        logger.debug("Getting " + url + "...");
+
+        WebTarget webResource = client.target(url);
+        setupAuthentication(webResource);
+
+        return webResource.request(MediaType.TEXT_PLAIN).get();
+    }
+
     public void deleteArtifact(Artifact artifact,
                                String storageId,
                                String repositoryId)

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
@@ -57,11 +57,26 @@ public class MessageDigestUtils
             throws IOException
     {
         InputStream is = null;
-        BufferedReader br = null;
 
         try
         {
             is = new FileInputStream(path);
+
+            return readChecksumFile(is);
+        }
+        finally
+        {
+            ResourceCloser.close(is, null);
+        }
+    }
+
+    public static String readChecksumFile(InputStream is)
+            throws IOException
+    {
+        BufferedReader br = null;
+
+        try
+        {
             br = new BufferedReader(new InputStreamReader(is));
 
             return br.readLine();

--- a/strongbox-resources/strongbox-storage-resources/strongbox-storage-api-resources/src/main/resources/etc/conf/strongbox.xml
+++ b/strongbox-resources/strongbox-storage-resources/strongbox-storage-api-resources/src/main/resources/etc/conf/strongbox.xml
@@ -9,7 +9,7 @@
         <storage id="storage0">
             <repositories>
                 <!-- Secured repositories do not allow anonymous access -->
-                <repository id="releases" policy="release" implementation="file-system" type="hosted" allows-force-deletion="true"/>
+                <repository id="releases" policy="release" implementation="file-system" type="hosted" allows-force-deletion="true" checksum-headers-enabled="true"/>
                 <repository id="releases-in-memory" policy="release" implementation="in-memory" type="hosted"/>
                 <repository id="releases-with-redeployment" policy="release" implementation="file-system" type="hosted" allows-redeployment="true" indexing-enabled="false"/>
                 <repository id="releases-with-trash" policy="release" implementation="file-system" type="hosted" trash-enabled="true" indexing-enabled="false"/>
@@ -19,7 +19,7 @@
                 <repository id="releases-without-delete-trash" policy="release" implementation="file-system" type="hosted" trash-enabled="true" allows-delete="false" indexing-enabled="false"/>
                 <repository id="releases-without-browsing" policy="release" implementation="file-system" type="hosted" allows-directory-browsing="false" indexing-enabled="false"/>
 
-                <repository id="snapshots" policy="snapshot" implementation="file-system" type="hosted" secured="true" />
+                <repository id="snapshots" policy="snapshot" implementation="file-system" type="hosted" secured="true" checksum-headers-enabled="true"/>
                 <repository id="snapshots-in-memory" policy="snapshot" implementation="in-memory" type="hosted" secured="true" />
 
                 <repository id="proxied-releases" policy="release" implementation="file-system" type="proxy">

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/BasicRepositoryService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/BasicRepositoryService.java
@@ -6,7 +6,7 @@ import org.carlspring.strongbox.storage.repository.Repository;
 /**
  * @author mtodorov
  */
-public interface BasicRepositoryService
+public interface BasicRepositoryService extends ConfigurationService
 {
 
     boolean containsArtifact(Repository repository, Artifact artifact);

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ConfigurationService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ConfigurationService.java
@@ -1,0 +1,13 @@
+package org.carlspring.strongbox.services;
+
+import org.carlspring.strongbox.configuration.Configuration;
+
+/**
+ * @author mtodorov
+ */
+public interface ConfigurationService
+{
+
+    Configuration getConfiguration();
+
+}

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/BasicRepositoryServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/BasicRepositoryServiceImpl.java
@@ -115,6 +115,7 @@ public class BasicRepositoryServiceImpl
         this.configurationManager = configurationManager;
     }
 
+    @Override
     public Configuration getConfiguration()
     {
         return configurationManager.getConfiguration();

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/Repository.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/Repository.java
@@ -55,6 +55,9 @@ public class Repository
     @XmlAttribute(name = "allows-directory-browsing")
     private boolean allowsDirectoryBrowsing = true;
 
+    @XmlAttribute(name = "checksum-headers-enabled")
+    private boolean checksumHeadersEnabled = false;
+
     /**
      * The per-repository proxy settings that override the overall global proxy settings.
      */
@@ -222,6 +225,16 @@ public class Repository
     public void setAllowsDirectoryBrowsing(boolean allowsDirectoryBrowsing)
     {
         this.allowsDirectoryBrowsing = allowsDirectoryBrowsing;
+    }
+
+    public boolean isChecksumHeadersEnabled()
+    {
+        return checksumHeadersEnabled;
+    }
+
+    public void setChecksumHeadersEnabled(boolean checksumHeadersEnabled)
+    {
+        this.checksumHeadersEnabled = checksumHeadersEnabled;
     }
 
     public ProxyConfiguration getProxyConfiguration()

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 /**
  * @author mtodorov
  */
-public interface ArtifactManagementService
+public interface ArtifactManagementService extends ConfigurationService
 {
 
     void store(String storageId,

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/ConfigurationManagementService.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/ConfigurationManagementService.java
@@ -11,14 +11,11 @@ import java.io.IOException;
 /**
  * @author mtodorov
  */
-public interface ConfigurationManagementService
+public interface ConfigurationManagementService extends ConfigurationService
 {
 
     void setConfiguration(Configuration configuration)
             throws IOException, JAXBException;
-
-    Configuration getConfiguration()
-            throws IOException;
 
     String getBaseUrl()
             throws IOException;

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactManagementServiceImpl.java
@@ -365,7 +365,8 @@ public class ArtifactManagementServiceImpl
         }
     }
 
-    private Configuration getConfiguration()
+    @Override
+    public Configuration getConfiguration()
     {
         return configurationManager.getConfiguration();
     }

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactSearchServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactSearchServiceImpl.java
@@ -1,7 +1,9 @@
 package org.carlspring.strongbox.services.impl;
 
+import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.services.ArtifactSearchService;
+import org.carlspring.strongbox.services.ConfigurationService;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.indexing.*;
 import org.carlspring.strongbox.storage.repository.Repository;
@@ -20,7 +22,8 @@ import org.springframework.stereotype.Component;
  * @author mtodorov
  */
 @Component
-public class ArtifactSearchServiceImpl implements ArtifactSearchService
+public class ArtifactSearchServiceImpl
+        implements ArtifactSearchService, ConfigurationService
 {
 
     private static final Logger logger = LoggerFactory.getLogger(ArtifactSearchServiceImpl.class);
@@ -40,7 +43,7 @@ public class ArtifactSearchServiceImpl implements ArtifactSearchService
 
         final String repositoryId = searchRequest.getRepositoryId();
 
-        final Collection<Storage> storages = configurationManager.getConfiguration().getStorages().values();
+        final Collection<Storage> storages = getConfiguration().getStorages().values();
         if (repositoryId != null && !repositoryId.isEmpty())
         {
             logger.debug("Repository: {}", repositoryId);
@@ -126,6 +129,12 @@ public class ArtifactSearchServiceImpl implements ArtifactSearchService
     public void setRepositoryIndexManager(RepositoryIndexManager repositoryIndexManager)
     {
         this.repositoryIndexManager = repositoryIndexManager;
+    }
+
+    @Override
+    public Configuration getConfiguration()
+    {
+        return configurationManager.getConfiguration();
     }
 
 }

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
@@ -44,7 +44,6 @@ public class ConfigurationManagementServiceImpl implements ConfigurationManageme
 
     @Override
     public Configuration getConfiguration()
-            throws IOException
     {
         return configurationManager.getConfiguration();
     }

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
@@ -1,6 +1,5 @@
 package org.carlspring.strongbox.services.impl;
 
-import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.services.RepositoryManagementService;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.indexing.RepositoryIndexManager;
@@ -29,9 +28,6 @@ public class RepositoryManagementServiceImpl extends BasicRepositoryServiceImpl
     private static final Logger logger = LoggerFactory.getLogger(RepositoryManagementServiceImpl.class);
 
     @Autowired
-    private ConfigurationManager configurationManager;
-
-    @Autowired
     private RepositoryIndexManager repositoryIndexManager;
 
     @Autowired
@@ -43,7 +39,7 @@ public class RepositoryManagementServiceImpl extends BasicRepositoryServiceImpl
                                  String repositoryId)
             throws IOException
     {
-        Storage storage = configurationManager.getConfiguration().getStorage(storageId);
+        Storage storage = getConfiguration().getStorage(storageId);
 
         final String storageBasedirPath = storage.getBasedir();
         final File repositoryBasedir = new File(storageBasedirPath, repositoryId).getAbsoluteFile();
@@ -120,7 +116,7 @@ public class RepositoryManagementServiceImpl extends BasicRepositoryServiceImpl
                                           String repositoryId)
             throws IOException
     {
-        Storage storage = configurationManager.getConfiguration().getStorage(storageId);
+        Storage storage = getConfiguration().getStorage(storageId);
 
         final String storageBasedirPath = storage.getBasedir();
 

--- a/strongbox-storage/strongbox-storage-metadata/src/main/java/org/carlspring/strongbox/services/ArtifactMetadataService.java
+++ b/strongbox-storage/strongbox-storage-metadata/src/main/java/org/carlspring/strongbox/services/ArtifactMetadataService.java
@@ -11,7 +11,7 @@ import java.security.NoSuchAlgorithmException;
 /**
  * @author stodorov
  */
-public interface ArtifactMetadataService
+public interface ArtifactMetadataService extends ConfigurationService
 {
 
     /**

--- a/strongbox-storage/strongbox-storage-metadata/src/main/java/org/carlspring/strongbox/services/impl/ArtifactMetadataServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-metadata/src/main/java/org/carlspring/strongbox/services/impl/ArtifactMetadataServiceImpl.java
@@ -51,7 +51,7 @@ public class ArtifactMetadataServiceImpl
 
         Path artifactBasePath = Paths.get(repository.getBasedir(), artifactPath);
 
-        return metadataManager.getMetadata(artifactBasePath);
+        return metadataManager.readMetadata(artifactBasePath);
     }
 
     @Override
@@ -59,14 +59,14 @@ public class ArtifactMetadataServiceImpl
             throws IOException,
                    XmlPullParserException
     {
-        return metadataManager.getMetadata(Paths.get(artifactBasePath));
+        return metadataManager.readMetadata(Paths.get(artifactBasePath));
     }
 
     @Override
     public Metadata getMetadata(InputStream is)
             throws IOException, XmlPullParserException
     {
-        return metadataManager.getMetadata(is);
+        return metadataManager.readMetadata(is);
     }
 
     public void rebuildMetadata(String storageId, String repositoryId, String basePath)
@@ -101,6 +101,7 @@ public class ArtifactMetadataServiceImpl
         metadataManager.mergeMetadata(repository, artifact, mergeMetadata);
     }
 
+    @Override
     public Configuration getConfiguration()
     {
         return configurationManager.getConfiguration();

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ConfigurationManagementRestlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ConfigurationManagementRestlet.java
@@ -76,18 +76,9 @@ public class ConfigurationManagementRestlet
     public Response getConfiguration()
             throws IOException, ParseException
     {
-        try
-        {
-            logger.debug("Received configuration request.");
+        logger.debug("Received configuration request.");
 
-            return Response.status(Response.Status.OK).entity(configurationManagementService.getConfiguration()).build();
-        }
-        catch (IOException e)
-        {
-            logger.error(e.getMessage(), e);
-
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
-        }
+        return Response.status(Response.Status.OK).entity(configurationManagementService.getConfiguration()).build();
     }
 
     @PUT

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/MetadataManagementRestletTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/MetadataManagementRestletTest.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.InputStream;
 
@@ -126,8 +127,18 @@ public class MetadataManagementRestletTest
         assertTrue("Failed to rebuild snapshot metadata!", client.pathExists(metadataPath2));
         assertTrue("Failed to rebuild snapshot metadata!", client.pathExists(metadataPath3));
 
-        InputStream is = client.getResource(metadataPath2);
+        Response resourceWithResponse = client.getResourceWithResponse(metadataPath2);
+        InputStream is = resourceWithResponse.readEntity(InputStream.class);
         Metadata metadata2 = artifactMetadataService.getMetadata(is);
+
+        String md5 = resourceWithResponse.getHeaderString("Checksum-MD5");
+        String sha1 = resourceWithResponse.getHeaderString("Checksum-SHA1");
+
+        assertNotNull("Failed to retrieve MD5 checksum via HTTP header!", md5);
+        assertNotNull("Failed to retrieve SHA-1 checksum via HTTP header!", sha1);
+
+        System.out.println("MD5:   " + md5);
+        System.out.println("SHA-1: " + sha1);
 
         assertNotNull("Incorrect metadata!", metadata2.getVersioning());
         assertNotNull("Incorrect metadata!", metadata2.getVersioning().getLatest());


### PR DESCRIPTION
- Added a convenience method to the ArtifactClient so that it can return the headers.
- Made the MessageDigestUtils support a checksum directly from an InputStream.
- Added a ConfigurationService interface which should be used by all classes which hava a Configuration getConfiguration() method (and applied the necessary refactoring).
- Renamed the MetadataManager.getMetadata(...) method to MetadataManager.readMetadata(...) and applied the necessary refactoring.
- Added a strongbox.xml configuration setting for enabling the checksums in headers functionality.
- Implemented the checksums in headers functionality.
- Made the MetadataManagementRestletTest case (method which covers SNAPSHOT-s) check the headers for checksums.