### PR TITLE
SB-437: Make sure the simple-test.xml is not included in the final artifact, or simply remove the test case that uses it

### DIFF
--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -48,34 +48,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-
-                <executions>
-                    <execution>
-                        <id>create-jar</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>create-jar-with-classpath</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>${project.artifactId}-${project.version}-classpath</finalName>
-                            <includes>
-                                <include>META-INF/spring/dummy.xml</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>create-test-jar</id>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
@@ -88,17 +60,6 @@
                         <logging.dir>${project.build.directory}/strongbox/logs</logging.dir>
                     </systemPropertyVariables>
                 </configuration>
-
-                <dependencies>
-                    <dependency>
-                        <groupId>${project.groupId}</groupId>
-                        <artifactId>${project.artifactId}</artifactId>
-                        <version>${project.version}</version>
-                        <classifier>classpath-tests</classifier>
-                        <scope>system</scope>
-                        <systemPath>${basedir}/target/${project.artifactId}-${project.version}-classpath-tests.jar</systemPath>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/resource/ResourcesBooterTest.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/resource/ResourcesBooterTest.java
@@ -29,7 +29,7 @@ public class ResourcesBooterTest
     public void testResourceBooting()
             throws Exception
     {
-        File file = new File(ConfigurationResourceResolver.getVaultDirectory() + "/etc/conf/simple-test.xml");
+        File file = new File(ConfigurationResourceResolver.getVaultDirectory() + "/etc/conf/strongbox.xml");
 
         assertTrue("Failed to copy configuration resource from classpath!", file.exists());
     }


### PR DESCRIPTION
- Removed the obsolete resource.
- Cleaned up the pom.xml.