### PR TITLE
SB-420: Spring Security authentication and authorization

### DIFF
--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -174,6 +174,18 @@
             </dependency>
 
             <dependency>
+                <groupId>com.orientechnologies</groupId>
+                <artifactId>orientdb-core</artifactId>
+                <version>${version.orientdb}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.orientechnologies</groupId>
+                <artifactId>orientdb-object</artifactId>
+                <version>${version.orientdb}</version>
+            </dependency>
+            
+            <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-config</artifactId>
                 <version>${version.spring.security}</version>

--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -57,6 +57,8 @@
         <version.slf4j>1.7.7</version.slf4j>
         <version.logback>1.1.2</version.logback>
         <version.spring>4.2.4.RELEASE</version.spring>
+        <version.spring.security>4.0.4.RELEASE</version.spring.security>
+        <version.orientdb>2.1.13</version.orientdb>
     </properties>
 
     <build>
@@ -164,6 +166,29 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <dependency>
+                <groupId>com.orientechnologies</groupId>
+                <artifactId>orientdb-server</artifactId>
+                <version>${version.orientdb}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-config</artifactId>
+                <version>${version.spring.security}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>${version.spring.security}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-web</artifactId>
+                <version>${version.spring.security}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.carlspring.commons</groupId>
                 <artifactId>commons-io</artifactId>

--- a/strongbox-resources/strongbox-web-resources/src/main/webapp/WEB-INF/web.xml
+++ b/strongbox-resources/strongbox-web-resources/src/main/webapp/WEB-INF/web.xml
@@ -22,6 +22,16 @@
            <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
     </listener>
 
+    <filter>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>springSecurityFilterChain</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+
     <servlet>
         <servlet-name>jersey-serlvet</servlet-name>
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -309,13 +309,11 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-core</artifactId>
-            <version>${version.orientdb}</version>
         </dependency>
 
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-object</artifactId>
-            <version>${version.orientdb}</version>
         </dependency>
 
         <dependency>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -307,6 +307,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.orientechnologies</groupId>
+            <artifactId>orientdb-core</artifactId>
+            <version>${version.orientdb}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.orientechnologies</groupId>
+            <artifactId>orientdb-object</artifactId>
+            <version>${version.orientdb}</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -302,6 +302,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.orientechnologies</groupId>
+            <artifactId>orientdb-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>
@@ -313,6 +318,19 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
         </dependency>
 
         <dependency>

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/SpringSecurityUser.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/SpringSecurityUser.java
@@ -37,7 +37,7 @@ class SpringSecurityUser implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return user.getUserName();
+		return user.getUsername();
 	}
 
 	@Override

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/SpringSecurityUser.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/SpringSecurityUser.java
@@ -1,0 +1,62 @@
+package org.carlspring.strongbox.rest.app.spring.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * A wrapper of {@link StrongboxUser} that is used by Spring Security
+ */
+class SpringSecurityUser implements UserDetails {
+	private final StrongboxUser user;
+
+	SpringSecurityUser(final StrongboxUser user) {
+		this.user = user;
+	}
+
+	public void setSalt(final String salt) {
+		user.setSalt(salt);
+	}
+
+	public String getSalt() {
+		return user.getSalt();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return user.getRoles().stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUserName();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return isEnabled();
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return isEnabled();
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return isEnabled();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return user.isEnabled();
+	}
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUser.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUser.java
@@ -7,18 +7,18 @@ import java.util.List;
  * An application user
  */
 public class StrongboxUser {
-	private String userName;
+	private String username;
 	private String password;
 	private boolean enabled;
 	private String salt;
 	private List<String> roles = new ArrayList<>();
 
-	public String getUserName() {
-		return userName;
+	public String getUsername() {
+		return username;
 	}
 
-	public void setUserName(final String userName) {
-		this.userName = userName;
+	public void setUsername(final String username) {
+		this.username = username;
 	}
 
 	public String getPassword() {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUser.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUser.java
@@ -1,0 +1,55 @@
+package org.carlspring.strongbox.rest.app.spring.security;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An application user
+ */
+public class StrongboxUser {
+	private String userName;
+	private String password;
+	private boolean enabled;
+	private String salt;
+	private List<String> roles = new ArrayList<>();
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(final String userName) {
+		this.userName = userName;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(final String password) {
+		this.password = password;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(final boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getSalt() {
+		return salt;
+	}
+
+	public void setSalt(final String salt) {
+		this.salt = salt;
+	}
+
+	public List<String> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(final List<String> roles) {
+		this.roles = roles;
+	}
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUserDetailService.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/StrongboxUserDetailService.java
@@ -1,0 +1,24 @@
+package org.carlspring.strongbox.rest.app.spring.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StrongboxUserDetailService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        StrongboxUser user = userRepository.findByUserName(username);
+        if (user == null) {
+            throw new UsernameNotFoundException("Cannot find user with that username");
+        }
+
+        return new SpringSecurityUser(user);
+    }
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UnauthorizedEntryPoint.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UnauthorizedEntryPoint.java
@@ -16,7 +16,7 @@ public class UnauthorizedEntryPoint implements AuthenticationEntryPoint {
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
 			throws IOException, ServletException {
 
-		// Use the type of authException to decide what to present to the use.
+		// Use the type of authException to decide what to present to the user.
 		// This simple impl just redirects to /login but it could be that the
 		// user is already logged in and (s)he has not enough rights
 		response.sendRedirect("/login");

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UnauthorizedEntryPoint.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UnauthorizedEntryPoint.java
@@ -1,0 +1,24 @@
+package org.carlspring.strongbox.rest.app.spring.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * An entry point used when an unauthorized access is attempt
+ */
+public class UnauthorizedEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+			throws IOException, ServletException {
+
+		// Use the type of authException to decide what to present to the use.
+		// This simple impl just redirects to /login but it could be that the
+		// user is already logged in and (s)he has not enough rights
+		response.sendRedirect("/login");
+	}
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UserRepository.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UserRepository.java
@@ -23,17 +23,8 @@ public class UserRepository {
 
 	public StrongboxUser findByUserName(final String username) {
 
-		// dummy impl that "finds" only user with username/password: strongbox/strongbox
-		StrongboxUser user;
-		if ("strongbox".equals(username)) {
-			user = new StrongboxUser();
-			user.setEnabled(true);
-			user.setUsername(username);
-			String password = passwordEncoder.encode(username);
-			user.setPassword(password);
-		}
-
-		user = withDatabase(db -> {
+		StrongboxUser user = withDatabase(db -> {
+			// TODO Does OrientDB support parameters ?!
 			OSQLSynchQuery<StrongboxUser> query = new OSQLSynchQuery<>("SELECT * FROM StrongboxUser WHERE username = '"+username+"'");
 			List<StrongboxUser> result = db.query(query);
 			if (!result.isEmpty()) {
@@ -49,6 +40,9 @@ public class UserRepository {
 
 	@PostConstruct
 	public void postConstruct() {
+		// add a user for testing
+		// Usually OrientDB should be setup separately(i.e.remotely) and
+		// users should be added either via REST endpoint or via OrientDB Studio/Console
 		withDatabase(db -> {
 			db.getEntityManager().registerEntityClass(StrongboxUser.class);
 
@@ -64,6 +58,8 @@ public class UserRepository {
 	}
 
 	private <R> R withDatabase(Function<OObjectDatabaseTx, R> code) {
+		// for simplicity use inmemory database
+		// TODO Replace it with remote instance!
 		OObjectDatabaseTx db = new OObjectDatabaseTx("memory:strongbox");
 		try {
 			if (db.exists()) {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UserRepository.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/app/spring/security/UserRepository.java
@@ -1,0 +1,82 @@
+package org.carlspring.strongbox.rest.app.spring.security;
+
+import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
+import com.orientechnologies.orient.core.sql.query.OSQLSynchQuery;
+import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.PostConstruct;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * DAO for {@link StrongboxUser} entities
+ */
+@Repository
+public class UserRepository {
+
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+
+	public StrongboxUser findByUserName(final String username) {
+
+		// dummy impl that "finds" only user with username/password: strongbox/strongbox
+		StrongboxUser user;
+		if ("strongbox".equals(username)) {
+			user = new StrongboxUser();
+			user.setEnabled(true);
+			user.setUsername(username);
+			String password = passwordEncoder.encode(username);
+			user.setPassword(password);
+		}
+
+		user = withDatabase(db -> {
+			OSQLSynchQuery<StrongboxUser> query = new OSQLSynchQuery<>("SELECT * FROM StrongboxUser WHERE username = '"+username+"'");
+			List<StrongboxUser> result = db.query(query);
+			if (!result.isEmpty()) {
+				StrongboxUser strongboxUser = result.get(0);
+				strongboxUser = db.detach(strongboxUser, true);
+				return strongboxUser;
+			}
+			return null;
+		});
+
+		return user;
+	}
+
+	@PostConstruct
+	public void postConstruct() {
+		withDatabase(db -> {
+			db.getEntityManager().registerEntityClass(StrongboxUser.class);
+
+			StrongboxUser martin = db.newInstance(StrongboxUser.class);
+			martin.setUsername("martin" );
+			martin.setPassword( passwordEncoder.encode("agent007"));
+			martin.setRoles(Collections.singletonList("ROLE_ADMIN"));
+			martin.setEnabled(true);
+
+			db.save(martin);
+			return null;
+		});
+	}
+
+	private <R> R withDatabase(Function<OObjectDatabaseTx, R> code) {
+		OObjectDatabaseTx db = new OObjectDatabaseTx("memory:strongbox");
+		try {
+			if (db.exists()) {
+				ODatabaseRecordThreadLocal.INSTANCE.set(db.getUnderlying());
+				db.open("admin", "admin");
+			} else {
+				db.create();
+			}
+			return code.apply(db);
+		} finally {
+			if (!db.isClosed()) {
+				db.close();
+			}
+		}
+	}
+}

--- a/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
+++ b/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
@@ -66,15 +66,17 @@
             entry-point-ref="unauthorizedEntryPoint"
             authentication-manager-ref="authenticationManager">
 
-        <!-- CSRF is disabled until Angular start sending it back -->
+        <!-- CSRF is disabled so that the application security could be tested with the browser.
+        Re-enable it once the Angular app start sending the CSRF token with every request -->
         <security:csrf disabled="true"/>
 
         <!--
-        Use Spring Security's (ugly) login page until prettier one is provided
+        Use Spring Security's (ugly) login page until prettier one is provided (with Angular)
         -->
         <security:form-login/>
 
-        <!-- Enables Spring Security's /logout endpoint that could be used to logout an user -->
+        <!-- Enables Spring Security's /logout endpoint that could be used to logout an user
+        -->
         <security:logout logout-url="/logout" />
 
         <!--

--- a/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
+++ b/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
@@ -17,40 +17,81 @@
     </beans:bean>
 
     <security:authentication-manager alias="authenticationManager">
+
+        <!--
+         Custom authentication provider based on OrientDB as user storage
+         -->
         <security:authentication-provider user-service-ref="userDetailService">
             <security:password-encoder ref="passwordEncoder"/>
         </security:authentication-provider>
+
+        <!--
+        A demo of simple in-memory authentication provider
+        -->
         <security:authentication-provider>
             <security:user-service>
-                <security:user name="martin" password="agent007" authorities="ROLE_ADMIN" />
+                <!-- This user is also setup with OrientDB -->
+                <!--<security:user name="martin" password="agent007" authorities="ROLE_ADMIN" />-->
+
+                <!-- A second user which has no rights to open /configuration/strongbox/** -->
                 <security:user name="james" password="bond" authorities="ROLE_USER" />
             </security:user-service>
         </security:authentication-provider>
+
+        <!--
+         For LDAP authentication see:
+         https://spring.io/guides/gs/authenticating-ldap/
+         https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/jc.html#ldap-authentication
+         -->
+
+        <!--
+         For Atlassian Crowd see:
+         https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Spring+Security
+         -->
+
+        <!--
+         For CAS see:
+         https://docs.spring.io/spring-security/site/docs/3.0.x/reference/cas.html
+         https://docs.spring.io/spring-security/site/docs/4.0.x/reference/html/sample-apps.html#cas-sample
+        -->
+
     </security:authentication-manager>
 
     <beans:bean id="unauthorizedEntryPoint" class="org.carlspring.strongbox.rest.app.spring.security.UnauthorizedEntryPoint" />
-            <!--auto-config="true"-->
+
     <security:http
             use-expressions="true"
             realm="Strongbox Realm"
             create-session="always"
             entry-point-ref="unauthorizedEntryPoint"
             authentication-manager-ref="authenticationManager">
+
+        <!-- CSRF is disabled until Angular start sending it back -->
         <security:csrf disabled="true"/>
-        <!--<security:http-basic/>-->
-        <security:access-denied-handler error-page="/login"/>
-        <!--<security:headers disabled="true"/>-->
+
+        <!--
+        Use Spring Security's (ugly) login page until prettier one is provided
+        -->
         <security:form-login/>
-        <security:logout />
-        <!--<security:anonymous enabled="false" />-->
+
+        <!-- Enables Spring Security's /logout endpoint that could be used to logout an user -->
+        <security:logout logout-url="/logout" />
+
+        <!--
+        Uncomment to enable any logged in user to be able to request that url
         <security:intercept-url method="GET" pattern="/configuration/strongbox/**" access="isAuthenticated()" />
+        -->
+
+        <!-- Only admins could open this url -->
+        <security:intercept-url method="GET" pattern="/configuration/strongbox/**" access="hasRole('ROLE_ADMIN')" />
+
+        <!--
+        Uncomment to enable anonymous users
+        <security:anonymous enabled="true"/>
+        -->
+
+        <!-- Any user can reach anything else -->
         <security:intercept-url pattern="/**" access="permitAll" />
-        <!--<security:custom-filter ref="authenticationTokenProcessingFilter" position="FORM_LOGIN_FILTER" />-->
-        <!--<security:intercept-url pattern="/rest/user/authenticate" access="permitAll" />-->
-        <!--<security:intercept-url method="GET" pattern="/rest/news/**" access="hasRole('user')" />-->
-        <!--<security:intercept-url method="PUT" pattern="/rest/news/**" access="hasRole('admin')" />-->
-        <!--<security:intercept-url method="POST" pattern="/rest/news/**" access="hasRole('admin')" />-->
-        <!--<security:intercept-url method="DELETE" pattern="/rest/news/**" access="hasRole('admin')" />-->
     </security:http>
 
 

--- a/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
+++ b/strongbox-web-core/src/main/resources/META-INF/spring/strongbox-security-context.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
+             xmlns:security="http://www.springframework.org/schema/security"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
+                                 http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.0.xsd">
+
+    <security:global-method-security authentication-manager-ref="authenticationManager"
+                                     pre-post-annotations="enabled" />
+
+    <beans:bean id="userDao" class="org.carlspring.strongbox.rest.app.spring.security.UserRepository"/>
+
+    <beans:bean id="userDetailService" class="org.carlspring.strongbox.rest.app.spring.security.StrongboxUserDetailService"/>
+
+    <beans:bean id="passwordEncoder" class="org.springframework.security.crypto.password.StandardPasswordEncoder">
+        <beans:constructor-arg value="ThisIsASecretSoChangeMe" />
+    </beans:bean>
+
+    <security:authentication-manager alias="authenticationManager">
+        <security:authentication-provider user-service-ref="userDetailService">
+            <security:password-encoder ref="passwordEncoder"/>
+        </security:authentication-provider>
+        <security:authentication-provider>
+            <security:user-service>
+                <security:user name="martin" password="agent007" authorities="ROLE_ADMIN" />
+                <security:user name="james" password="bond" authorities="ROLE_USER" />
+            </security:user-service>
+        </security:authentication-provider>
+    </security:authentication-manager>
+
+    <beans:bean id="unauthorizedEntryPoint" class="org.carlspring.strongbox.rest.app.spring.security.UnauthorizedEntryPoint" />
+            <!--auto-config="true"-->
+    <security:http
+            use-expressions="true"
+            realm="Strongbox Realm"
+            create-session="always"
+            entry-point-ref="unauthorizedEntryPoint"
+            authentication-manager-ref="authenticationManager">
+        <security:csrf disabled="true"/>
+        <!--<security:http-basic/>-->
+        <security:access-denied-handler error-page="/login"/>
+        <!--<security:headers disabled="true"/>-->
+        <security:form-login/>
+        <security:logout />
+        <!--<security:anonymous enabled="false" />-->
+        <security:intercept-url method="GET" pattern="/configuration/strongbox/**" access="isAuthenticated()" />
+        <security:intercept-url pattern="/**" access="permitAll" />
+        <!--<security:custom-filter ref="authenticationTokenProcessingFilter" position="FORM_LOGIN_FILTER" />-->
+        <!--<security:intercept-url pattern="/rest/user/authenticate" access="permitAll" />-->
+        <!--<security:intercept-url method="GET" pattern="/rest/news/**" access="hasRole('user')" />-->
+        <!--<security:intercept-url method="PUT" pattern="/rest/news/**" access="hasRole('admin')" />-->
+        <!--<security:intercept-url method="POST" pattern="/rest/news/**" access="hasRole('admin')" />-->
+        <!--<security:intercept-url method="DELETE" pattern="/rest/news/**" access="hasRole('admin')" />-->
+    </security:http>
+
+
+</beans:beans>


### PR DESCRIPTION
This Pull Request adds authen/authorization with Spring Security.
`strongbox-security-context.xml` sets up two providers 
- one that uses custom implementation based on OrientDB (first time using OrientDB, so be kind! :-) )
- one that uses simple provider with hardcoded users in the context.xml

To add other types of providers see the links in the .xml file.

To add more security:
- add more `<security:intercept-url>` entries in the context.xml and define which roles are allowed/denied to reach them
- provide REST APIs to add/edit/remove users (with roles)