### PR TITLE
SB-471: Fix the failing tests under Ubuntu

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ConfigurationManagementRestlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ConfigurationManagementRestlet.java
@@ -83,6 +83,7 @@ public class ConfigurationManagementRestlet
 
     @PUT
     @Path("/baseUrl/{baseUrl:.*}")
+    @Produces(MediaType.TEXT_PLAIN)
     public Response setBaseUrl(@PathParam("baseUrl") String baseUrl)
             throws IOException,
                    AuthenticationException,
@@ -123,6 +124,7 @@ public class ConfigurationManagementRestlet
 
     @PUT
     @Path("/port/{port}")
+    @Produces(MediaType.TEXT_PLAIN)
     public Response setPort(@PathParam("port") int port)
             throws IOException, JAXBException
     {


### PR DESCRIPTION
This should fix the tests which are sometimes failing under Ubuntu. (Not quite sure why Jersey seems to be behaving differently there for restlets that don't have @Produces/@Consumes annotations). The same fix may have to be applied elsewhere, if the 'javax.ws.rs.ProcessingException: org.apache.http.client.ClientProtocolException" re-occurs.