### PR TITLE
 Resources should be closed

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
@@ -13,10 +13,11 @@ public class ConnectionChecker
     public static boolean checkServiceAvailability(String host, int port, int timeout)
             throws IOException
     {
-        Socket socket = new Socket();
-        try
+        boolean isConnected = false;
+        try (Socket socket = new Socket())
         {
             socket.connect(new InetSocketAddress(host, port), timeout);
+            isConnected = socket.isConnected();
         }
         catch (SocketException e)
         {
@@ -30,7 +31,7 @@ public class ConnectionChecker
             return false;
         }
 
-        return socket.isConnected();
+        return isConnected;
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.