### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
@@ -10,6 +10,9 @@ public class ConnectionChecker
 {
 
 
+    private ConnectionChecker() {
+    }
+
     public static boolean checkServiceAvailability(String host, int port, int timeout)
             throws IOException
     {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ResourceCloser.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ResourceCloser.java
@@ -17,6 +17,9 @@ import org.slf4j.Logger;
 public class ResourceCloser
 {
 
+    private ResourceCloser() {
+    }
+
     public static void close(Closeable resource, Logger logger)
     {
         if (resource != null)

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ArtifactFileUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ArtifactFileUtils.java
@@ -7,6 +7,9 @@ public class ArtifactFileUtils
 {
 
 
+    private ArtifactFileUtils() {
+    }
+
     public static boolean isArtifactFile(String path)
     {
         return !isMetadataFile(path) && !isChecksum(path);

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/DirUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/DirUtils.java
@@ -10,6 +10,9 @@ public class DirUtils
 {
 
 
+    private DirUtils() {
+    }
+
     public static void removeEmptyAncestors(String path, String stopAtPath)
             throws IOException
     {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/FileUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/FileUtils.java
@@ -8,6 +8,9 @@ import java.io.File;
 public class FileUtils
 {
 
+    private FileUtils() {
+    }
+
     public static String normalizePath(String path)
     {
         if (path.contains("\\") && !File.separator.equals("\\"))

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
@@ -15,6 +15,9 @@ public class MessageDigestUtils
 
     private static final Logger logger = LoggerFactory.getLogger(MessageDigestUtils.class);
 
+    private MessageDigestUtils() {
+    }
+
 
     public static String convertToHexadecimalString(MessageDigest md)
     {

--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
@@ -25,6 +25,9 @@ public class MetadataHelper
 
     public static final SimpleDateFormat LAST_UPDATED_FIELD_FORMATTER = new SimpleDateFormat("yyyyMMddHHmmss");
 
+    private MetadataHelper() {
+    }
+
 
     public static void setLastUpdated(Versioning versioning)
     {

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/encryption/EncryptionUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/encryption/EncryptionUtils.java
@@ -16,6 +16,9 @@ public class EncryptionUtils
 
     private static Logger logger = LoggerFactory.getLogger(EncryptionUtils.class);
 
+    private EncryptionUtils() {
+    }
+
 
     /**
      * Encrypts a String using the MD5 algorithm.

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/authentication/basic/BasicAuthenticationDecoder.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/authentication/basic/BasicAuthenticationDecoder.java
@@ -10,6 +10,9 @@ import javax.xml.bind.DatatypeConverter;
 public class BasicAuthenticationDecoder
 {
 
+    private BasicAuthenticationDecoder() {
+    }
+
     /**
      * Decode the basic auth and convert it to array login/password.
      *

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
@@ -12,6 +12,9 @@ import java.util.List;
 public class PrivilegeUtils
 {
 
+    private PrivilegeUtils() {
+    }
+
     public static List<String> toStringList(Collection<Privilege> privileges)
     {
         List<String> privilegesAsStrings = new ArrayList<String>();

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
@@ -12,6 +12,9 @@ import java.util.List;
 public class RoleUtils
 {
 
+    private RoleUtils() {
+    }
+
     public static List<String> toStringList(Collection<Role> roles)
     {
         List<String> rolesAsStrings = new ArrayList<String>();

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/util/ArtifactInfoUtils.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/util/ArtifactInfoUtils.java
@@ -8,6 +8,9 @@ import org.apache.maven.index.ArtifactInfo;
 public class ArtifactInfoUtils
 {
 
+    private ArtifactInfoUtils() {
+    }
+
     public static String convertToGAVTC(ArtifactInfo artifactInfo)
     {
         @SuppressWarnings("UnnecessaryLocalVariable")


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.