### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/url/ClasspathURLStreamHandlerFactory.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/url/ClasspathURLStreamHandlerFactory.java
@@ -12,7 +12,7 @@ public class ClasspathURLStreamHandlerFactory
         implements URLStreamHandlerFactory
 {
 
-    private final Map<String, URLStreamHandler> protocolHandlers = new HashMap<String, URLStreamHandler>();
+    private final Map<String, URLStreamHandler> protocolHandlers = new HashMap<>();
 
 
     public ClasspathURLStreamHandlerFactory(String protocol, URLStreamHandler urlHandler)

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/xml/ElementWrapper.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/xml/ElementWrapper.java
@@ -13,7 +13,7 @@ public class ElementWrapper<T>
 {
 
     @XmlAnyElement(lax = true)
-    private List<T> elements = new ArrayList<T>();
+    private List<T> elements = new ArrayList<>();
 
 
     public ElementWrapper()

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/xml/parsers/GenericParser.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/xml/parsers/GenericParser.java
@@ -28,7 +28,7 @@ public class GenericParser<T>
 
     private ReentrantLock lock = new ReentrantLock();
 
-    private Set<Class> classes = new LinkedHashSet<Class>();
+    private Set<Class> classes = new LinkedHashSet<>();
 
     private JAXBContext context;
 

--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
@@ -122,7 +122,7 @@ public class MetadataMerger
 
     private Collection<SnapshotVersion> createNewSnapshotVersions(String version, String timestamp, int buildNumber)
     {
-        Collection<SnapshotVersion> toReturn = new ArrayList<SnapshotVersion>();
+        Collection<SnapshotVersion> toReturn = new ArrayList<>();
 
         SnapshotVersion sv1 = new SnapshotVersion();
         SnapshotVersion sv2 = new SnapshotVersion();

--- a/strongbox-metadata-core/src/test/java/org/carlspring/strongbox/storage/metadata/MetadataHelperTest.java
+++ b/strongbox-metadata-core/src/test/java/org/carlspring/strongbox/storage/metadata/MetadataHelperTest.java
@@ -280,7 +280,7 @@ public class MetadataHelperTest
         plugin.setName("");
         plugin.setPrefix("");
 
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         plugins.add(plugin);
         metadata.setPlugins(plugins);
         return metadata;
@@ -295,7 +295,7 @@ public class MetadataHelperTest
         metadata.setVersioning(new Versioning());
         metadata.getVersioning().setLatest(PRE_VERSION);
         metadata.getVersioning().setRelease(PRE_VERSION);
-        List<String> versions = new ArrayList<String>();
+        List<String> versions = new ArrayList<>();
         versions.add(PRE_VERSION);
         metadata.getVersioning().setVersions(versions);
         metadata.getVersioning()
@@ -316,7 +316,7 @@ public class MetadataHelperTest
         snapshot.setBuildNumber(1);
         snapshot.setTimestamp(timestamp.substring(0, 7) + "." + timestamp.substring(8));
 
-        List<SnapshotVersion> snapshotVersions = new ArrayList<SnapshotVersion>();
+        List<SnapshotVersion> snapshotVersions = new ArrayList<>();
         snapshotVersions.addAll(createNewSnapshotVersions(SNAPSHOT_VERSION, timestamp, 1));
 
         Versioning versioning = new Versioning();
@@ -330,7 +330,7 @@ public class MetadataHelperTest
 
     private Collection<SnapshotVersion> createNewSnapshotVersions(String version, String timestamp, int buildNumber)
     {
-        Collection<SnapshotVersion> toReturn = new ArrayList<SnapshotVersion>();
+        Collection<SnapshotVersion> toReturn = new ArrayList<>();
 
         SnapshotVersion sv1 = new SnapshotVersion();
         SnapshotVersion sv2 = new SnapshotVersion();

--- a/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
+++ b/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
@@ -82,7 +82,7 @@ public class RestClient extends ArtifactClient
 
             final ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes());
 
-            GenericParser<ServerConfiguration> parser = new GenericParser<ServerConfiguration>(classes);
+            GenericParser<ServerConfiguration> parser = new GenericParser<>(classes);
 
             configuration = parser.parse(bais);
         }
@@ -165,7 +165,7 @@ public class RestClient extends ArtifactClient
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        GenericParser<ProxyConfiguration> parser = new GenericParser<ProxyConfiguration>(ProxyConfiguration.class);
+        GenericParser<ProxyConfiguration> parser = new GenericParser<>(ProxyConfiguration.class);
         parser.store(proxyConfiguration, baos);
 
         Response response = resource.request(MediaType.APPLICATION_XML)
@@ -193,7 +193,7 @@ public class RestClient extends ArtifactClient
             final String xml = response.readEntity(String.class);
             final ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes());
 
-            GenericParser<ProxyConfiguration> parser = new GenericParser<ProxyConfiguration>(ProxyConfiguration.class);
+            GenericParser<ProxyConfiguration> parser = new GenericParser<>(ProxyConfiguration.class);
 
             proxyConfiguration = parser.parse(bais);
         }
@@ -222,7 +222,7 @@ public class RestClient extends ArtifactClient
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        GenericParser<Storage> parser = new GenericParser<Storage>(Storage.class);
+        GenericParser<Storage> parser = new GenericParser<>(Storage.class);
         parser.store(storage, baos);
 
         Response response = resource.request(MediaType.APPLICATION_XML)
@@ -255,7 +255,7 @@ public class RestClient extends ArtifactClient
 
             final ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes());
 
-            GenericParser<Storage> parser = new GenericParser<Storage>(Storage.class);
+            GenericParser<Storage> parser = new GenericParser<>(Storage.class);
 
             storage = parser.parse(bais);
         }
@@ -291,7 +291,7 @@ public class RestClient extends ArtifactClient
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        GenericParser<Repository> parser = new GenericParser<Repository>(Repository.class);
+        GenericParser<Repository> parser = new GenericParser<>(Repository.class);
         parser.store(repository, baos);
 
         Response response = resource.request(MediaType.APPLICATION_XML)
@@ -326,7 +326,7 @@ public class RestClient extends ArtifactClient
 
             final ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes());
 
-            GenericParser<Repository> parser = new GenericParser<Repository>(Repository.class);
+            GenericParser<Repository> parser = new GenericParser<>(Repository.class);
 
             repository = parser.parse(bais);
         }

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/configuration/AuthenticationConfiguration.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/configuration/AuthenticationConfiguration.java
@@ -14,7 +14,7 @@ public class AuthenticationConfiguration
 
     @XmlElement(name = "realm")
     @XmlElementWrapper(name = "realms")
-    private List<String> realms = new ArrayList<String>();
+    private List<String> realms = new ArrayList<>();
 
     @XmlElement(name = "anonymous-access")
     private AnonymousAccessConfiguration anonymousAccessConfiguration;

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/configuration/AuthorizationConfiguration.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/configuration/AuthorizationConfiguration.java
@@ -19,10 +19,10 @@ public class AuthorizationConfiguration
 {
 
     @XmlElement(name = "roles")
-    private List<Role> roles = new ArrayList<Role>();
+    private List<Role> roles = new ArrayList<>();
 
     @XmlElement(name = "privileges")
-    private List<Privilege> privileges = new ArrayList<Privilege>();
+    private List<Privilege> privileges = new ArrayList<>();
 
 
     public AuthorizationConfiguration()

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/certificates/KeyStores.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/certificates/KeyStores.java
@@ -100,7 +100,7 @@ public class KeyStores
                    NoSuchAlgorithmException
     {
         final KeyStore keyStore = load(fileName, password);
-        final Map<String, Certificate> certificates = new HashMap<String, Certificate>();
+        final Map<String, Certificate> certificates = new HashMap<>();
         final Enumeration<String> aliases = keyStore.aliases();
 
         while (aliases.hasMoreElements())
@@ -354,7 +354,7 @@ public class KeyStores
             return credentials.get();
         }
 
-        static final ThreadLocal<PasswordAuthentication> credentials = new ThreadLocal<PasswordAuthentication>();
+        static final ThreadLocal<PasswordAuthentication> credentials = new ThreadLocal<>();
     }
 
 }

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/Role.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/Role.java
@@ -30,11 +30,11 @@ public class Role implements Serializable
      */
     @XmlElement(name = "role")
     @XmlElementWrapper(name = "roles")
-    private List<String> roles = new ArrayList<String>();
+    private List<String> roles = new ArrayList<>();
 
     @XmlElement(name = "privilege")
     @XmlElementWrapper(name = "privileges")
-    private List<String> privileges = new ArrayList<String>();
+    private List<String> privileges = new ArrayList<>();
 
 
     public Role()

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/User.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/User.java
@@ -22,7 +22,7 @@ public class User implements Serializable
 
     @XmlElement(name = "role")
     @XmlElementWrapper(name = "roles")
-    private List<String> roles = new ArrayList<String>();
+    private List<String> roles = new ArrayList<>();
 
     @XmlElement
     private String fullName;

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/caching/CachedUserManager.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/caching/CachedUserManager.java
@@ -16,7 +16,7 @@ public class CachedUserManager implements UserManager
 
     private static Logger logger = LoggerFactory.getLogger(CachedUserManager.class);
 
-    private Map<String, User> cachedUsers = new LinkedHashMap<String, User>();
+    private Map<String, User> cachedUsers = new LinkedHashMap<>();
 
     /**
      * Specifies how long to keep the cached credentials.
@@ -90,7 +90,7 @@ public class CachedUserManager implements UserManager
 
     private Set<String> getExpiredCredentials()
     {
-        Set<String> expiredCredentials = new LinkedHashSet<String>();
+        Set<String> expiredCredentials = new LinkedHashSet<>();
 
         for (String username : cachedUsers.keySet())
         {

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/managers/AuthenticationManager.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/managers/AuthenticationManager.java
@@ -32,7 +32,7 @@ public class AuthenticationManager
 
     private AuthenticationConfiguration configuration;
 
-    private GenericParser<AuthenticationConfiguration> parser = new GenericParser<AuthenticationConfiguration>(AuthenticationConfiguration.class);
+    private GenericParser<AuthenticationConfiguration> parser = new GenericParser<>(AuthenticationConfiguration.class);
 
 
     @Override

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
@@ -14,7 +14,7 @@ public class PrivilegeUtils
 
     public static List<String> toStringList(Collection<Privilege> privileges)
     {
-        List<String> privilegesAsStrings = new ArrayList<String>();
+        List<String> privilegesAsStrings = new ArrayList<>();
 
         for (Privilege privilege : privileges)
         {
@@ -26,7 +26,7 @@ public class PrivilegeUtils
 
     public static List<Privilege> toList(Collection<Privilege> privileges)
     {
-        List<Privilege> privilegesList = new ArrayList<Privilege>();
+        List<Privilege> privilegesList = new ArrayList<>();
         privilegesList.addAll(privileges);
         
         return privilegesList;

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
@@ -14,7 +14,7 @@ public class RoleUtils
 
     public static List<String> toStringList(Collection<Role> roles)
     {
-        List<String> rolesAsStrings = new ArrayList<String>();
+        List<String> rolesAsStrings = new ArrayList<>();
 
         for (Role role : roles)
         {
@@ -26,7 +26,7 @@ public class RoleUtils
 
     public static List<Role> toList(Collection<Role> roles)
     {
-        List<Role> rolesList = new ArrayList<Role>();
+        List<Role> rolesList = new ArrayList<>();
         rolesList.addAll(roles);
 
         return rolesList;

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/visitors/ParentGroupVisitor.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/visitors/ParentGroupVisitor.java
@@ -31,7 +31,7 @@ public class ParentGroupVisitor implements Visitor
     public void endVisit(Group group, Set<Group> hierarchy)
     {
         // Invert the list, so it's top to bottom instead.
-        List<Group> list = new ArrayList<Group>(hierarchy);
+        List<Group> list = new ArrayList<>(hierarchy);
         Collections.reverse(list);
 
         hierarchy.clear();

--- a/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtilsTest.java
+++ b/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtilsTest.java
@@ -17,7 +17,7 @@ public class PrivilegeUtilsTest
     @Test
     public void testPrivilegesToString()
     {
-        List<Privilege> privileges = new ArrayList<Privilege>();
+        List<Privilege> privileges = new ArrayList<>();
         privileges.add(new Privilege("read", "Read permission"));
         privileges.add(new Privilege("write", "Write permission"));
         privileges.add(new Privilege("deploy", "Deploy permission"));

--- a/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/jaas/util/RoleUtilsTest.java
+++ b/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/jaas/util/RoleUtilsTest.java
@@ -17,7 +17,7 @@ public class RoleUtilsTest
     @Test
     public void testRolesToString()
     {
-        List<Role> roles = new ArrayList<Role>();
+        List<Role> roles = new ArrayList<>();
         roles.add(new Role("Admin", "Admin role"));
         roles.add(new Role("Deployer", "Deployer role"));
 

--- a/strongbox-security-api/src/test/java/org/carlspring/strongbox/visitors/ParentGroupVisitorTest.java
+++ b/strongbox-security-api/src/test/java/org/carlspring/strongbox/visitors/ParentGroupVisitorTest.java
@@ -21,7 +21,7 @@ public class ParentGroupVisitorTest
         Group group2 = createGroup("developers", "Developers", group1);
         Group group3 = createGroup("java-developers-uk", "Java Developers UK", group2);
 
-        Set<Group> nestedGroups = new LinkedHashSet<Group>();
+        Set<Group> nestedGroups = new LinkedHashSet<>();
         ParentGroupVisitor visitor = new ParentGroupVisitor();
 
         try

--- a/strongbox-security-api/src/test/java/org/carlspring/strongbox/xml/parsers/AuthenticationConfigurationParserTest.java
+++ b/strongbox-security-api/src/test/java/org/carlspring/strongbox/xml/parsers/AuthenticationConfigurationParserTest.java
@@ -26,7 +26,7 @@ public class AuthenticationConfigurationParserTest
 
     public static final String XML_OUTPUT_FILE = CONFIGURATION_BASEDIR + "/security-authentication-saved.xml";
 
-    private GenericParser<AuthenticationConfiguration> parser = new GenericParser<AuthenticationConfiguration>(AuthenticationConfiguration.class);
+    private GenericParser<AuthenticationConfiguration> parser = new GenericParser<>(AuthenticationConfiguration.class);
 
 
     @Test
@@ -47,7 +47,7 @@ public class AuthenticationConfigurationParserTest
     public void testStoreAuthenticationConfiguration()
             throws IOException, JAXBException
     {
-        List<String> realms = new ArrayList<String>();
+        List<String> realms = new ArrayList<>();
         realms.add("org.carlspring.strongbox.jaas.xml.XMLUserRealm");
         realms.add("org.carlspring.strongbox.jaas.xml.LDAPUserRealm");
         realms.add("org.carlspring.strongbox.jaas.xml.ADUserRealm");

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/AbstractConfigurationManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/AbstractConfigurationManager.java
@@ -27,7 +27,7 @@ public abstract class AbstractConfigurationManager<T>
 
     public AbstractConfigurationManager(Class... classes)
     {
-        parser = new GenericParser<T>(classes);
+        parser = new GenericParser<>(classes);
     }
 
     @PostConstruct

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/Storage.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/Storage.java
@@ -28,7 +28,7 @@ public class Storage
 
     @XmlElement(name = "repositories")
     @XmlJavaTypeAdapter(RepositoryMapAdapter.class)
-    private Map<String, Repository> repositories = new LinkedHashMap<String, Repository>();
+    private Map<String, Repository> repositories = new LinkedHashMap<>();
 
 
     public Storage()

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ArtifactChecksum.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ArtifactChecksum.java
@@ -14,7 +14,7 @@ public class ArtifactChecksum
      * Key:   Algorithm
      * Value: Checksum
      */
-    private Map<String, String> checksums = new LinkedHashMap<String, String>();
+    private Map<String, String> checksums = new LinkedHashMap<>();
 
     /**
      * The last time this checksum object was accessed in any way.

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
@@ -36,7 +36,7 @@ public class ChecksumCacheManager
      * Key:     Artifact path
      * Value:   Artifact checksum.
      */
-    private Map<String, ArtifactChecksum> cachedChecksums = new LinkedHashMap<String, ArtifactChecksum>();
+    private Map<String, ArtifactChecksum> cachedChecksums = new LinkedHashMap<>();
 
     /**
      * Specifies how long to keep the cached checksums.
@@ -131,7 +131,7 @@ public class ChecksumCacheManager
 
     private Set<String> getExpiredChecksums()
     {
-        Set<String> expiredChecksums = new LinkedHashSet<String>();
+        Set<String> expiredChecksums = new LinkedHashSet<>();
 
         for (String artifactBasePath : cachedChecksums.keySet())
         {

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
@@ -38,7 +38,7 @@ public class ConfigurationManagerTest
 
     public static final String STORAGE_BASEDIR = TEST_CLASSES + "/storages/storage0";
 
-    private GenericParser<Configuration> parser = new GenericParser<Configuration>(Configuration.class);
+    private GenericParser<Configuration> parser = new GenericParser<>(Configuration.class);
 
     @Autowired
     private ConfigurationManager configurationManager;

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexer.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexer.java
@@ -78,7 +78,7 @@ public class RepositoryIndexer
     public void delete(final Collection<ArtifactInfo> artifactInfos)
             throws IOException
     {
-        final List<ArtifactContext> delete = new ArrayList<ArtifactContext>();
+        final List<ArtifactContext> delete = new ArrayList<>();
         for (final ArtifactInfo artifactInfo : artifactInfos)
         {
             logger.debug("Deleting artifact: {}; ctx id: {}; idx dir: {}",

--- a/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/testing/AssignedPorts.java
+++ b/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/testing/AssignedPorts.java
@@ -22,7 +22,7 @@ public class AssignedPorts
      * K: port key
      * V: the port
      */
-    private Map<String, Integer> ports = new LinkedHashMap<String, Integer>();
+    private Map<String, Integer> ports = new LinkedHashMap<>();
 
 
     public AssignedPorts()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.