### PR TITLE
Fixing code quality issues: squid:S2864 - squid:S1066

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/io/MultipleDigestInputStream.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/io/MultipleDigestInputStream.java
@@ -232,28 +232,25 @@ public class MultipleDigestInputStream
     public void reposition()
             throws IOException
     {
-        if (byteRanges != null && !byteRanges.isEmpty() && currentByteRangeIndex < byteRanges.size())
+        if (byteRanges != null && !byteRanges.isEmpty() && currentByteRangeIndex < byteRanges.size() && currentByteRangeIndex < byteRanges.size())
         {
-            if (currentByteRangeIndex < byteRanges.size())
+            ByteRange current = currentByteRange;
+
+            currentByteRangeIndex++;
+            currentByteRange = byteRanges.get(currentByteRangeIndex);
+
+            if (currentByteRange.getOffset() > current.getLimit())
             {
-                ByteRange current = currentByteRange;
+                // If the offset is higher than the current position, skip forward
+                long bytesToSkip = currentByteRange.getOffset() - current.getLimit();
 
-                currentByteRangeIndex++;
-                currentByteRange = byteRanges.get(currentByteRangeIndex);
-
-                if (currentByteRange.getOffset() > current.getLimit())
-                {
-                    // If the offset is higher than the current position, skip forward
-                    long bytesToSkip = currentByteRange.getOffset() - current.getLimit();
-
-                    //noinspection ResultOfMethodCallIgnored
-                    in.skip(bytesToSkip);
-                }
-                else
-                {
-                    reloadableInputStreamHandler.reload();
-                    in = reloadableInputStreamHandler.getInputStream();
-                }
+                //noinspection ResultOfMethodCallIgnored
+                in.skip(bytesToSkip);
+            }
+            else
+            {
+                reloadableInputStreamHandler.reload();
+                in = reloadableInputStreamHandler.getInputStream();
             }
         }
     }

--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
@@ -195,12 +195,10 @@ public class MetadataHelper
     {
         for (SnapshotVersion snapshotVersion : metadata.getVersioning().getSnapshotVersions())
         {
-            if (snapshotVersion.getVersion().equals(timestampedSnapshotVersion))
+            if (snapshotVersion.getVersion().equals(timestampedSnapshotVersion) 
+                && classifier == null || snapshotVersion.getClassifier().equals(classifier))
             {
-                if (classifier == null || snapshotVersion.getClassifier().equals(classifier))
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/caching/CachedUserManager.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/caching/CachedUserManager.java
@@ -92,12 +92,12 @@ public class CachedUserManager implements UserManager
     {
         Set<String> expiredCredentials = new LinkedHashSet<String>();
 
-        for (String username : cachedUsers.keySet())
+        for (Map.Entry<String, User> stringUserEntry : cachedUsers.entrySet())
         {
-            Credentials credentials = cachedUsers.get(username).getCredentials();
+            Credentials credentials = stringUserEntry.getValue().getCredentials();
             if (System.currentTimeMillis() - credentials.getLastAccessed() > credentialsLifetime)
             {
-                expiredCredentials.add(username);
+                expiredCredentials.add(stringUserEntry.getKey());
             }
         }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
@@ -133,13 +133,13 @@ public class ChecksumCacheManager
     {
         Set<String> expiredChecksums = new LinkedHashSet<String>();
 
-        for (String artifactBasePath : cachedChecksums.keySet())
+        for (Map.Entry<String, ArtifactChecksum> stringArtifactChecksumEntry : cachedChecksums.entrySet())
         {
-            ArtifactChecksum checksum = cachedChecksums.get(artifactBasePath);
+            ArtifactChecksum checksum = stringArtifactChecksumEntry.getValue();
 
             if (System.currentTimeMillis() - checksum.getLastAccessed() > cachedChecksumLifetime)
             {
-                expiredChecksums.add(artifactBasePath);
+                expiredChecksums.add(stringArtifactChecksumEntry.getKey());
             }
         }
 

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
@@ -125,9 +125,9 @@ public class StorageBooter
         }
 
         final Map<String,Storage> storages = configurationManager.getConfiguration().getStorages();
-        for (String storageId : storages.keySet())
+        for (Map.Entry<String, Storage> stringStorageEntry : storages.entrySet())
         {
-            initializeStorage(storages.get(storageId));
+            initializeStorage(stringStorageEntry.getValue());
         }
 
         return new File(basedir).getAbsoluteFile();

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ArtifactRestlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ArtifactRestlet.java
@@ -471,13 +471,10 @@ public class ArtifactRestlet
                 String version = artifactFile.getPath().substring(artifactFile.getPath().lastIndexOf(File.separatorChar) + 1);
                 java.nio.file.Path path = Paths.get(artifactFile.getPath().substring(0, artifactFile.getPath().lastIndexOf(File.separatorChar)));
                 Metadata metadata = metadataManager.readMetadata(path);
-                if (metadata != null && metadata.getVersioning() != null)
+                if (metadata != null && metadata.getVersioning() != null && metadata.getVersioning().getVersions().contains(version))
                 {
-                    if (metadata.getVersioning().getVersions().contains(version))
-                    {
-                        metadata.getVersioning().getVersions().remove(version);
-                        metadataManager.storeMetadata(path, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
-                    }
+                    metadata.getVersioning().getVersions().remove(version);
+                    metadataManager.storeMetadata(path, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”.
squid:S1066 - “Collapsible "if" statements should be merged”.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
Ayman Abdelghany.