### PR TITLE
Resolve the exception below which happens when you build the strongbox-web-core 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,5 @@ To accept, please:
 | Denis Ivaykin                |                                          | Moscow, Russia                          | 2014-04-19 |
 | Juan Ignacio Bais            |                                          | Buenos Aires, Argentina                 | 2016-02-24 |
 | Ivan Ursul                   |                                          | Lviv, Ukraine                           | 2016-05-02 |
+| Ivan Ursul                   |                                          | Lviv, Ukraine                           | 2016-05-02 |
+| Alex Oreshkevich             | redsoft.pro                              | Minsk, Republic of Belarus              | 2016-05-12 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,5 +24,4 @@ To accept, please:
 | Denis Ivaykin                |                                          | Moscow, Russia                          | 2014-04-19 |
 | Juan Ignacio Bais            |                                          | Buenos Aires, Argentina                 | 2016-02-24 |
 | Ivan Ursul                   |                                          | Lviv, Ukraine                           | 2016-05-02 |
-| Ivan Ursul                   |                                          | Lviv, Ukraine                           | 2016-05-02 |
 | Alex Oreshkevich             | redsoft.pro                              | Minsk, Republic of Belarus              | 2016-05-12 |

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -500,16 +500,6 @@
                             <webAppSourceDirectory>${project.build.directory}/strongbox/webapp</webAppSourceDirectory>
                         </configuration>
 
-                        <executions>
-                            <execution>
-                                <id>jetty-stop</id>
-
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
 
                     <plugin>


### PR DESCRIPTION
Hi Martin,

I think I've resolved issue with NoClassDefFoundError. Spending a Lot Of Time I found that we don't need jetty stop manual execution specified in pom.xml file, because we are using jetty as a deamon and as a part of our current maven build. When the build ends jetty will be stopped automatically and all resources will be released.

As a proof I was inspected process list at my machine, there was no separate process for jetty, and there was no java processes after maven build was finished.

Please let me know if my fix works for you and if you are pleased with that solution. 