### PR TITLE
SB-544: Make the REST API documentation publicly accessible over HTTP

### DIFF
--- a/strongbox-resources/strongbox-web-resources/src/main/webapp/WEB-INF/web.xml
+++ b/strongbox-resources/strongbox-web-resources/src/main/webapp/WEB-INF/web.xml
@@ -50,7 +50,27 @@
 
     <filter-mapping>
         <filter-name>jersey-serlvet</filter-name>
-        <url-pattern>/*</url-pattern>
+        <url-pattern>/storages/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>jersey-serlvet</filter-name>
+        <url-pattern>/configuration/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>jersey-serlvet</filter-name>
+        <url-pattern>/logging/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>jersey-serlvet</filter-name>
+        <url-pattern>/metadata/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>jersey-serlvet</filter-name>
+        <url-pattern>/search/*</url-pattern>
+    </filter-mapping>
+    <filter-mapping>
+        <filter-name>jersey-serlvet</filter-name>
+        <url-pattern>/trash/*</url-pattern>
     </filter-mapping>
 
     <welcome-file-list>


### PR DESCRIPTION
Cleared out the filter mapping wildcard. (Not the best solution as it is right now, but will have to do).