### PR TITLE
SB-535: Go over all of the pom.xml files and make sure no unnecessary plugins get executed when using -DskipTests

### DIFF
--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -543,6 +543,7 @@
 
                         <configuration>
                             <daemon>true</daemon>
+                            <skip>${skipTests}</skip>
                         </configuration>
 
                         <executions>


### PR DESCRIPTION
Fixed.