### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/strongbox-client/src/main/java/org/carlspring/strongbox/client/HttpArtifactClientFactory.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/client/HttpArtifactClientFactory.java
@@ -15,6 +15,9 @@ import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 public class HttpArtifactClientFactory
 {
 
+    private HttpArtifactClientFactory() 
+    {
+    }
 
     public static CloseableHttpClient createHttpClientWithAuthentication(String hostName,
                                                                          String username,

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/net/ConnectionChecker.java
@@ -13,6 +13,10 @@ public class ConnectionChecker
 {
 
 
+    private ConnectionChecker() 
+    {
+    }
+
     public static boolean checkServiceAvailability(String host, int port, int timeout)
             throws IOException
     {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ResourceCloser.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ResourceCloser.java
@@ -17,6 +17,10 @@ import org.slf4j.Logger;
 public class ResourceCloser
 {
 
+    private ResourceCloser() 
+    {
+    }
+
     public static void close(Closeable resource, Logger logger)
     {
         if (resource != null)

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ArtifactFileUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ArtifactFileUtils.java
@@ -7,6 +7,10 @@ public class ArtifactFileUtils
 {
 
 
+    private ArtifactFileUtils() 
+    {
+    }
+
     public static boolean isArtifactFile(String path)
     {
         return !isMetadataFile(path) && !isChecksum(path);

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/DirUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/DirUtils.java
@@ -10,6 +10,10 @@ public class DirUtils
 {
 
 
+    private DirUtils() 
+    {
+    }
+
     public static void removeEmptyAncestors(String path, String stopAtPath)
             throws IOException
     {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/FileUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/FileUtils.java
@@ -8,6 +8,10 @@ import java.io.File;
 public class FileUtils
 {
 
+    private FileUtils() 
+    {
+    }
+
     public static String normalizePath(String path)
     {
         if (path.contains("\\") && !File.separator.equals("\\"))

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/MessageDigestUtils.java
@@ -22,6 +22,10 @@ public class MessageDigestUtils
 
     private static final Logger logger = LoggerFactory.getLogger(MessageDigestUtils.class);
 
+    private MessageDigestUtils() 
+    {
+    }
+
 
     public static String convertToHexadecimalString(MessageDigest md)
     {

--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
@@ -26,6 +26,10 @@ public class MetadataHelper
 
     public static final SimpleDateFormat LAST_UPDATED_FIELD_FORMATTER = new SimpleDateFormat("yyyyMMddHHmmss");
 
+    private MetadataHelper() 
+    {
+    }
+
 
     public static void setLastUpdated(Versioning versioning)
     {

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/certificates/KeyStores.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/certificates/KeyStores.java
@@ -39,6 +39,10 @@ public class KeyStores
     {
         Authenticator.setDefault(authenticator);
     }
+    
+    private KeyStores() 
+    {
+    }
 
 
     private static KeyStore load(final File fileName,

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/encryption/EncryptionUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/encryption/EncryptionUtils.java
@@ -16,6 +16,10 @@ public class EncryptionUtils
 
     private static Logger logger = LoggerFactory.getLogger(EncryptionUtils.class);
 
+    private EncryptionUtils() 
+    {
+    }
+
 
     /**
      * Encrypts a String using the MD5 algorithm.

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/PrivilegeUtils.java
@@ -12,6 +12,10 @@ import java.util.List;
 public class PrivilegeUtils
 {
 
+    private PrivilegeUtils() 
+    {
+    }
+
     public static List<String> toStringList(Collection<Privilege> privileges)
     {
         List<String> privilegesAsStrings = new ArrayList<String>();

--- a/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
+++ b/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/jaas/util/RoleUtils.java
@@ -12,6 +12,10 @@ import java.util.List;
 public class RoleUtils
 {
 
+    private RoleUtils() 
+    {
+    }
+
     public static List<String> toStringList(Collection<Role> roles)
     {
         List<String> rolesAsStrings = new ArrayList<String>();

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/util/ArtifactInfoUtils.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/util/ArtifactInfoUtils.java
@@ -8,6 +8,10 @@ import org.apache.maven.index.ArtifactInfo;
 public class ArtifactInfoUtils
 {
 
+    private ArtifactInfoUtils() 
+    {
+    }
+
     public static String convertToGAVTC(ArtifactInfo artifactInfo)
     {
         @SuppressWarnings("UnnecessaryLocalVariable")


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed