### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataHelper.java
@@ -196,12 +196,10 @@ public class MetadataHelper
     {
         for (SnapshotVersion snapshotVersion : metadata.getVersioning().getSnapshotVersions())
         {
-            if (snapshotVersion.getVersion().equals(timestampedSnapshotVersion))
+            if (snapshotVersion.getVersion().equals(timestampedSnapshotVersion) 
+                && classifier == null || snapshotVersion.getClassifier().equals(classifier))
             {
-                if (classifier == null || snapshotVersion.getClassifier().equals(classifier))
-                {
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
@@ -133,13 +133,13 @@ public class ChecksumCacheManager
     {
         Set<String> expiredChecksums = new LinkedHashSet<String>();
 
-        for (String artifactBasePath : cachedChecksums.keySet())
+        for (Map.Entry<String, ArtifactChecksum> artifactChecksumEntry : cachedChecksums.entrySet())
         {
-            ArtifactChecksum checksum = cachedChecksums.get(artifactBasePath);
+            ArtifactChecksum checksum = artifactChecksumEntry.getValue();
 
             if (System.currentTimeMillis() - checksum.getLastAccessed() > cachedChecksumLifetime)
             {
-                expiredChecksums.add(artifactBasePath);
+                expiredChecksums.add(artifactChecksumEntry.getKey());
             }
         }
 

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
@@ -129,10 +129,10 @@ public class StorageBooter
             basedir = ConfigurationResourceResolver.getVaultDirectory() + "/storages";
         }
 
-        final Map<String,Storage> storages = configurationManager.getConfiguration().getStorages();
-        for (String storageId : storages.keySet())
+        final Map<String,Storage> storageEntry = configurationManager.getConfiguration().getStorages();
+        for (Map.Entry<String, Storage> stringStorageEntry : storageEntry.entrySet())
         {
-            initializeStorage(storages.get(storageId));
+            initializeStorage(stringStorageEntry.getValue());
         }
 
         return new File(basedir).getAbsoluteFile();

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ArtifactRestlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/ArtifactRestlet.java
@@ -492,13 +492,11 @@ public class ArtifactRestlet
                 java.nio.file.Path path = Paths.get(artifactFile.getPath().substring(0, artifactFile.getPath().lastIndexOf(File.separatorChar)));
 
                 Metadata metadata = getMetadataManager().readMetadata(path);
-                if (metadata != null && metadata.getVersioning() != null)
+                if (metadata != null && metadata.getVersioning() != null
+                        && metadata.getVersioning().getVersions().contains(version))
                 {
-                    if (metadata.getVersioning().getVersions().contains(version))
-                    {
-                        metadata.getVersioning().getVersions().remove(version);
-                        getMetadataManager().storeMetadata(path, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
-                    }
+                    metadata.getVersioning().getVersions().remove(version);
+                    getMetadataManager().storeMetadata(path, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S1066 - Collapsible "if" statements should be merged. 
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1066

Please let me know if you have any questions.

Faisal Hameed