### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/url/ClasspathURLStreamHandlerFactory.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/url/ClasspathURLStreamHandlerFactory.java
@@ -25,6 +25,7 @@ public class ClasspathURLStreamHandlerFactory
         protocolHandlers.put(protocol, urlHandler);
     }
 
+    @Override
     public URLStreamHandler createURLStreamHandler(String protocol)
     {
         return protocolHandlers.get(protocol);

--- a/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/VersionComparator.java
+++ b/strongbox-metadata-core/src/main/java/org/carlspring/strongbox/storage/metadata/comparators/VersionComparator.java
@@ -11,6 +11,7 @@ public class VersionComparator
         implements Comparator<String>
 {
 
+    @Override
     public int compare(String v1, String v2)
     {
         if (v1 == null || v2 == null)

--- a/strongbox-testing/strongbox-testing-core/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactDeployerTest.java
+++ b/strongbox-testing/strongbox-testing-core/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactDeployerTest.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class ArtifactDeployerTest
 {
 
-    private final static File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/releases/.temp");
+    private static final File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/releases/.temp");
 
     @Autowired
     private AssignedPorts assignedPorts;

--- a/strongbox-testing/strongbox-testing-core/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGeneratorTest.java
+++ b/strongbox-testing/strongbox-testing-core/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGeneratorTest.java
@@ -22,7 +22,7 @@ public class ArtifactGeneratorTest
         extends TestCaseWithArtifactGeneration
 {
 
-    private final static File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/releases");
+    private static final File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/releases");
 
 
     @Test

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/TrashRestletTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/TrashRestletTest.java
@@ -26,13 +26,13 @@ public class TrashRestletTest
 
     public static class SpringConfig { }
 
-    private final static File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory()).getAbsoluteFile();
+    private static final File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory()).getAbsoluteFile();
 
     private static final String STORAGE = "storage0";
 
     private static final String REPOSITORY_WITH_TRASH = "releases-with-trash";
 
-    private final static String REPOSITORY_WITH_TRASH_BASEDIR = BASEDIR.getAbsolutePath() +
+    private static final String REPOSITORY_WITH_TRASH_BASEDIR = BASEDIR.getAbsolutePath() +
                                                                 "/storages/" + STORAGE + "/" + REPOSITORY_WITH_TRASH;
     private RestClient client = new RestClient();
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/TrashRestletUndeleteTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/TrashRestletUndeleteTest.java
@@ -24,13 +24,13 @@ public class TrashRestletUndeleteTest
         extends TestCaseWithArtifactGeneration
 {
 
-    private final static File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory()).getAbsoluteFile();
+    private static final File BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory()).getAbsoluteFile();
 
     private static final String STORAGE = "storage0";
 
     private static final String REPOSITORY_WITH_TRASH = "releases-with-trash";
 
-    private final static String REPOSITORY_WITH_TRASH_BASEDIR = BASEDIR.getAbsolutePath() +
+    private static final String REPOSITORY_WITH_TRASH_BASEDIR = BASEDIR.getAbsolutePath() +
                                                                 "/storages/" + STORAGE + "/" + REPOSITORY_WITH_TRASH;
 
     private RestClient client = new RestClient();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1161 - "@Override" annotation should be used on any method overriding.
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal Hameed