### PR TITLE
Multiple code quality fix-3

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManagerTest.java
@@ -25,8 +25,8 @@ public class ChecksumCacheManagerTest
             throws Exception
     {
         ChecksumCacheManager manager = new ChecksumCacheManager();
-        manager.setCachedChecksumLifetime(3000l);
-        manager.setCachedChecksumExpiredCheckInterval(500l);
+        manager.setCachedChecksumLifetime(3000L);
+        manager.setCachedChecksumExpiredCheckInterval(500L);
 
         CheckingThread checkerThread = new CheckingThread(manager);
 
@@ -42,7 +42,7 @@ public class ChecksumCacheManagerTest
 
         checkerThread.start();
 
-        Thread.sleep(3000l);
+        Thread.sleep(3000L);
 
         manager.getArtifactChecksum(artifact1BasePath, "md5");
 

--- a/strongbox-storage/strongbox-storage-metadata/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceSnapshotsTest.java
+++ b/strongbox-storage/strongbox-storage-metadata/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceSnapshotsTest.java
@@ -45,7 +45,7 @@ public class ArtifactMetadataServiceSnapshotsTest
 
     private static final File REPOSITORY_BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/snapshots");
 
-    public static final String[] CLASSIFIERS = { "javadoc", "sources", "source-release" };
+    private static final String[] CLASSIFIERS = { "javadoc", "sources", "source-release" };
 
     public static final String ARTIFACT_BASE_PATH_STRONGBOX_METADATA = "org/carlspring/strongbox/strongbox-metadata";
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/SearchRestlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/rest/SearchRestlet.java
@@ -65,7 +65,7 @@ public class SearchRestlet
                                 @Context HttpServletRequest request)
             throws IOException, ParseException
     {
-        if (request.getHeader("accept").toLowerCase().equals("text/plain"))
+        if (request.getHeader("accept").equalsIgnoreCase("text/plain"))
         {
             final SearchResults artifacts = getSearchResults(storageId, repositoryId, query);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case. 
squid:S1873 -  "static final" arrays should be "private".
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1873
https://dev.eclipse.org/sonar/rules/show/squid:S1157

Please let me know if you have any questions.

Faisal Hameed