### PR TITLE
SB-575: Replace the REST-related test cases with rest-assured

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controller/ArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controller/ArtifactController.java
@@ -104,8 +104,7 @@ public class ArtifactController
                             @ApiResponse(code = 400, message = "An error occurred.") })
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
     @RequestMapping(value = "{storageId}/{repositoryId}/**",
-                    method = RequestMethod.GET,
-                    consumes = MediaType.TEXT_PLAIN_VALUE)
+                    method = RequestMethod.GET)
     public void download(@ApiParam(value = "The storageId", required = true)
                          @PathVariable String storageId,
                          @ApiParam(value = "The repositoryId", required = true)


### PR DESCRIPTION
SB-693: Make sure the strongbox-web-integration-tests still work after the refactoring in SB-575

- Sorted out the media type issue.
