### PR TITLE
Return code is: 415 , ReasonPhrase:Unsupported Media Type

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controller/ArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controller/ArtifactController.java
@@ -105,7 +105,7 @@ public class ArtifactController
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
     @RequestMapping(value = "{storageId}/{repositoryId}/**",
                     method = RequestMethod.GET,
-                    consumes = MediaType.TEXT_PLAIN_VALUE)
+                    consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.APPLICATION_OCTET_STREAM_VALUE})
     public void download(@ApiParam(value = "The storageId", required = true)
                          @PathVariable String storageId,
                          @ApiParam(value = "The repositoryId", required = true)


### PR DESCRIPTION
Fixed 'mvn deploy'.
Error:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project hello-strongbox-maven: Failed to retrieve remote metadata org.carlspring.strongbox.examples:hello-strongbox-maven:1.0-SNAPSHOT/maven-metadata.xml: Could not transfer metadata org.carlspring.strongbox.examples:hello-strongbox-maven:1.0-SNAPSHOT/maven-metadata.xml from/to snapshots (http://localhost:8080/strongbox-webapp/storages/storage0/snapshots/): Failed to transfer file: http://localhost:8080/strongbox-webapp/storages/storage0/snapshots/org/carlspring/strongbox/examples/hello-strongbox-maven/1.0-SNAPSHOT/maven-metadata.xml. Return code is: 415 , ReasonPhrase:Unsupported Media Type. -> [Help 1]

The problem was that maven don't provide any ContentType with 'maven-metadata.xml' GET reuqest and Spring expects `text/plain` according to artifact download method. 
It was found that Spring resolve empty ContentType as 'application/octet-stream' which was added to artifact download method.