### PR TITLE
SB-311: Implement index packing [3/3]

### DIFF
--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactIndexesServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/ArtifactIndexesServiceImpl.java
@@ -5,6 +5,7 @@ import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.handlers.ArtifactLocationGenerateMavenIndexOperation;
 import org.carlspring.strongbox.services.ArtifactIndexesService;
+import org.carlspring.strongbox.services.RepositoryManagementService;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.indexing.RepositoryIndexManager;
 import org.carlspring.strongbox.storage.repository.Repository;
@@ -33,6 +34,10 @@ public class ArtifactIndexesServiceImpl
     @Autowired
     private RepositoryIndexManager repositoryIndexManager;
 
+    @Autowired
+    private RepositoryManagementService repositoryManagementService;
+
+
     @Override
     public void rebuildIndexes(String storageId,
                                String repositoryId,
@@ -52,6 +57,10 @@ public class ArtifactIndexesServiceImpl
         locator.setOperation(operation);
         locator.locateArtifactDirectories();
 
+        if (artifactPath == null)
+        {
+            repositoryManagementService.pack(storageId, repositoryId);
+        }
     }
 
     @Override
@@ -64,7 +73,6 @@ public class ArtifactIndexesServiceImpl
         {
             rebuildIndexes(storageId, repository, null);
         }
-
     }
 
     @Override
@@ -76,7 +84,6 @@ public class ArtifactIndexesServiceImpl
         {
             rebuildIndexes(storageId);
         }
-
     }
 
     private Configuration getConfiguration()
@@ -91,7 +98,7 @@ public class ArtifactIndexesServiceImpl
 
     private Map<String, Repository> getRepositories(String storageId)
     {
-        return getStorages().get(storageId)
-                            .getRepositories();
+        return getStorages().get(storageId).getRepositories();
     }
+
 }

--- a/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
@@ -104,8 +104,6 @@ public class RepositoryManagementServiceImpl
 
         IndexingContext context = repositoryIndexer.getIndexingContext();
 
-        pack(storageId, repositoryId);
-
         ScanningRequest scanningRequest = new ScanningRequest(context,
                                                               new ReindexArtifactScanningListener(repositoryIndexer.getIndexer()),
                                                               startingPath.getPath());

--- a/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/services/ArtifactSearchServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/services/ArtifactSearchServiceImplTest.java
@@ -14,8 +14,6 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import static org.junit.Assert.assertTrue;
@@ -27,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 public class ArtifactSearchServiceImplTest
         extends TestCaseWithArtifactGenerationWithIndexing
 {
-    private static final Logger logger = LoggerFactory.getLogger(ArtifactSearchServiceImplTest.class);
 
     private static final File REPOSITORY_BASEDIR = new File(ConfigurationResourceResolver.getVaultDirectory() + "/storages/storage0/releases");
 

--- a/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
@@ -63,6 +63,8 @@ public class RepositoryIndexerTest
 
         final int x = repositoryManagementService.reIndex("storage0", "releases", "org/carlspring/strongbox/strongbox-commons");
 
+        repositoryManagementService.pack("storage0", "releases");
+
         assertTrue("Failed to pack index!", new File(REPOSITORY_BASEDIR.getAbsolutePath(), ".index/nexus-maven-repository-index.gz").exists());
         assertTrue("Failed to pack index!", new File(REPOSITORY_BASEDIR.getAbsolutePath(), ".index/nexus-maven-repository-index-packer.properties").exists());
 

--- a/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/testing/TestCaseWithArtifactGenerationWithIndexing.java
+++ b/strongbox-storage/strongbox-storage-indexing/src/test/java/org/carlspring/strongbox/testing/TestCaseWithArtifactGenerationWithIndexing.java
@@ -27,13 +27,12 @@ public class TestCaseWithArtifactGenerationWithIndexing
 {
 
     @Configuration
-    @Import({
-            StorageIndexingConfig.class,
-            StorageApiConfig.class,
-            CommonConfig.class,
-            ClientConfig.class,
-            DataServiceConfig.class
-    })
+    @Import({ StorageIndexingConfig.class,
+              StorageApiConfig.class,
+              CommonConfig.class,
+              ClientConfig.class,
+              DataServiceConfig.class
+            })
     public static class SpringConfig { }
 
     @Autowired
@@ -51,7 +50,7 @@ public class TestCaseWithArtifactGenerationWithIndexing
     {
         File artifactFile = new File(repositoryBasedir, artifactPath);
 
-        Artifact artifact = ArtifactUtils.getArtifactFromGAV("org.carlspring.strongbox:strongbox-utils:6.2.2:jar");
+        Artifact artifact = ArtifactUtils.convertPathToArtifact(artifactPath);
 
         RepositoryIndexer indexer = repositoryIndexManager.getRepositoryIndex(storageId + ":" + repositoryId);
 


### PR DESCRIPTION
- Packing is now only invoked, when re-indexing is triggered against the root of the repository, or for the tests.