### PR TITLE
SB-800: Set up integration tests in the strongbox project using the maven-failsafe-plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                             withSonarQubeEnv('sonar') {
                                 // requires SonarQube Scanner for Maven 3.2+
                                 sh "mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.2:sonar" +
-                                   " -Dspring.profiles.active=quartz-integration-tests"
+                                   " -Dintegration.tests"
 
                                 build(job: "strongbox/strongbox-os-builds", wait: false)
                             }
@@ -39,7 +39,7 @@ pipeline {
                                        " -Psonar-github" +
                                        " -Dsonar.github.repository=${REPO_NAME}" +
                                        " -Dsonar.github.pullRequest=${PR_NUMBER}" +
-                                       " -Dspring.profiles.active=quartz-integration-tests"
+                                       " -Dintegration.tests"
                                 }
                             }
                             else

--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -61,6 +61,10 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/strongbox-commons/src/test/java/org/carlspring/strongbox/net/ConnectionCheckerTestIT.java
+++ b/strongbox-commons/src/test/java/org/carlspring/strongbox/net/ConnectionCheckerTestIT.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.fail;
 /**
  * @author mtodorov
  */
-public class ConnectionCheckerTest
+public class ConnectionCheckerTestIT
 {
 
     @Test

--- a/strongbox-cron-tasks/pom.xml
+++ b/strongbox-cron-tasks/pom.xml
@@ -31,7 +31,6 @@
 
         <version.quartz>2.2.3</version.quartz>
         <version.groovy>2.3.0-beta-2</version.groovy>
-
     </properties>
 
     <build>

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/ClearRepositoryTrashCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/ClearRepositoryTrashCronJobTestIT.java
@@ -37,11 +37,11 @@ import static org.junit.Assert.*;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class ClearRepositoryTrashCronJobTest
+public class ClearRepositoryTrashCronJobTestIT
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
-    private final Logger logger = LoggerFactory.getLogger(ClearRepositoryTrashCronJobTest.class);
+    private final Logger logger = LoggerFactory.getLogger(ClearRepositoryTrashCronJobTestIT.class);
 
     private static final String STORAGE1 = "storage1";
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RebuildMavenIndexesCronJobTestIT.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.*;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RebuildMavenIndexesCronJobTest
+public class RebuildMavenIndexesCronJobTestIT
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RebuildMavenMetadataCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RebuildMavenMetadataCronJobTestIT.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertNull;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RebuildMavenMetadataCronJobTest
+public class RebuildMavenMetadataCronJobTestIT
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RegenerateMavenChecksumCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RegenerateMavenChecksumCronJobTestIT.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RegenerateMavenChecksumCronJobTest
+public class RegenerateMavenChecksumCronJobTestIT
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RegenerateNugetChecksumCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RegenerateNugetChecksumCronJobTestIT.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.*;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RegenerateNugetChecksumCronJobTest
+public class RegenerateNugetChecksumCronJobTestIT
         extends TestCaseWithNugetPackageGeneration
 {
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.*;
  */
 @CronTaskTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RemoveTimestampedMavenSnapshotCronJobTest
+public class RemoveTimestampedMavenSnapshotCronJobTestIT
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 

--- a/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/context/CronTaskTest.java
+++ b/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/context/CronTaskTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
                                   WebConfig.class })
 @WebAppConfiguration
 @WithUserDetails(value = "admin")
-@IfProfileValue(name = "spring.profiles.active", values = { "integration-tests" })
+// @IfProfileValue(name = "spring.profiles.active", values = { "integration-tests" })
 public @interface CronTaskTest
 {
 

--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Sonar settings: -->
         <sonar.language>java</sonar.language>
@@ -119,11 +120,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.20</version>
                     <inherited>false</inherited>
                     <configuration>
                         <argLine>-Xmx1024m -Xms512m</argLine>
+                        <includes>
+                            <include>**/*Test</include>
+                        </includes>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.20</version>
+
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>2.20</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -722,6 +739,33 @@
                                 <id>dependency-check</id>
                                 <goals>
                                     <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>fail-safe-integration-tests</id>
+            <activation>
+                <property>
+                    <name>integration.tests</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/strongbox-security-api/pom.xml
+++ b/strongbox-security-api/pom.xml
@@ -219,7 +219,7 @@
         <!-- These two profiles need to be on top. -->
 
         <profile>
-            <id>run-it-tests</id>
+            <id>run-tests</id>
             <activation>
                 <property>
                     <name>skipTests</name>
@@ -258,14 +258,6 @@
                                     </ldifFiles>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>unboundid-stop</id>
-
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
                         </executions>
                     </plugin>
 
@@ -294,17 +286,6 @@
                                     </userCredentials>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>stop</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-
-                                <configuration>
-                                    <shutdownPort>${port.littleproxy.shutdown}</shutdownPort>
-                                </configuration>
-                            </execution>
                         </executions>
                     </plugin>
 
@@ -326,6 +307,160 @@
 
                             <useUnlimitedThreads>false</useUnlimitedThreads>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>fail-safe-integration-tests-configuration</id>
+            <activation>
+                <property>
+                    <name>integration.tests</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+
+                        <configuration>
+                            <systemPropertyVariables>
+                                <strongbox.home>${project.build.directory}/strongbox</strongbox.home>
+                                <logging.dir>${project.build.directory}/strongbox/logs</logging.dir>
+
+                                <port.littleproxy>${port.littleproxy.listen}</port.littleproxy>
+                                <port.unboundid>${port.unboundid}</port.unboundid>
+
+                                <!-- override jre/lib/net.properties -->
+                                <jdk.http.auth.tunneling.disabledSchemes>none</jdk.http.auth.tunneling.disabledSchemes>
+                            </systemPropertyVariables>
+
+                            <useUnlimitedThreads>false</useUnlimitedThreads>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>stop-services-for-unit-tests</id>
+            <activation>
+                <property>
+                    <name>!integration.tests</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>unboundid-maven-plugin</artifactId>
+
+                        <configuration>
+                            <baseDn>dc=carlspring,dc=com</baseDn>
+                            <portSSL>${port.unboundid}</portSSL>
+                            <useSSL>true</useSSL>
+                            <keyStorePassword>password</keyStorePassword>
+                            <keyStorePath>${dir.strongbox.home}/etc/ssl/keystore.jks</keyStorePath>
+                            <trustStorePath>${dir.strongbox.home}/etc/ssl/truststore.jks</trustStorePath>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>unboundid-stop</id>
+
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>little-proxy-maven-plugin</artifactId>
+
+                        <configuration>
+                            <hash>5FD4F8E2A</hash>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>stop</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+
+                                <configuration>
+                                    <shutdownPort>${port.littleproxy.shutdown}</shutdownPort>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>stop-services-for-integration-tests</id>
+            <activation>
+                <property>
+                    <name>integration.tests</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>unboundid-maven-plugin</artifactId>
+
+                        <configuration>
+                            <baseDn>dc=carlspring,dc=com</baseDn>
+                            <portSSL>${port.unboundid}</portSSL>
+                            <useSSL>true</useSSL>
+                            <keyStorePassword>password</keyStorePassword>
+                            <keyStorePath>${dir.strongbox.home}/etc/ssl/keystore.jks</keyStorePath>
+                            <trustStorePath>${dir.strongbox.home}/etc/ssl/truststore.jks</trustStorePath>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>unboundid-stop</id>
+
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.carlspring.maven</groupId>
+                        <artifactId>little-proxy-maven-plugin</artifactId>
+
+                        <configuration>
+                            <hash>5FD4F8E2A</hash>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>stop</id>
+
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+
+                                <configuration>
+                                    <shutdownPort>${port.littleproxy.shutdown}</shutdownPort>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/certificates/KeyStoreManagerIntegrationTestIT.java
+++ b/strongbox-security-api/src/test/java/org/carlspring/strongbox/security/certificates/KeyStoreManagerIntegrationTestIT.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
-public class KeyStoreManagerIntegrationTest
+public class KeyStoreManagerIntegrationTestIT
 {
 
     @org.springframework.context.annotation.Configuration
@@ -60,7 +60,8 @@ public class KeyStoreManagerIntegrationTest
 
     private final Proxy PROXY_HTTP = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(PROXY_HOST, PROXY_HTTP_PORT));
 
-    private static final PasswordAuthentication credentials = new PasswordAuthentication(PROXY_USERNAME, PROXY_PASSWORD.toCharArray());
+    private static final PasswordAuthentication credentials = new PasswordAuthentication(PROXY_USERNAME,
+                                                                                         PROXY_PASSWORD.toCharArray());
 
     public static int LDAPS_PORT;
 
@@ -127,6 +128,7 @@ public class KeyStoreManagerIntegrationTest
         if (!ConnectionChecker.checkServiceAvailability(SOCKS_HOST, PROXY_SOCKS_PORT, 5000))
         {
             System.out.println("WARN: Skipping the testSocks() test, as the proxy server is unreachable.");
+
             return;
         }
 


### PR DESCRIPTION
Implemented.

All integration tests can now be invoked using:

```
mvn clean install -Dintegration.tests
```