### PR TITLE
SB-742: Start using the org.owasp:dependency-check-maven plugin to scan the dependencies for vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,15 +94,6 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-
-                        <executions>
-                            <execution>
-                                <id>dependency-check-aggregate</id>
-                                <goals>
-                                    <goal>aggregate</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Further fixes.
