### PR TITLE
Implement a Spring controller that returns the list of files and directories in a path as JSON

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -63,14 +63,16 @@ public class BrowseController
         {
             Map<String,SortedSet<String>> storages = new HashMap<>();
             storages.put("storages", new TreeSet<String>(configurationManager.getConfiguration()
-                    .getStorages().keySet()));
+                    .getStorages()
+                    .keySet()));
+            
             return ResponseEntity.ok(objectMapper.writer().writeValueAsString(storages));
         }
         catch (Exception e)
         {
             logger.error(e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(String.format("{ 'error': '%s' }", e.getMessage()));
+                                 .body(String.format("{ 'error': '%s' }", e.getMessage()));
         }
     }
     
@@ -138,7 +140,8 @@ public class BrowseController
             }
             
             Path baseDir = Paths.get(repository.getBasedir());
-            if (path.isPresent()) {
+            if (path.isPresent())
+            {
                 baseDir = Paths.get(baseDir.toString(), path.get());
             }
             if (!Files.exists(baseDir))
@@ -146,6 +149,7 @@ public class BrowseController
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                                      .body("{ 'error': 'The requested repository path was not found.' }");
             }
+            
             logger.debug("Listing repository contents for {}/{}: {}", storageId, repositoryId, baseDir.toString());
             
             List<String> directories = new ArrayList<>();
@@ -158,6 +162,7 @@ public class BrowseController
             Map<String,List<String>> contents = new HashMap<>();
             contents.put("directories", directories);
             contents.put("files", files);
+            
             return ResponseEntity.ok(objectMapper.writer().writeValueAsString(contents));
         }
         catch (Exception e)

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -1,0 +1,171 @@
+package org.carlspring.strongbox.controllers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.inject.Inject;
+
+import org.carlspring.strongbox.storage.Storage;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+/**
+ * REST API for browsing storage/repository/filesystem structures.
+ *
+ * @author Guido Grazioli <guido.grazioli@gmail.com>
+ */
+@RestController
+@RequestMapping(path = BrowseController.ROOT_CONTEXT)
+public class BrowseController
+        extends BaseArtifactController
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(BrowseController.class);
+
+    // must be the same as @RequestMapping value on the class definition
+    public final static String ROOT_CONTEXT = "/browse";
+    
+    @Inject
+    private ObjectMapper objectMapper;
+
+    @ApiOperation(value = "List configured storages.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "The list was returned."),
+                            @ApiResponse(code = 500, message = "An error occurred.") })
+    @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
+    @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> browse()
+    {
+        try
+        {
+            Map<String,SortedSet<String>> storages = new HashMap<>();
+            storages.put("storages", new TreeSet<String>(configurationManager.getConfiguration()
+                    .getStorages().keySet()));
+            return ResponseEntity.ok(objectMapper.writer().writeValueAsString(storages));
+        }
+        catch (Exception e)
+        {
+            logger.error(e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(String.format("{ 'error': '%s' }", e.getMessage()));
+        }
+    }
+    
+    @ApiOperation(value = "List configured repositories for a storage.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "The list was returned."),
+                            @ApiResponse(code = 404, message = "The requested storage was not found."),
+                            @ApiResponse(code = 500, message = "An error occurred.") })
+    @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
+    @RequestMapping(value="/{storageId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> repositories(@ApiParam(value = "The storageId", required = true)
+                                               @PathVariable("storageId") String storageId)
+    {
+        try
+        {
+            Storage storage = configurationManager.getConfiguration().getStorage(storageId);
+            if (storage == null) 
+            {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                     .body("{ 'error': 'The requested storage was not found.' }");
+            }
+            
+            Map<String,SortedSet<String>> repos = new HashMap<>();
+            repos.put("repositories", new TreeSet<String>(storage.getRepositories().keySet()));
+            
+            return ResponseEntity.ok(objectMapper.writer().writeValueAsString(repos));
+        }
+        catch (Exception e)
+        {
+            logger.error(e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body(String.format("{ 'error': '%s' }", e.getMessage()));
+        }
+    }
+    
+    @ApiOperation(value = "List the contents for a repository.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "The list was returned."),
+                            @ApiResponse(code = 404, message = "The requested storage, repository, or path was not found."),
+                            @ApiResponse(code = 500, message = "An error occurred.") })
+    @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
+    @RequestMapping(value = { "/{storageId}/{repositoryId}",
+                              "/{storageId}/{repositoryId}/{path}" }, 
+                    method = RequestMethod.GET, 
+                    produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> contents(@ApiParam(value = "The storageId", required = true)
+                                           @PathVariable("storageId") String storageId,
+                                           @ApiParam(value = "The repositoryId", required = true)
+                                           @PathVariable("repositoryId") String repositoryId,
+                                           @ApiParam(value = "The repository path", required = false)
+                                           @PathVariable("path") Optional<String> path)
+    {
+        try
+        {
+            Storage storage = configurationManager.getConfiguration().getStorage(storageId);
+            if (storage == null) 
+            {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                     .body("{ 'error': 'The requested storage was not found.' }");
+            }
+            
+            Repository repository = storage.getRepository(repositoryId);
+            if (repository == null) 
+            {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                     .body("{ 'error': 'The requested repository was not found.' }");
+            }
+            
+            Path baseDir = Paths.get(repository.getBasedir());
+            if (path.isPresent()) {
+                baseDir = Paths.get(baseDir.toString(), path.get());
+            }
+            if (!Files.exists(baseDir))
+            {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                                     .body("{ 'error': 'The requested repository path was not found.' }");
+            }
+            logger.debug("Listing repository contents for {}/{}: {}", storageId, repositoryId, baseDir.toString());
+            
+            List<String> directories = new ArrayList<>();
+            List<String> files = new ArrayList<>();
+            Files.list(baseDir)
+                 .filter(p -> !p.getFileName().toString().startsWith("."))
+                 .sorted()
+                 .forEach(p -> (Files.isDirectory(p) ? directories : files).add(p.getFileName().toString()));
+                                             
+            Map<String,List<String>> contents = new HashMap<>();
+            contents.put("directories", directories);
+            contents.put("files", files);
+            return ResponseEntity.ok(objectMapper.writer().writeValueAsString(contents));
+        }
+        catch (Exception e)
+        {
+            logger.error(e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body(String.format("{ 'error': '%s' }", e.getMessage()));
+        }
+    }
+    
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
@@ -37,6 +37,7 @@ public class BrowseControllerTest
     {
         Files.createFile(Paths.get("target/strongbox-vault/storages/storage0/releases","testfile")).toFile().deleteOnExit();
         Files.createDirectory(Paths.get("target/strongbox-vault/storages/storage0/releases","testdir")).toFile().deleteOnExit();
+        Files.createDirectory(Paths.get("target/strongbox-vault/storages/storage0/releases","testdir/testsubdir")).toFile().deleteOnExit();
     }
     
     @Test
@@ -139,7 +140,7 @@ public class BrowseControllerTest
                 .readValue(contents, new TypeReference<Map<String, List<String>>>(){});
         
         assertArrayEquals("Returned files", new String[] { }, returnedMap.get("files").toArray());
-        assertArrayEquals("Returned files", new String[] { }, returnedMap.get("directories").toArray());
+        assertArrayEquals("Returned files", new String[] { "testsubdir" }, returnedMap.get("directories").toArray());
     }
 
     @Test

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
@@ -1,0 +1,157 @@
+package org.carlspring.strongbox.controllers;
+
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.carlspring.strongbox.controllers.context.IntegrationTest;
+import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Guido Grazioli
+ */
+@IntegrationTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class BrowseControllerTest
+        extends RestAssuredBaseTest
+{
+
+    @BeforeClass
+    public static void setup()
+            throws Exception
+    {
+        Files.createFile(Paths.get("target/strongbox-vault/storages/storage0/releases","testfile")).toFile().deleteOnExit();
+        Files.createDirectory(Paths.get("target/strongbox-vault/storages/storage0/releases","testdir")).toFile().deleteOnExit();
+    }
+    
+    @Test
+    public void testGetStorages()
+            throws Exception
+    {
+
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT;
+        String storages = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                 .when()
+                                 .get(url)
+                                 .prettyPeek()
+                                 .asString();
+
+        Map<String, List<String>> returnedMap = new ObjectMapper()
+                .readValue(storages, new TypeReference<Map<String, List<String>>>(){});
+        
+        assertNotNull("Failed to get storage list!", returnedMap);
+        assertNotNull("Failed to get storage list!", returnedMap.get("storages"));
+        assertTrue("Returned storages size does not match", returnedMap.get("storages").size() >= 9);
+    }
+
+    @Test
+    public void testGetRepositories()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storage0";
+        String repos = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                              .when()
+                              .get(url)
+                              .prettyPeek()
+                              .asString();
+
+        Map<String, List<String>> returnedMap = new ObjectMapper()
+                .readValue(repos, new TypeReference<Map<String, List<String>>>(){});
+        
+        assertNotNull("Failed to get repository list!", returnedMap);
+        assertNotNull("Failed to get repository list!", returnedMap.get("repositories"));
+        assertEquals("Returned repositories do not match", returnedMap.get("repositories").size(), 2);
+        assertArrayEquals("Returned repos do not match", new String[] { "releases", "snapshots" }, returnedMap.get("repositories").toArray());
+    }
+
+    @Test
+    public void testGetRepositoriesWithStorageNotFound()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storagefoo";
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url)
+               .prettyPeek()
+               .then()
+               .statusCode(404);
+    }
+    
+    @Test
+    public void testRepositoryContents()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storage0/releases";
+        String contents = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                 .when()
+                                 .get(url)
+                                 .prettyPeek()
+                                 .asString();
+        
+        Map<String, List<String>> returnedMap = new ObjectMapper()
+                .readValue(contents, new TypeReference<Map<String, List<String>>>(){});
+        
+        assertArrayEquals("Returned files", new String[] { "testfile" }, returnedMap.get("files").toArray());
+        assertArrayEquals("Returned files", new String[] { "testdir" }, returnedMap.get("directories").toArray());
+
+    }
+
+    @Test
+    public void testRepositoryContentsWithRepositoryNotFound()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storage0/repofoo";
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url)
+               .prettyPeek()
+               .then()
+               .statusCode(404);   
+    }
+    
+    @Test
+    public void testRepositoryContentsWithPath()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storage0/releases/testdir";
+        String contents = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                 .when()
+                                 .get(url)
+                                 .prettyPeek()
+                                 .asString();
+
+        Map<String, List<String>> returnedMap = new ObjectMapper()
+                .readValue(contents, new TypeReference<Map<String, List<String>>>(){});
+        
+        assertArrayEquals("Returned files", new String[] { }, returnedMap.get("files").toArray());
+        assertArrayEquals("Returned files", new String[] { }, returnedMap.get("directories").toArray());
+    }
+
+    @Test
+    public void testRepositoryContentsWithPathNotFound()
+            throws Exception
+    {
+        String url = getContextBaseUrl() + BrowseController.ROOT_CONTEXT + "/storage0/releases/foo/bar";
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url)
+               .prettyPeek()
+               .then()
+               .statusCode(404);
+    }
+}


### PR DESCRIPTION
The /browse endpoint allows to fetch storage, repository,
and repository file contents in JSON format.

Served paths are in the following format:
 - Storage list:             `/browse`
 - Repository list:         ` /browse/{storage}`
 - Repository root contents: `/browse/{storage}/{repository}`
 - Repository path contents: `/browse/{storage}/{repository}/{path}`

This is the implementation for #444 .
