### PR TITLE
SearchController fixes

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -42,9 +42,6 @@
           <option name="ANNOTATION_PARAMETER_WRAP" value="2" />
           <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
         </JavaCodeStyleSettings>
-        <MarkdownNavigatorCodeStyleSettings>
-          <option name="RIGHT_MARGIN" value="72" />
-        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/SearchController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/SearchController.java
@@ -7,19 +7,13 @@ import org.carlspring.strongbox.storage.search.SearchResults;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URLDecoder;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -49,11 +43,10 @@ public class SearchController
      * @throws IOException
      * @throws ParseException
      */
-    @ApiOperation(value = "Used to search for artifacts.",
-                  response = SearchResults.class)
-    @ApiResponses(value = { @ApiResponse(code = 200,
-                                         message = "") })
-    @PreAuthorize("hasAuthority('SEARCH_ARTIFACTS')")
+    @ApiOperation(value = "Used to search for artifacts.", response = SearchResults.class)
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "") })
+    // TODO: Make this configurable
+    // @PreAuthorize("hasAuthority('SEARCH_ARTIFACTS')")
     @RequestMapping(value = "",
                     method = RequestMethod.GET,
                     consumes = { MediaType.APPLICATION_OCTET_STREAM_VALUE,
@@ -61,20 +54,16 @@ public class SearchController
                     produces = { MediaType.APPLICATION_XML_VALUE,
                                  MediaType.APPLICATION_JSON_VALUE,
                                  MediaType.TEXT_PLAIN_VALUE })
-    public ResponseEntity search(@ApiParam(value = "The storageId")
-                                 @RequestParam(name = "storageId",
-                                               required = false) final String storageId,
-                                 @ApiParam(value = "The repositoryId",
-                                           required = true)
-                                 @RequestParam(name = "repositoryId") final String repositoryId,
-                                 @ApiParam(value = "The search query",
-                                           required = true)
+    public ResponseEntity search(@ApiParam(value = "The storageId", required = false)
+                                 @RequestParam(name = "storageId", required = false) final String storageId,
+                                 @ApiParam(value = "The repositoryId", required = false)
+                                 @RequestParam(name = "repositoryId", required = false) final String repositoryId,
+                                 @ApiParam(value = "The search query", required = true)
                                  @RequestParam(name = "q") final String query,
-                                 @ApiParam(value = "The search query",
-                                           required = false)
-                                 @RequestParam(name = "searchProvider") final String searchProvider,
+                                 @ApiParam(value = "The search provider", required = false)
+                                 @RequestParam(name = "searchProvider", required = false) final String searchProvider,
                                  HttpServletRequest request)
-            throws IOException, ParseException, JAXBException, SearchException
+            throws IOException, SearchException
     {
         String accept = request.getHeader("accept");
         String q = URLDecoder.decode(query, "UTF-8");


### PR DESCRIPTION
- Applied fixes to the SearchController.
- Had to disable the @PreAuthorize part.

Example requests:
* OrientDB: 
```
http://localhost:48080/search?q=groupId=org.carlspring.strongbox;&searchProvider=OrientDB
```
* Maven Indexer:
```
http://localhost:48080/search?q=g:org.carlspring.strongbox&searchProvider=Maven%20Indexer
```

@fuss86 @sbespalov Had to disable the `@PreAuthorize` annotation. 
