### PR TITLE
Extracted Directory Browsing Code to BaseArtifactController [done] 

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
@@ -1,13 +1,24 @@
 package org.carlspring.strongbox.controllers;
 
 import org.carlspring.strongbox.providers.layout.LayoutProviderRegistry;
+import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.comparator.DirectoryFileComparator;
 import org.carlspring.strongbox.providers.datastore.StorageProviderRegistry;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
-
+import org.springframework.http.HttpStatus;
 import javax.inject.Inject;
-
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import io.swagger.annotations.Api;
+import java.io.File;
+import java.net.URLEncoder;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Locale;
+import java.util.regex.Matcher;
 
 @Api(value = "/storages")
 public abstract class BaseArtifactController
@@ -55,5 +66,170 @@ public abstract class BaseArtifactController
     {
         this.storageProviderRegistry = storageProviderRegistry;
     }
+    
+    protected boolean probeForDirectoryListing(Repository repository,
+                                               String path)
+    {
+        String filePath = path.replaceAll("/", Matcher.quoteReplacement(File.separator));
 
+        String dir = repository.getBasedir() + File.separator + filePath;
+
+        File file = new File(dir);
+
+        // Do not allow .index and .trash directories (or any other directory starting with ".") to be browseable.
+        // NB: Files will still be downloadable.
+        if (!file.isHidden() && !path.startsWith(".") && !path.contains("/."))
+        {
+            if (file.exists() && file.isDirectory())
+            {
+                return true;
+            }
+
+            file = new File(dir + File.separator);
+
+            return file.exists() && file.isDirectory();
+        }
+        else
+        {
+            return false;
+        }
+    }
+    
+    protected void getDirectoryListing(HttpServletRequest request,
+                                       HttpServletResponse response)
+    {
+        String dirPath = null;
+        
+        if (System.getProperty("strongbox.storage.booter.basedir") != null)
+        {
+            dirPath = System.getProperty("strongbox.storage.booter.basedir");
+        }
+        else
+        {
+            // Assuming this invocation is related to tests:
+            dirPath =  ConfigurationResourceResolver.getVaultDirectory() + "/storages/";
+        }        
+        generateDirectoryListing(dirPath, request, response);
+    }
+    
+    protected void getDirectoryListing(Repository repository,
+                                       HttpServletRequest request,
+                                       HttpServletResponse response)
+    {
+        String dirPath = repository.getBasedir();
+        
+        generateDirectoryListing(dirPath, request, response);
+    }
+    
+    protected void getDirectoryListing(Repository repository,
+                                       String path,
+                                       HttpServletRequest request,
+                                       HttpServletResponse response)
+    {
+        path = path.replaceAll("/", Matcher.quoteReplacement(File.separator));
+
+        if (request == null)
+        {
+            throw new RuntimeException("Unable to retrieve HTTP request from execution context");
+        }
+
+        String dirPath = repository.getBasedir() + File.separator + path;
+                
+        generateDirectoryListing(dirPath, request, response);
+    }
+
+    private void generateDirectoryListing(String dirPath, 
+                                          HttpServletRequest request, 
+                                          HttpServletResponse response)
+    {   
+        if(dirPath == null)
+        {
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+            logger.debug("Could not retrive /storages base directory");
+            return;
+        }
+        
+        File file = new File(dirPath);
+        String requestUri = request.getRequestURI();
+        
+        if (file.isDirectory() && !requestUri.endsWith("/"))
+        {
+            response.setLocale(new Locale(request.getRequestURI() + "/"));
+            response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+        }
+
+        try
+        {
+            logger.debug(" browsing: " + file.toString());
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("<html>");
+            sb.append("<head>");
+            sb.append(
+                    "<style>body{font-family: \"Trebuchet MS\", verdana, lucida, arial, helvetica, sans-serif;} table tr {text-align: left;}</style>");
+            sb.append("<title>Index of " + request.getRequestURI() + "</title>");
+            sb.append("</head>");
+            sb.append("<body>");
+            sb.append("<h1>Index of " + request.getRequestURI() + "</h1>");
+            sb.append("<table cellspacing=\"10\">");
+            sb.append("<tr>");
+            sb.append("<th>Name</th>");
+            sb.append("<th>Last modified</th>");
+            sb.append("<th>Size</th>");
+            sb.append("</tr>");
+            sb.append("<tr>");
+            sb.append("<td colspan=3><a href='..'>..</a></td>");
+            sb.append("</tr>");
+
+            File[] childFiles = file.listFiles();
+            if (childFiles != null)
+            {
+                Arrays.sort(childFiles, DirectoryFileComparator.DIRECTORY_COMPARATOR);
+
+                for (File childFile : childFiles)
+                {
+                    String name = childFile.getName();
+
+                    if (name.startsWith(".") || childFile.isHidden())
+                    {
+                        continue;
+                    }
+
+                    String lastModified = new SimpleDateFormat("dd-MM-yyyy HH-mm-ss").format(
+                            new Date(childFile.lastModified()));
+
+                    sb.append("<tr>");
+                    sb.append("<td><a href='" + URLEncoder.encode(name, "UTF-8") + (childFile.isDirectory() ?
+                                                                                    "/" : "") + "'>" + name +
+                              (childFile.isDirectory() ? "/" : "") + "</a></td>");
+                    sb.append("<td>" + lastModified + "</td>");
+                    sb.append("<td>" + FileUtils.byteCountToDisplaySize(childFile.length()) + "</td>");
+                    sb.append("</tr>");
+                }
+            }
+
+            sb.append("</table>");
+            sb.append("</body>");
+            sb.append("</html>");
+
+            response.setContentType("text/html;charset=UTF-8");
+            response.setStatus(HttpStatus.FOUND.value());
+            response.getWriter()
+                    .write(sb.toString());
+            response.getWriter()
+                    .flush();
+            response.getWriter()
+                    .close();
+
+        }
+        catch (Exception e)
+        {
+            logger.error(" error accessing requested directory: " + file.getAbsolutePath(), e);
+
+            response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        }
+    }
+    
+        
+    
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/maven/MavenArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/maven/MavenArtifactController.java
@@ -160,7 +160,7 @@ public class MavenArtifactController
         {
             try
             {
-                generateDirectoryListing(repository, path, request, response);
+                getDirectoryListing(repository, path, request, response);
             }
             catch (Exception e)
             {
@@ -229,129 +229,6 @@ public class MavenArtifactController
         else
         {
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
-        }
-    }
-
-    private boolean probeForDirectoryListing(Repository repository,
-                                             String path)
-    {
-        String filePath = path.replaceAll("/", Matcher.quoteReplacement(File.separator));
-
-        String dir = repository.getBasedir() + File.separator + filePath;
-
-        File file = new File(dir);
-
-        // Do not allow .index and .trash directories (or any other directory starting with ".") to be browseable.
-        // NB: Files will still be downloadable.
-        if (!file.isHidden() && !path.startsWith(".") && !path.contains("/."))
-        {
-            if (file.exists() && file.isDirectory())
-            {
-                return true;
-            }
-
-            file = new File(dir + File.separator);
-
-            return file.exists() && file.isDirectory();
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    private void generateDirectoryListing(Repository repository,
-                                          String path,
-                                          HttpServletRequest request,
-                                          HttpServletResponse response)
-    {
-        path = path.replaceAll("/", Matcher.quoteReplacement(File.separator));
-
-        if (request == null)
-        {
-            throw new RuntimeException("Unable to retrieve HTTP request from execution context");
-        }
-
-        String dir = repository.getBasedir() + File.separator + path;
-        String requestUri = request.getRequestURI();
-
-        File file = new File(dir);
-
-        if (file.isDirectory() && !requestUri.endsWith("/"))
-        {
-            response.setLocale(new Locale(request.getRequestURI() + "/"));
-            response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
-        }
-
-        try
-        {
-            logger.debug(" browsing: " + file.toString());
-
-            StringBuilder sb = new StringBuilder();
-            sb.append("<html>");
-            sb.append("<head>");
-            sb.append(
-                    "<style>body{font-family: \"Trebuchet MS\", verdana, lucida, arial, helvetica, sans-serif;} table tr {text-align: left;}</style>");
-            sb.append("<title>Index of " + request.getRequestURI() + "</title>");
-            sb.append("</head>");
-            sb.append("<body>");
-            sb.append("<h1>Index of " + request.getRequestURI() + "</h1>");
-            sb.append("<table cellspacing=\"10\">");
-            sb.append("<tr>");
-            sb.append("<th>Name</th>");
-            sb.append("<th>Last modified</th>");
-            sb.append("<th>Size</th>");
-            sb.append("</tr>");
-            sb.append("<tr>");
-            sb.append("<td colspan=3><a href='..'>..</a></td>");
-            sb.append("</tr>");
-
-            File[] childFiles = file.listFiles();
-            if (childFiles != null)
-            {
-                Arrays.sort(childFiles, DirectoryFileComparator.DIRECTORY_COMPARATOR);
-
-                for (File childFile : childFiles)
-                {
-                    String name = childFile.getName();
-
-                    if (name.startsWith(".") || childFile.isHidden())
-                    {
-                        continue;
-                    }
-
-                    String lastModified = new SimpleDateFormat("dd-MM-yyyy HH-mm-ss").format(
-                            new Date(childFile.lastModified()));
-
-                    sb.append("<tr>");
-                    sb.append("<td><a href='" + URLEncoder.encode(name, "UTF-8") + (childFile.isDirectory() ?
-                                                                                    "/" : "") + "'>" + name +
-                              (childFile.isDirectory() ? "/" : "") + "</a></td>");
-                    sb.append("<td>" + lastModified + "</td>");
-                    sb.append("<td>" + FileUtils.byteCountToDisplaySize(childFile.length()) + "</td>");
-                    sb.append("</tr>");
-                }
-            }
-
-            sb.append("</table>");
-            sb.append("</body>");
-            sb.append("</html>");
-
-            response.setContentType("text/html;charset=UTF-8");
-            response.setStatus(HttpStatus.FOUND.value());
-            response.getWriter()
-                    .write(sb.toString());
-            response.getWriter()
-                    .flush();
-            response.getWriter()
-                    .close();
-
-        }
-        catch (Exception e)
-        {
-            logger.error(" error accessing requested directory: " + file.getAbsolutePath(), e);
-
-            response.setStatus(404);
         }
     }
 


### PR DESCRIPTION
This covers issue #446.

Extracted directory browsing code from `MavenArtifactController` to `BaseArtifactController`.

In `BaseArtifactController`, 
`getDirectoryListing(Request, Response)` lists all Storages.
`getDIrectoryListing(StorageId, Request, Response)` lists all Repositories in Storage with id = StorageId
`getDIrectoryListing(StorageId, RepositoryId, Request, Response)` lists all sub-directories and files  in Repository with id = RepositoryId.

This implementation is generic enough for solving issue #464.

Quick look suggests it will support NuGet and NPM browsing requests too.

Should browsing support for NuGet and NPM be implemented in this PR or new issue will be opened for it?
