### PR TITLE
#464 - Added browsing support for Storages and Repositories under a Storage

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import io.swagger.annotations.Api;
 import java.io.File;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -154,8 +155,15 @@ public abstract class BaseArtifactController
         
         if (file.isDirectory() && !requestUri.endsWith("/"))
         {
-            response.setLocale(new Locale(request.getRequestURI() + "/"));
-            response.setStatus(HttpStatus.TEMPORARY_REDIRECT.value());
+            try
+            {
+                response.sendRedirect(requestUri + "/");
+            }
+            catch (IOException e)
+            {
+                logger.debug("Error redirecting to " + requestUri + "/");
+            }
+            return;
         }
 
         try

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseStoragesController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseStoragesController.java
@@ -1,0 +1,72 @@
+package org.carlspring.strongbox.controllers;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.carlspring.strongbox.storage.Storage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author sanket407
+ */
+
+@RestController
+@RequestMapping(path = BrowseStoragesController.ROOT_CONTEXT, headers = "user-agent=unknown/*")
+public class BrowseStoragesController
+        extends BaseArtifactController
+{
+    private Logger logger = LoggerFactory.getLogger(BrowseStoragesController.class);
+
+    public static final String ROOT_CONTEXT = "/storages";
+
+
+    @ApiOperation(value = "Used to browse the configured storages")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
+                            @ApiResponse(code = 400, message = "An error occurred.") })
+    @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
+    @RequestMapping(value = { "" , "/" }, method = RequestMethod.GET)
+    public void browseStorages(HttpServletRequest request,
+                               HttpServletResponse response)
+    {
+        logger.debug("Requested browsing for storages");
+
+        getDirectoryListing(request, response);
+    }
+
+    @ApiOperation(value = "Used to browse the repositories in a storage")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
+                            @ApiResponse(code = 400, message = "An error occurred.") })
+    @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
+    @RequestMapping(value = { "{storageId}/" , "{storageId}" }, method = RequestMethod.GET)
+    public void browseRepositores(@ApiParam(value = "The storageId", required = true)
+                                  @PathVariable String storageId,
+                                  HttpServletRequest request,
+                                  HttpServletResponse response) 
+            throws IOException
+    {
+        logger.debug("Requested browsing for repositores in storage : " + storageId);
+
+        Storage storage = configurationManager.getConfiguration().getStorage(storageId);
+        if (storage == null)
+        {
+            logger.error("Unable to find storage by ID " + storageId);
+
+            response.sendError(HttpStatus.NOT_FOUND.value(), "Unable to find storage by ID " + storageId);
+
+            return;
+        }
+
+        getDirectoryListing(storage, request, response);
+    }
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseStoragesController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseStoragesController.java
@@ -20,12 +20,12 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * @author sanket407
  */
-
 @RestController
 @RequestMapping(path = BrowseStoragesController.ROOT_CONTEXT, headers = "user-agent=unknown/*")
 public class BrowseStoragesController
         extends BaseArtifactController
 {
+    
     private Logger logger = LoggerFactory.getLogger(BrowseStoragesController.class);
 
     public static final String ROOT_CONTEXT = "/storages";

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/web/HeaderMappingFilter.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/web/HeaderMappingFilter.java
@@ -122,7 +122,7 @@ public class HeaderMappingFilter
         String[] pathParts = pathInfo.split("/");
         if (pathParts.length < 4)
         {
-            throw new IllegalArgumentException(String.format("Illegal format of `storages` request [%s].%nRequest path should be in the form of:%n%n\t'storages/{storageId}/{repositoryId}/...'", pathInfo));
+            return null;
         }
         String storageId = pathParts[2];
         String repositoryId = pathParts[3];

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseStoragesControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseStoragesControllerTest.java
@@ -41,22 +41,26 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author sanket407
  */
-
 @IntegrationTest
 @RunWith(SpringJUnit4ClassRunner.class)
 public class BrowseStoragesControllerTest
         extends TestCaseWithRepository
-{     
+{
+    
+    
     @Test
     public void testBrowseStorages()
             throws Exception
     {
         String path = "/storages/";
 
-        RestAssuredMockMvc.given().header("User-Agent", "unknown/*")
-        .contentType(MediaType.TEXT_PLAIN_VALUE)
-        .when().get(path)
-        .then().statusCode(302);
+        RestAssuredMockMvc.given()
+                          .header("User-Agent", "unknown/*")
+                          .contentType(MediaType.TEXT_PLAIN_VALUE)
+                          .when()
+                          .get(path)
+                          .then()
+                          .statusCode(302);
     }
 
     @Test
@@ -65,10 +69,13 @@ public class BrowseStoragesControllerTest
     {
         String path = "/storages/storage0/";
 
-
-        RestAssuredMockMvc.given().header("User-Agent", "unknown/*")
-        .contentType(MediaType.TEXT_PLAIN_VALUE)
-        .when().get(path)
-        .then().statusCode(302);
+        RestAssuredMockMvc.given()
+                          .header("User-Agent", "unknown/*")
+                          .contentType(MediaType.TEXT_PLAIN_VALUE)
+                          .when()
+                          .get(path)
+                          .then()
+                          .statusCode(302);
     }
+    
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseStoragesControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseStoragesControllerTest.java
@@ -1,0 +1,74 @@
+package org.carlspring.strongbox.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecBuilder;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
+import io.restassured.response.ExtractableResponse;
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.carlspring.strongbox.configuration.ConfigurationManager;
+import org.carlspring.strongbox.controllers.context.IntegrationTest;
+import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
+import org.carlspring.strongbox.rest.common.MavenRestAssuredBaseTest;
+import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.testing.TestCaseWithRepository;
+import org.carlspring.strongbox.web.HeaderMappingFilter;
+import org.carlspring.strongbox.xml.configuration.repository.MavenRepositoryConfiguration;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author sanket407
+ */
+
+@IntegrationTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class BrowseStoragesControllerTest
+        extends TestCaseWithRepository
+{     
+    @Test
+    public void testBrowseStorages()
+            throws Exception
+    {
+        String path = "/storages/";
+
+        RestAssuredMockMvc.given().header("User-Agent", "unknown/*")
+        .contentType(MediaType.TEXT_PLAIN_VALUE)
+        .when().get(path)
+        .then().statusCode(302);
+    }
+
+    @Test
+    public void testBrowseRepositoriesInStorages()
+            throws Exception
+    {
+        String path = "/storages/storage0/";
+
+
+        RestAssuredMockMvc.given().header("User-Agent", "unknown/*")
+        .contentType(MediaType.TEXT_PLAIN_VALUE)
+        .when().get(path)
+        .then().statusCode(302);
+    }
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/maven/MavenArtifactControllerTest.java
@@ -523,11 +523,11 @@ public class MavenArtifactControllerTest
         ExtractableResponse trashDirectoryListing = client.getResourceWithResponse(basePath, ".trash");
         ExtractableResponse indexDirectoryListing = client.getResourceWithResponse(basePath, ".index");
         ExtractableResponse directoryListing = client.getResourceWithResponse(basePath,
-                                                                              "org/carlspring/strongbox/browse");
+                                                                              "org/carlspring/strongbox/browse/");
         ExtractableResponse fileListing = client.getResourceWithResponse(basePath,
-                                                                         "org/carlspring/strongbox/browse/foo-bar/1.0");
+                                                                         "org/carlspring/strongbox/browse/foo-bar/1.0/");
         ExtractableResponse invalidPath = client.getResourceWithResponse(basePath,
-                                                                         "org/carlspring/strongbox/browse/1.0");
+                                                                         "org/carlspring/strongbox/browse/1.0/");
 
         String repositoryRootContent = repositoryRoot.asString();
         String directoryListingContent = directoryListing.asString();


### PR DESCRIPTION
Implemented #464 
1. Added REST endpoints for browsing storages and repostories in BrowseStoragesController in org.carlspring.strongbox.controllers  

- /storages  - Browse all the storages 
- /storages/STORAGE - Browse all the repositories under Storage - 'STORAGE' 

For directly Invoking or Testing Against this controller set header 'user-agent=unknown/*'

2. Added code for redirecting a GET request for a directory not ending in '/' to the equivalent path ending in '/'. So /storages will get redirected to /storages/ , /storages/storage0' will get redirected to /storages/storage0/' . 