### PR TITLE
Implement a Spring controller that displays the environment variables and properties

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfo.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfo.java
@@ -1,0 +1,62 @@
+package org.carlspring.strongbox.controllers.environment;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author Pablo Tirado
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "name",
+        "value",
+})
+public class EnvironmentInfo
+        implements Comparable<EnvironmentInfo>
+{
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("value")
+    private String value;
+
+    @JsonCreator
+    public EnvironmentInfo(@JsonProperty("name") String name,
+                           @JsonProperty("value") String value)
+    {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+
+    public void setValue(String value)
+    {
+        this.value = value;
+    }
+
+
+    @Override
+    public int compareTo(EnvironmentInfo other)
+    {
+        return getName().compareTo(other.getName());
+    }
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
@@ -1,0 +1,89 @@
+package org.carlspring.strongbox.controllers.environment;
+
+import org.carlspring.strongbox.controllers.BaseController;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Pablo Tirado
+ */
+@RestController
+@PreAuthorize("hasAuthority('ADMIN')")
+@RequestMapping("/configuration/environment/info")
+@Api("/configuration/environment/info")
+public class EnvironmentInfoController
+        extends BaseController
+{
+
+    private ObjectMapper objectMapper;
+
+    public EnvironmentInfoController(ObjectMapper objectMapper)
+    {
+        this.objectMapper = objectMapper;
+    }
+
+    @ApiOperation(value = "List all the environment variables and system properties.")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "The list was returned."),
+                            @ApiResponse(code = 500, message = "An error occurred.") })
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity getEnvironmentAndSystemProperties()
+    {
+        logger.debug("Listing of all environment variables and system properties");
+
+        Map<String, List<EnvironmentInfo>> propertiesMap = new HashMap<>();
+        List<EnvironmentInfo> environmentVariables = getEnvironmentVariables();
+        List<EnvironmentInfo> systemProperties = getSystemProperties();
+
+        propertiesMap.put("environment", environmentVariables);
+        propertiesMap.put("system", systemProperties);
+
+        try
+        {
+            return ResponseEntity.ok(objectMapper.writeValueAsString(propertiesMap));
+        }
+        catch (JsonProcessingException e)
+        {
+            logger.error(e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                                 .body(String.format("{ 'error': '%s' }", e.getMessage()));
+        }
+    }
+
+    private List<EnvironmentInfo> getEnvironmentVariables()
+    {
+        Map<String, String> environmentMap = System.getenv();
+
+        return environmentMap.entrySet().stream()
+                             .sorted(Map.Entry.comparingByKey())
+                             .map(e -> new EnvironmentInfo(e.getKey(), e.getValue()))
+                             .collect(Collectors.toList());
+    }
+
+    private List<EnvironmentInfo> getSystemProperties()
+    {
+        Properties systemProperties = System.getProperties();
+
+        return systemProperties.entrySet().stream()
+                               .sorted(Comparator.comparing(
+                                       Map.Entry::getKey,
+                                       Comparator.comparing(e -> (String) e))
+                               )
+                               .map(e -> new EnvironmentInfo((String) e.getKey(), (String) e.getValue()))
+                               .collect(Collectors.toList());
+    }
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
@@ -1,0 +1,83 @@
+package org.carlspring.strongbox.controllers.environment;
+
+import org.carlspring.strongbox.controllers.context.IntegrationTest;
+import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Ordering;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.junit.Assert.*;
+
+/**
+ * @author Pablo Tirado
+ */
+@IntegrationTest
+@RunWith(SpringRunner.class)
+public class EnvironmentInfoControllerTestIT
+        extends RestAssuredBaseTest
+{
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Test
+    public void testGetEnvironmentAndSystemProperties()
+            throws Exception
+    {
+        String path = "/configuration/environment/info";
+
+        String envSystemProperties = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .when()
+                                            .get(path)
+                                            .prettyPeek()
+                                            .asString();
+
+        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envSystemProperties,
+                                                                          new TypeReference<Map<String, List<EnvironmentInfo>>>()
+                                                                          {
+                                                                          });
+
+        assertNotNull("Failed to get environment and system properties list!", returnedMap);
+        assertNotNull("Failed to get environment variables list!", returnedMap.get("environment"));
+        assertFalse("Returned environment variables are empty", returnedMap.get("environment").isEmpty());
+        assertNotNull("Failed to get system properties list!", returnedMap.get("system"));
+        assertFalse("Returned system properties are empty", returnedMap.get("system").isEmpty());
+    }
+
+    @Test
+    public void testGetEnvironmentAndSystemPropertiesCheckSorted()
+            throws Exception
+    {
+        String path = "/configuration/environment/info";
+
+        String envSystemProperties = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                            .when()
+                                            .get(path)
+                                            .prettyPeek()
+                                            .asString();
+
+        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envSystemProperties,
+                                                                          new TypeReference<Map<String, List<EnvironmentInfo>>>()
+                                                                          {
+                                                                          });
+
+        List<EnvironmentInfo> environmentVariables = returnedMap.get("environment");
+        assertNotNull("Failed to get environment variables list!", environmentVariables);
+        assertTrue("Environment variables list is not sorted!", Ordering.natural().isOrdered(environmentVariables));
+
+        List<EnvironmentInfo> systemProperties = returnedMap.get("system");
+        assertNotNull("Failed to get system properties list!", systemProperties);
+        assertTrue("System properties list is not sorted!", Ordering.natural().isOrdered(systemProperties));
+    }
+}


### PR DESCRIPTION
Related issue: #458

The `/configuration/environment/info` endpoint allows to fetch environment variables and system properties in JSON format, sorted.

I finally created a package `org.carlspring.strongbox.controllers.environment` where there is a controller and an entity that represents the property (name-value).

I also implemented the proper test cases.
  