### PR TITLE
Make the EnvironmentInfoController controller also display JVM args used to run Strongbox

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfo.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfo.java
@@ -53,10 +53,25 @@ public class EnvironmentInfo
         this.value = value;
     }
 
-
     @Override
     public int compareTo(EnvironmentInfo other)
     {
         return getName().compareTo(other.getName());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EnvironmentInfo that = (EnvironmentInfo) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+
+        return Objects.hash(name);
     }
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
@@ -100,7 +100,7 @@ public class EnvironmentInfoController
                 argument = argument.substring(2);
                 String[] argumentArray = argument.split("=");
                 String argumentName = argumentArray[0];
-                String argumentValue = argumentArray.length == 2 ? argumentArray[1] : null;
+                String argumentValue = argumentArray.length == 2 ? argumentArray[1] : "";
                 if (!jvmArgumentsMap.containsKey(argumentName))
                 {
                     jvmArgumentsMap.put(argumentName, argumentValue);

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
@@ -32,42 +32,44 @@ public class EnvironmentInfoControllerTestIT
     private ObjectMapper mapper;
 
     @Test
-    public void testGetEnvironmentAndSystemProperties()
+    public void testGetEnvironmentInfo()
             throws Exception
     {
         String path = "/configuration/environment/info";
 
-        String envSystemProperties = given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                                            .when()
-                                            .get(path)
-                                            .prettyPeek()
-                                            .asString();
+        String envInfo = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .when()
+                                .get(path)
+                                .prettyPeek()
+                                .asString();
 
-        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envSystemProperties,
+        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envInfo,
                                                                           new TypeReference<Map<String, List<EnvironmentInfo>>>()
                                                                           {
                                                                           });
 
-        assertNotNull("Failed to get environment and system properties list!", returnedMap);
+        assertNotNull("Failed to get all environment info list!", returnedMap);
         assertNotNull("Failed to get environment variables list!", returnedMap.get("environment"));
         assertFalse("Returned environment variables are empty", returnedMap.get("environment").isEmpty());
         assertNotNull("Failed to get system properties list!", returnedMap.get("system"));
         assertFalse("Returned system properties are empty", returnedMap.get("system").isEmpty());
+        assertNotNull("Failed to get JVM arguments list!", returnedMap.get("jvmArgs"));
+        assertFalse("Returned JVM arguments are empty", returnedMap.get("jvmArgs").isEmpty());
     }
 
     @Test
-    public void testGetEnvironmentAndSystemPropertiesCheckSorted()
+    public void testGetEnvironmentInfoCheckSorted()
             throws Exception
     {
         String path = "/configuration/environment/info";
 
-        String envSystemProperties = given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                                            .when()
-                                            .get(path)
-                                            .prettyPeek()
-                                            .asString();
+        String envInfo = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .when()
+                                .get(path)
+                                .prettyPeek()
+                                .asString();
 
-        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envSystemProperties,
+        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envInfo,
                                                                           new TypeReference<Map<String, List<EnvironmentInfo>>>()
                                                                           {
                                                                           });
@@ -79,5 +81,9 @@ public class EnvironmentInfoControllerTestIT
         List<EnvironmentInfo> systemProperties = returnedMap.get("system");
         assertNotNull("Failed to get system properties list!", systemProperties);
         assertTrue("System properties list is not sorted!", Ordering.natural().isOrdered(systemProperties));
+
+        List<EnvironmentInfo> jvmArguments = returnedMap.get("jvmArgs");
+        assertNotNull("Failed to get JVM arguments list!", returnedMap.get("jvmArgs"));
+        assertTrue("JVM arguments list is not sorted!", Ordering.natural().isOrdered(jvmArguments));
     }
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
@@ -4,13 +4,12 @@ import org.carlspring.strongbox.controllers.context.IntegrationTest;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 
 import javax.inject.Inject;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.common.collect.Ordering;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,18 +42,24 @@ public class EnvironmentInfoControllerTestIT
                                 .prettyPeek()
                                 .asString();
 
-        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envInfo,
-                                                                          new TypeReference<Map<String, List<EnvironmentInfo>>>()
-                                                                          {
-                                                                          });
+        Map<String, List<?>> returnedMap = mapper.readValue(envInfo,
+                                                            new TypeReference<Map<String, List<?>>>()
+                                                            {
+                                                            });
 
         assertNotNull("Failed to get all environment info list!", returnedMap);
-        assertNotNull("Failed to get environment variables list!", returnedMap.get("environment"));
-        assertFalse("Returned environment variables are empty", returnedMap.get("environment").isEmpty());
-        assertNotNull("Failed to get system properties list!", returnedMap.get("system"));
-        assertFalse("Returned system properties are empty", returnedMap.get("system").isEmpty());
-        assertNotNull("Failed to get JVM arguments list!", returnedMap.get("jvmArgs"));
-        assertFalse("Returned JVM arguments are empty", returnedMap.get("jvmArgs").isEmpty());
+
+        List<?> environmentVariables = returnedMap.get("environment");
+        assertNotNull("Failed to get environment variables list!", environmentVariables);
+        assertFalse("Returned environment variables are empty", environmentVariables.isEmpty());
+
+        List<?> systemProperties = returnedMap.get("system");
+        assertNotNull("Failed to get system properties list!", systemProperties);
+        assertFalse("Returned system properties are empty", systemProperties.isEmpty());
+
+        List<?> jvmArguments = returnedMap.get("jvm");
+        assertNotNull("Failed to get JVM arguments list!", jvmArguments);
+        assertFalse("Returned JVM arguments are empty", jvmArguments.isEmpty());
     }
 
     @Test
@@ -66,24 +71,41 @@ public class EnvironmentInfoControllerTestIT
         String envInfo = given().contentType(MediaType.APPLICATION_JSON_VALUE)
                                 .when()
                                 .get(path)
-                                .prettyPeek()
                                 .asString();
 
-        Map<String, List<EnvironmentInfo>> returnedMap = mapper.readValue(envInfo,
-                                                                          new TypeReference<Map<String, List<EnvironmentInfo>>>()
-                                                                          {
-                                                                          });
+        JsonNode root = mapper.readTree(envInfo);
 
-        List<EnvironmentInfo> environmentVariables = returnedMap.get("environment");
+        // Environment variables
+        JsonNode environmentNode = root.path("environment");
+        ObjectReader listEnvironmentInfoReader = mapper.readerFor(new TypeReference<List<EnvironmentInfo>>()
+        {
+        });
+        List<EnvironmentInfo> environmentVariables = listEnvironmentInfoReader.readValue(environmentNode);
+        Comparator<EnvironmentInfo> environmentInfoComparator = Comparator.comparing(EnvironmentInfo::getName,
+                                                                                     String.CASE_INSENSITIVE_ORDER);
+        List<EnvironmentInfo> sortedEnvironmentVariables = new ArrayList<>(environmentVariables);
+        sortedEnvironmentVariables.sort(environmentInfoComparator);
         assertNotNull("Failed to get environment variables list!", environmentVariables);
-        assertTrue("Environment variables list is not sorted!", Ordering.natural().isOrdered(environmentVariables));
+        assertEquals("Environment variables list is not sorted!", environmentVariables, sortedEnvironmentVariables);
 
-        List<EnvironmentInfo> systemProperties = returnedMap.get("system");
+        // System properties
+        JsonNode systemNode = root.path("system");
+        List<EnvironmentInfo> systemProperties = listEnvironmentInfoReader.readValue(systemNode);
+        List<EnvironmentInfo> sortedSystemProperties = new ArrayList<>(systemProperties);
+        sortedSystemProperties.sort(environmentInfoComparator);
         assertNotNull("Failed to get system properties list!", systemProperties);
-        assertTrue("System properties list is not sorted!", Ordering.natural().isOrdered(systemProperties));
+        assertEquals("System properties list is not sorted!", systemProperties, sortedSystemProperties);
 
-        List<EnvironmentInfo> jvmArguments = returnedMap.get("jvmArgs");
-        assertNotNull("Failed to get JVM arguments list!", returnedMap.get("jvmArgs"));
-        assertTrue("JVM arguments list is not sorted!", Ordering.natural().isOrdered(jvmArguments));
+        // JVM arguments
+        JsonNode jvmNode = root.path("jvm");
+        ObjectReader listStringReader = mapper.readerFor(new TypeReference<List<String>>()
+        {
+        });
+        List<String> jvmArguments = listStringReader.readValue(jvmNode);
+        Comparator<String> stringComparator = String::compareToIgnoreCase;
+        List<String> sortedJvmArguments = new ArrayList<>(jvmArguments);
+        sortedJvmArguments.sort(stringComparator);
+        assertNotNull("Failed to get JVM arguments list!", jvmArguments);
+        assertEquals("JVM arguments list is not sorted!", jvmArguments, sortedJvmArguments);
     }
 }


### PR DESCRIPTION
Related issue: #477 

The /configuration/environment/info endpoint allows to fetch JVM args (among others) in JSON format, sorted.

Considered that a JVM argument is defined as -Dname=value or -Dname (in this case, empty string value).

I also implemented the proper test cases.