### PR TITLE
SB-445: Refactor UserController to return proper JSON messages upon successful/failed action

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseController.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.controllers;
 import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.controllers.support.ErrorResponseEntityBody;
+import org.carlspring.strongbox.controllers.support.ResponseEntityBody;
 import org.carlspring.strongbox.resource.ResourceCloser;
 
 import javax.inject.Inject;
@@ -28,6 +29,18 @@ public abstract class BaseController
     @Inject
     protected ConfigurationManager configurationManager;
 
+    protected ResponseEntityBody getResponseEntityBody(String message)
+    {
+        return new ResponseEntityBody(message);
+    }
+
+    protected ResponseEntity toResponseEntity(String message,
+                                              HttpStatus httpStatus)
+    {
+        return ResponseEntity.status(httpStatus)
+                             .body(getResponseEntityBody(message));
+    }
+
     protected ResponseEntity toResponseEntityError(String message,
                                                    HttpStatus httpStatus)
     {
@@ -40,16 +53,24 @@ public abstract class BaseController
         return toResponseEntityError(message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    protected ResponseEntity toError(String message)
+    protected ResponseEntity toError(String message,
+                                     Boolean... wrapBody)
     {
+        if (wrapBody != null)
+        {
+            return toError(new RuntimeException(message), wrapBody);
+        }
+
         return toError(new RuntimeException(message));
     }
 
-    protected ResponseEntity toError(Throwable cause)
+    protected ResponseEntity toError(Throwable cause,
+                                     Boolean... wrapBody)
     {
         logger.error(cause.getMessage(), cause);
+        Object bodyContent = wrapBody != null ? getResponseEntityBody(cause.getMessage()) : cause.getMessage();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                             .body(cause.getMessage());
+                             .body(bodyContent);
     }
 
     protected Configuration getConfiguration()

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/ResponseEntityBody.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/ResponseEntityBody.java
@@ -1,0 +1,32 @@
+package org.carlspring.strongbox.controllers.support;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Pablo Tirado
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResponseEntityBody
+{
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonCreator
+    public ResponseEntityBody(@JsonProperty("message") String message)
+    {
+        this.message = message;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public void setMessage(String message)
+    {
+        this.message = message;
+    }
+}


### PR DESCRIPTION
Related issue: #445 

In the method `create`, an additional check has been added before saving: if you try to create a user with an existing username, a 409 code (conflict) is returned with the proper body message wrapped.

I also implemented the proper test cases.