### PR TITLE
Added header support for Maven and Nuget - Hosted Repositories #372 [ready]

### DIFF
--- a/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
+++ b/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
@@ -366,7 +366,7 @@ public class RestAssuredArtifactClient
                            .asString();
     }
 
-     public Headers getHeadersfromHEAD(String url)
+    public Headers getHeadersfromHEAD(String url)
     {
         MockMvcRequestSpecification o = givenLocal().contentType(MediaType.TEXT_PLAIN_VALUE);
 

--- a/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
+++ b/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
@@ -366,4 +366,52 @@ public class RestAssuredArtifactClient
                            .asString();
     }
 
+     public Headers getHeadersfromHEAD(String url)
+    {
+        MockMvcRequestSpecification o = givenLocal().contentType(MediaType.TEXT_PLAIN_VALUE);
+
+        MockMvcResponse response = o.when().head(url);
+        Headers allHeaders = response.getHeaders();
+
+        logger.debug("HTTP HEAD " + url);
+        logger.debug("Response headers:");
+
+        allHeaders.forEach(header -> logger.debug("\t" + header.getName() + " = " + header.getValue()));
+
+        if (response.getStatusCode() == OK || response.getStatusCode() == PARTIAL_CONTENT)
+        {
+            logger.debug("Received headers successfully.");
+            return allHeaders;
+        }
+        else
+        {
+            logger.warn("[getArtifactAsByteArray] response " + response.getStatusCode());
+            return null;
+        }
+    }
+
+    public Headers getHeadersFromGET(String url)
+    {
+        MockMvcRequestSpecification o = givenLocal().contentType(MediaType.TEXT_PLAIN_VALUE);
+
+        MockMvcResponse response = o.when().get(url);
+        Headers allHeaders = response.getHeaders();
+
+        logger.debug("HTTP GET " + url);
+        logger.debug("Response headers:");
+
+        allHeaders.forEach(header -> logger.debug("\t" + header.getName() + " = " + header.getValue()));
+
+        if (response.getStatusCode() == OK || response.getStatusCode() == PARTIAL_CONTENT)
+        {
+            logger.debug("Received headers successfully.");
+            return allHeaders;
+        }
+        else
+        {
+            logger.warn("[getArtifactAsByteArray] response " + response.getStatusCode());
+            return null;
+        }
+    }
+
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
@@ -346,4 +346,13 @@ public class GroupRepositoryProvider extends AbstractRepositoryProvider
         return artifactEntryService.countCoordinates(storageRepositoryPairSet, searchRequest.getCoordinates(),
                                                      searchRequest.isStrict());
     }
+    
+    @Override
+    public RepositoryPath getPath(String storageId,
+                                  String repositoryId,
+                                  String artifactPath)
+           throws IOException
+    {
+        throw new UnsupportedOperationException("Currently getPath() is not supported for GroupRepositoryProvider");
+    }
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
@@ -60,21 +60,15 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
                                                 String repositoryId,
                                                 String path)
             throws IOException
-    {
-        Repository repository = getConfiguration().getStorage(storageId).getRepository(repositoryId);
-
-        final LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository.getLayout());
-        final RepositoryPath artifactPath = layoutProvider.resolve(repository).resolve(path);
-
-        logger.debug(" -> Checking local cache for {} ...", artifactPath);
-        if (layoutProvider.containsPath(repository, path))
+    {        
+        RepositoryPath artifactPath = getPath(storageId, repositoryId, path);
+              
+        if (artifactPath != null)
         {
-            logger.debug("The artifact {} was found in the local cache", artifactPath);
             ArtifactInputStream ais = (ArtifactInputStream) Files.newInputStream(artifactPath);
             return decorate(storageId, repositoryId, path, ais);
         }
 
-        logger.debug("The artifact {} was not found in the local cache", artifactPath);
         return null;
     }
 
@@ -140,5 +134,27 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
         return artifactEntryService.countArtifacts(searchRequest.getStorageId(), searchRequest.getRepositoryId(),
                                                    searchRequest.getCoordinates(), searchRequest.isStrict());
     }
+    
+    @Override
+    public RepositoryPath getPath(String storageId,
+                                  String repositoryId,
+                                  String path) 
+           throws IOException
+    {
+        Repository repository = getConfiguration().getStorage(storageId).getRepository(repositoryId);
 
+        final LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository.getLayout());
+        final RepositoryPath artifactPath = layoutProvider.resolve(repository).resolve(path);
+
+        logger.debug(" -> Checking local cache for {} ...", artifactPath);
+        if (layoutProvider.containsPath(repository, path))
+        {
+            logger.debug("The artifact {} was found in the local cache", artifactPath);
+            return artifactPath;
+        }
+
+        logger.debug("The artifact {} was not found in the local cache", artifactPath);
+        
+        return null;
+    }
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
@@ -129,4 +129,13 @@ public class ProxyRepositoryProvider
 
         return artifactEntry;
     }
+    
+    @Override
+    public RepositoryPath getPath(String storageId,
+                                  String repositoryId,
+                                  String artifactPath)
+            throws IOException
+    {
+        throw new UnsupportedOperationException("Currently getPath() is not supported for ProxyRepositoryProvider");
+    }
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
@@ -379,6 +379,14 @@ public class ArtifactManagementService implements ConfigurationService
         return null;
     }
     
+    public RepositoryPath getPath(String storageId,
+                                  String repositoryId,
+                                  String path) 
+             throws IOException
+    {
+        return artifactResolutionService.getPath(storageId, repositoryId, path);
+    }
+    
     public void delete(String storageId,
                        String repositoryId,
                        String artifactPath,

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactResolutionService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactResolutionService.java
@@ -12,6 +12,7 @@ import org.carlspring.strongbox.io.ArtifactOutputStream;
 import org.carlspring.strongbox.io.RepositoryInputStream;
 import org.carlspring.strongbox.io.RepositoryOutputStream;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
 
 /**
  * @author mtodorov
@@ -39,5 +40,9 @@ public interface ArtifactResolutionService
                                 ArtifactCoordinates artifactCoordinates)
             throws MalformedURLException, 
                    IOException;
-
+    
+    RepositoryPath getPath(String storageId, 
+                           String repositoryId, 
+                           String path) 
+            throws IOException;
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ArtifactResolutionServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ArtifactResolutionServiceImpl.java
@@ -14,6 +14,7 @@ import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.io.RepositoryInputStream;
 import org.carlspring.strongbox.io.RepositoryOutputStream;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.layout.LayoutProvider;
 import org.carlspring.strongbox.providers.layout.LayoutProviderRegistry;
 import org.carlspring.strongbox.providers.repository.RepositoryProvider;
@@ -118,6 +119,21 @@ public class ArtifactResolutionServiceImpl
                                    .toUri()
                                    .resolve(artifactResource)
                                    .toURL();
+    }
+    
+    @Override
+    public RepositoryPath getPath(String storageId,
+                                  String repositoryId,
+                                  String artifactPath) 
+           throws IOException
+    {        
+        final Repository repository = getStorage(storageId).getRepository(repositoryId);
+
+        RepositoryProvider repositoryProvider = repositoryProviderRegistry.getProvider(repository.getType());
+
+        RepositoryPath resolvedPath = (RepositoryPath)repositoryProvider.getPath(storageId, repositoryId, artifactPath);
+
+        return resolvedPath;
     }
     
 }

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/repository/RepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/repository/RepositoryProvider.java
@@ -34,5 +34,10 @@ public interface RepositoryProvider
     List<Path> search(RepositorySearchRequest searchRequest, RepositoryPageRequest pageRequest);
     
     Long count(RepositorySearchRequest searchRequest);
+    
+    Path getPath(String storageId,
+                 String repositoryId,
+                 String artifactPath) 
+            throws IOException;
 
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/maven/MavenArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/maven/MavenArtifactController.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -26,6 +27,10 @@ import org.carlspring.maven.commons.util.ArtifactUtils;
 import org.carlspring.strongbox.client.ArtifactTransportException;
 import org.carlspring.strongbox.controllers.BaseArtifactController;
 import org.carlspring.strongbox.event.artifact.ArtifactEventListenerRegistry;
+import org.carlspring.strongbox.io.ArtifactInputStream;
+import org.carlspring.strongbox.io.RepositoryInputStream;
+import org.carlspring.strongbox.providers.io.RepositoryFileAttributes;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.services.ArtifactManagementService;
 import org.carlspring.strongbox.storage.ArtifactResolutionException;
 import org.carlspring.strongbox.storage.ArtifactStorageException;
@@ -112,9 +117,11 @@ public class MavenArtifactController
 
     @ApiOperation(value = "Used to retrieve an artifact", position = 1)
     @ApiResponses(value = { @ApiResponse(code = 200, message = ""),
-                            @ApiResponse(code = 400, message = "An error occurred.") })
+                            @ApiResponse(code = 404, message = "Requested path not found."),
+                            @ApiResponse(code = 500, message = "Server Error."),
+                            @ApiResponse(code = 503, message = "Repository not in service currently.")})
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
-    @RequestMapping(value = { "{storageId}/{repositoryId}/{path:.+}" }, method = RequestMethod.GET)
+    @RequestMapping(value = { "{storageId}/{repositoryId}/{path:.+}" }, method = {RequestMethod.GET, RequestMethod.HEAD})
     public void download(@ApiParam(value = "The storageId", required = true)
                          @PathVariable String storageId,
                          @ApiParam(value = "The repositoryId", required = true)
@@ -155,62 +162,107 @@ public class MavenArtifactController
 
             return;
         }
-
-        if (repository.allowsDirectoryBrowsing() && probeForDirectoryListing(repository, path))
+        
+        boolean isHeadRequest = request.getMethod().equals("HEAD");
+        
+        if(!isHeadRequest)
         {
-            try
+            if (repository.allowsDirectoryBrowsing() && probeForDirectoryListing(repository, path))
             {
-                getDirectoryListing(repository, path, request, response);
-            }
-            catch (Exception e)
-            {
-                logger.debug("Unable to generate directory listing for " +
-                             "/" + storageId + "/" + repositoryId + "/" + path, e);
+                try
+                {
+                    getDirectoryListing(repository, path, request, response);
+                }
+                catch (Exception e)
+                {
+                    logger.debug("Unable to generate directory listing for " +
+                            "/" + storageId + "/" + repositoryId + "/" + path, e);
 
-                response.setStatus(INTERNAL_SERVER_ERROR.value());
-            }
+                    response.setStatus(INTERNAL_SERVER_ERROR.value());
+                }
 
-            return;
-        }
-
-        InputStream is;
-        try
-        {
-            is = getArtifactManagementService().resolve(storageId, repositoryId, path);
-            if (is == null)
-            {
-                response.setStatus(NOT_FOUND.value());
                 return;
             }
 
-            if (isRangedRequest(httpHeaders))
+
+            InputStream is;
+            try
             {
-                logger.debug("Detecting range request....");
+                is = getArtifactManagementService().resolve(storageId, repositoryId, path);
+                if (is == null)
+                {
+                    response.setStatus(NOT_FOUND.value());
+                    return;
+                }
 
-                handlePartialDownload(is, httpHeaders, response);
+                if(!isHeadRequest)
+                {
+                    if (isRangedRequest(httpHeaders))
+                    {
+                        logger.debug("Detecting range request....");
+
+                        handlePartialDownload(is, httpHeaders, response);
+                    }
+
+                    artifactEventListenerRegistry.dispatchArtifactDownloadingEvent(storage.getId(), repository.getId(), path);
+
+                    copyToResponse(is, response);
+
+                    artifactEventListenerRegistry.dispatchArtifactDownloadedEvent(storage.getId(), repository.getId(), path);
+                }
             }
+            catch (ArtifactResolutionException | ArtifactTransportException e)
+            {
+                logger.debug("Unable to find artifact by path " + path, e);
 
-            artifactEventListenerRegistry.dispatchArtifactDownloadingEvent(storage.getId(), repository.getId(), path);
+                response.setStatus(NOT_FOUND.value());
 
-            copyToResponse(is, response);
-
-            artifactEventListenerRegistry.dispatchArtifactDownloadedEvent(storage.getId(), repository.getId(), path);
+                return;
+            }
+            ArtifactControllerHelper.setHeadersForChecksums(is, response);
         }
-        catch (ArtifactResolutionException | ArtifactTransportException e)
+        else
         {
-            logger.debug("Unable to find artifact by path " + path, e);
+            RepositoryPath resolvedPath = getArtifactManagementService().getPath(storageId, repositoryId, path);
+            
+            logger.debug("Resolved path : " + resolvedPath);
+            
+            if(resolvedPath == null)
+            {
+                response.setStatus(HttpStatus.NOT_FOUND.value());
+                return;
+            }
+            
+            try 
+            {
+                try (ArtifactInputStream ais = (ArtifactInputStream) Files.newInputStream(resolvedPath))
+                {
+                    try (RepositoryInputStream is =  RepositoryInputStream.of(repository, path, ais))
+                    {
+                        ArtifactControllerHelper.setHeadersForChecksums(is, response);
+                    }
+                }
+                RepositoryFileAttributes fileAttributes = Files.readAttributes(resolvedPath, RepositoryFileAttributes.class);
+                
+                response.setHeader("Content-Length", String.valueOf(fileAttributes.size()));
+                response.setHeader("Last-Modified", fileAttributes.lastModifiedTime().toString());
+                
+            }
+            catch(Exception e)
+            {
+                logger.error(String.format("Failed to process Maven head request: /%s/%s/%s",
+                                           storageId,
+                                           repositoryId,
+                                           path),
+                             e);
 
-            response.setStatus(NOT_FOUND.value());
-
-            return;
+                response.setStatus(INTERNAL_SERVER_ERROR.value());
+            }
         }
+            setMediaTypeHeader(path, response);
 
-        setMediaTypeHeader(path, response);
-
-        response.setHeader("Accept-Ranges", "bytes");
-
-        ArtifactControllerHelper.setHeadersForChecksums(is, response);
-
+            response.setHeader("Accept-Ranges", "bytes");
+                
         logger.debug("Download succeeded.");
     }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/nuget/NugetPackageController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/nuget/NugetPackageController.java
@@ -38,7 +38,10 @@ import org.carlspring.strongbox.artifact.coordinates.PathNupkg;
 import org.carlspring.strongbox.controllers.BaseArtifactController;
 import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.domain.ArtifactTagEntry;
+import org.carlspring.strongbox.io.ArtifactInputStream;
 import org.carlspring.strongbox.io.ReplacingInputStream;
+import org.carlspring.strongbox.io.RepositoryInputStream;
+import org.carlspring.strongbox.providers.io.RepositoryFileAttributes;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.services.ArtifactManagementService;
 import org.carlspring.strongbox.services.ArtifactTagService;
@@ -421,45 +424,73 @@ public class NugetPackageController extends BaseArtifactController
     }
 
     @ApiOperation(value = "Used to download a package")
-    @ApiResponses(value = { @ApiResponse(code = HttpURLConnection.HTTP_OK, message = "The package was downloaded successfully."),
-                            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "An error occurred.") })
+    @ApiResponses(value = { @ApiResponse(code = HttpURLConnection.HTTP_OK, message = "The request was successfull."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Server error occurred."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "The requested path was not found."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_UNAVAILABLE, message = "Repository not in service currently.")})
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
-    @RequestMapping(path = "{storageId}/{repositoryId}/{commandName:(?:download|package)}/{packageId}/{packageVersion}", method = RequestMethod.GET, produces = MediaType.APPLICATION_OCTET_STREAM)
+    @RequestMapping(path = "{storageId}/{repositoryId}/{commandName:(?:download|package)}/{packageId}/{packageVersion}", method = {RequestMethod.GET, RequestMethod.HEAD},
+                    produces = MediaType.APPLICATION_OCTET_STREAM)
     public void downloadPackage(@ApiParam(value = "The storageId", required = true) @PathVariable(name = "storageId") String storageId,
                                 @ApiParam(value = "The repositoryId", required = true) @PathVariable(name = "repositoryId") String repositoryId,
                                 @ApiParam(value = "The packageId", required = true) @PathVariable(name = "packageId") String packageId,
                                 @ApiParam(value = "The packageVersion", required = true) @PathVariable(name = "packageVersion") String packageVersion,
-                                HttpServletResponse response)
+                                HttpServletResponse response,
+                                HttpServletRequest request)
             throws IOException
     {
-        getPackageInternal(storageId, repositoryId, packageId, packageVersion, response);
+        getPackageInternal(storageId, repositoryId, packageId, packageVersion, response, request);
     }
 
     @ApiOperation(value = "Used to download a package")
-    @ApiResponses(value = { @ApiResponse(code = HttpURLConnection.HTTP_OK, message = "The package was downloaded successfully."),
-                            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "An error occurred.") })
+    @ApiResponses(value = { @ApiResponse(code = HttpURLConnection.HTTP_OK, message = "The request was successfull."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_INTERNAL_ERROR, message = "Server error occurred."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_NOT_FOUND, message = "The requested path was not found."),
+                            @ApiResponse(code = HttpURLConnection.HTTP_UNAVAILABLE, message = "Repository not in service currently.")})
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
-    @RequestMapping(path = "{storageId}/{repositoryId}/{packageId}/{packageVersion}", method = RequestMethod.GET, produces = MediaType.APPLICATION_OCTET_STREAM)
+    @RequestMapping(path = "{storageId}/{repositoryId}/{packageId}/{packageVersion}", method = {RequestMethod.GET, RequestMethod.HEAD},
+                    produces = MediaType.APPLICATION_OCTET_STREAM)
     public void getPackage(@ApiParam(value = "The storageId", required = true) @PathVariable(name = "storageId") String storageId,
                            @ApiParam(value = "The repositoryId", required = true) @PathVariable(name = "repositoryId") String repositoryId,
                            @ApiParam(value = "The packageId", required = true) @PathVariable(name = "packageId") String packageId,
                            @ApiParam(value = "The packageVersion", required = true) @PathVariable(name = "packageVersion") String packageVersion,
-                           HttpServletResponse response)
+                           HttpServletResponse response,
+                           HttpServletRequest request)
             throws IOException
     {
-        getPackageInternal(storageId, repositoryId, packageId, packageVersion, response);
+        getPackageInternal(storageId, repositoryId, packageId, packageVersion, response, request);
     }    
     
     private void getPackageInternal(String storageId,
                                     String repositoryId,
                                     String packageId,
                                     String packageVersion,
-                                    HttpServletResponse response)
+                                    HttpServletResponse response,
+                                    HttpServletRequest request)
         throws IOException
     {
+        logger.debug("Requested Nuget Package %s, %s, %s, %s.", storageId, repositoryId, packageId, packageVersion);
+        
         Storage storage = configurationManager.getConfiguration().getStorage(storageId);
-        Repository repository = storage.getRepository(repositoryId);
+        if (storage == null)
+        {
+            logger.error("Unable to find storage by ID " + storageId);
 
+            response.sendError(INTERNAL_SERVER_ERROR.value(), "Unable to find storage by ID " + storageId);
+
+            return;
+        }
+
+        Repository repository = storage.getRepository(repositoryId);
+        if (repository == null)
+        {
+            logger.error("Unable to find repository by ID " + repositoryId + " for storage " + storageId);
+
+            response.sendError(INTERNAL_SERVER_ERROR.value(),
+                               "Unable to find repository by ID " + repositoryId + " for storage " + storageId);
+            return;
+        }
+        
         if (!repository.isInService())
         {
             logger.error("Repository is not in service...");
@@ -472,34 +503,75 @@ public class NugetPackageController extends BaseArtifactController
         String fileName = String.format("%s.%s.nupkg", packageId, packageVersion);
         String path = String.format("%s/%s/%s", packageId, packageVersion, fileName);
 
-        try
+        boolean isHeadRequest = request.getMethod().equals("HEAD");
+        
+        if(!isHeadRequest)
         {
-            InputStream is = getArtifactManagementService().resolve(storageId,
-                                                                    repositoryId,
-                                                                    path);
-            if (is == null)
+            try
             {
-                logger.debug("Unable to find artifact by path " + path);
+                InputStream is = getArtifactManagementService().resolve(storageId,
+                                                                        repositoryId,
+                                                                        path);
+                if (is == null)
+                {
+                    logger.debug("Unable to find artifact by path " + path);
 
-                response.setStatus(NOT_FOUND.value());
+                    response.setStatus(NOT_FOUND.value());
+                    return;
+                }
+
+                response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
+
+                copyToResponse(is, response);
+                ArtifactControllerHelper.setHeadersForChecksums(is, response);
+            }
+            catch (Exception e)
+            {
+                logger.error(String.format("Failed to process Nuget get request: %s:%s:%s:%s",
+                                           storageId,
+                                           repositoryId,
+                                           packageId,
+                                           packageVersion),
+                             e);
+
+                response.setStatus(INTERNAL_SERVER_ERROR.value());
+            }
+        }
+        else
+        {
+            RepositoryPath resolvedPath = getArtifactManagementService().getPath(storageId, repositoryId, path);
+            
+            if(resolvedPath == null)
+            {
+                response.setStatus(HttpStatus.NOT_FOUND.value());
                 return;
             }
-
-            response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
-            
-            copyToResponse(is, response);
-            ArtifactControllerHelper.setHeadersForChecksums(is, response);
-        }
-        catch (Exception e)
-        {
-            logger.error(String.format("Failed to process Nuget get request: %s:%s:%s:%s",
-                                       storageId,
-                                       repositoryId,
-                                       packageId,
-                                       packageVersion),
-                         e);
-
-            response.setStatus(INTERNAL_SERVER_ERROR.value());
+   
+            try
+            {
+                try (ArtifactInputStream ais = (ArtifactInputStream) Files.newInputStream(resolvedPath))
+                {
+                    try (RepositoryInputStream is =  RepositoryInputStream.of(repository, path, ais))
+                    {
+                        ArtifactControllerHelper.setHeadersForChecksums(is, response);
+                    }
+                }
+                RepositoryFileAttributes fileAttributes = Files.readAttributes(resolvedPath, RepositoryFileAttributes.class);
+                response.setHeader("Content-Length", String.valueOf(fileAttributes.size()));
+                response.setHeader("Last-Modified", fileAttributes.lastModifiedTime().toString());
+                response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", fileName));
+            }
+            catch (Exception e)
+            {
+                logger.error(String.format("Failed to process Nuget head request: %s:%s:%s:%s",
+                                           storageId,
+                                           repositoryId,
+                                           packageId,
+                                           packageVersion),
+                             e);
+    
+                response.setStatus(INTERNAL_SERVER_ERROR.value());
+            }
         }
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/maven/MavenArtifactControllerTest.java
@@ -40,6 +40,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import com.google.common.base.Throwables;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
 import io.restassured.response.ExtractableResponse;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.metadata.Metadata;
@@ -398,6 +400,35 @@ public class MavenArtifactControllerTest
 
         assertEquals("MD5 checksums did not match!", md5Local, md5Remote);
         assertEquals("SHA-1 checksums did not match!", sha1Local, sha1Remote);
+    }
+
+
+    @Test
+    public void testHeadersFetch()
+            throws Exception
+    {   
+        String artifactPath;
+        Headers headersFromGET, headersFromHEAD;
+
+        /* Hosted Repository */
+        artifactPath = "storages/storage0/act-releases-1/org/carlspring/strongbox/browse/foo-bar/2.4/foo-bar-2.4.pom";
+        headersFromGET = client.getHeadersFromGET(artifactPath);
+        headersFromHEAD = client.getHeadersfromHEAD(artifactPath);
+        assertHeadersEquals(headersFromGET,headersFromHEAD);
+    }
+    
+    private void assertHeadersEquals(Headers h1, Headers h2)
+    {
+        assertNotNull(h1);
+        assertNotNull(h2);
+
+        for(Header header : h1)
+        {
+            if(h2.hasHeaderWithName(header.getName()))
+            {
+                assertEquals(header.getValue(),h2.getValue(header.getName()));
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
#372 
Added Header Support for Maven and Nuget Hosted Repositories.
More code can be removed from controller after implementing getPath() for group and proxy repository.
Currently keeping it simple for hosted repository support.
Also GET doesn't return Last-Modified as of now as implementing it will either cause unnecessary code or GET failures for proxy and group repositories. Will implement it after getPath() is implemented for both group and proxy repositories . 
Currently GET and HEAD request for HostedRepositoryProvider will return same headers except Last-Modified.