### PR TITLE
Refactor the port management code in ConfigurationManagementController

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseController.java
@@ -2,7 +2,9 @@ package org.carlspring.strongbox.controllers;
 
 import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
+import org.carlspring.strongbox.controllers.support.BaseUrlEntityBody;
 import org.carlspring.strongbox.controllers.support.ErrorResponseEntityBody;
+import org.carlspring.strongbox.controllers.support.PortEntityBody;
 import org.carlspring.strongbox.controllers.support.ResponseEntityBody;
 import org.carlspring.strongbox.resource.ResourceCloser;
 
@@ -14,12 +16,14 @@ import java.io.OutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 /**
  * Provides common subroutines that will be useful for any backend controllers.
  *
  * @author Alex Oreshkevich
+ * @author Pablo Tirado
  */
 public abstract class BaseController
 {
@@ -28,6 +32,18 @@ public abstract class BaseController
 
     @Inject
     protected ConfigurationManager configurationManager;
+
+    protected Object getResponseEntityBody(String message, String accept)
+    {
+        if (MediaType.APPLICATION_JSON_VALUE.equals(accept))
+        {
+            return new ResponseEntityBody(message);
+        }
+        else
+        {
+            return message;
+        }
+    }
 
     protected ResponseEntityBody getResponseEntityBody(String message)
     {
@@ -39,6 +55,30 @@ public abstract class BaseController
     {
         return ResponseEntity.status(httpStatus)
                              .body(getResponseEntityBody(message));
+    }
+
+    protected Object getPortEntityBody(int port, String accept)
+    {
+        if (MediaType.APPLICATION_JSON_VALUE.equals(accept))
+        {
+            return new PortEntityBody(port);
+        }
+        else
+        {
+            return String.valueOf(port);
+        }
+    }
+
+    protected Object getBaseUrlEntityBody(String baseUrl, String accept)
+    {
+        if (MediaType.APPLICATION_JSON_VALUE.equals(accept))
+        {
+            return new BaseUrlEntityBody(baseUrl);
+        }
+        else
+        {
+            return baseUrl;
+        }
     }
 
     protected ResponseEntity toResponseEntityError(String message,

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/BaseUrlEntityBody.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/BaseUrlEntityBody.java
@@ -1,0 +1,32 @@
+package org.carlspring.strongbox.controllers.support;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Pablo Tirado
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BaseUrlEntityBody
+{
+
+    @JsonProperty("baseUrl")
+    private String baseUrl;
+
+    @JsonCreator
+    public BaseUrlEntityBody(@JsonProperty("baseUrl") String baseUrl)
+    {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getBaseUrl()
+    {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl)
+    {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/PortEntityBody.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/support/PortEntityBody.java
@@ -1,0 +1,32 @@
+package org.carlspring.strongbox.controllers.support;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Pablo Tirado
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PortEntityBody
+{
+
+    @JsonProperty("port")
+    private int port;
+
+    @JsonCreator
+    public PortEntityBody(@JsonProperty("port") int port)
+    {
+        this.port = port;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public void setPort(int port)
+    {
+        this.port = port;
+    }
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
@@ -19,13 +19,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import io.restassured.http.ContentType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpServerErrorException;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
@@ -3,6 +3,8 @@ package org.carlspring.strongbox.controllers;
 import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ProxyConfiguration;
 import org.carlspring.strongbox.controllers.context.IntegrationTest;
+import org.carlspring.strongbox.controllers.support.BaseUrlEntityBody;
+import org.carlspring.strongbox.controllers.support.PortEntityBody;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
@@ -17,11 +19,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import io.restassured.http.ContentType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpServerErrorException;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static junit.framework.TestCase.assertFalse;
@@ -34,7 +39,7 @@ import static org.junit.Assert.assertTrue;
  * @author Alex Oreshkevich
  */
 @IntegrationTest
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 public class ConfigurationManagementControllerTest
         extends RestAssuredBaseTest
 {
@@ -47,51 +52,77 @@ public class ConfigurationManagementControllerTest
 
         String url = getContextBaseUrl() + "/configuration/strongbox/port/" + newPort;
 
-        int status = given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                            .when()
-                            .put(url)
-                            .then()
-                            .statusCode(200) // check http status code
-                            .extract()
-                            .statusCode();
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .put(url)
+               .then()
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body("message", equalTo("The port was updated."));
 
         url = getContextBaseUrl() + "/configuration/strongbox/port";
 
-        String port = given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                             .when()
-                             .get(url)
-                             .then()
-                             .statusCode(200) // check http status code
-                             .extract().asString();
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url)
+               .then()
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body("port", equalTo(newPort));
+    }
 
-        assertEquals("Failed to set port!", 200, status);
-        assertEquals("Failed to get port!", newPort, Integer.parseInt(port));
+    @Test
+    public void testSetAndGetPortWithBody()
+            throws Exception
+    {
+        int newPort = 18080;
+        PortEntityBody portEntity = new PortEntityBody(newPort);
+
+        String url = getContextBaseUrl() + "/configuration/strongbox/port";
+
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+               .contentType(MediaType.APPLICATION_JSON_VALUE)
+               .body(portEntity)
+               .when()
+               .put(url)
+               .then()
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body("message", equalTo("The port was updated."));
+
+        url = getContextBaseUrl() + "/configuration/strongbox/port";
+
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url)
+               .then()
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body("port", equalTo(newPort));
     }
 
     @Test
     public void testSetAndGetBaseUrl()
             throws Exception
     {
-        String baseUrl = "http://localhost:" + 40080 + "/newurl";
+        String newBaseUrl = "http://localhost:" + 40080 + "/newurl";
+        BaseUrlEntityBody baseUrlEntity = new BaseUrlEntityBody(newBaseUrl);
 
         String url = getContextBaseUrl() + "/configuration/strongbox/baseUrl";
 
-        given().contentType(MediaType.TEXT_PLAIN_VALUE)
-               .body(baseUrl)
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+               .contentType(MediaType.APPLICATION_JSON_VALUE)
+               .body(baseUrlEntity)
                .when()
                .put(url)
                .then()
-               .statusCode(200)
-               .extract();
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body("message", equalTo("The base URL was updated."));
 
         url = getContextBaseUrl() + "/configuration/strongbox/baseUrl";
 
-        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+        given().header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                .when()
                .get(url)
                .then()
-               .statusCode(200)
-               .body("baseUrl", equalTo(baseUrl));
+               .statusCode(HttpStatus.OK.value())
+               .body("baseUrl", equalTo(newBaseUrl));
     }
 
     @Test

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ConfigurationManagementControllerTest.java
@@ -1,8 +1,8 @@
 package org.carlspring.strongbox.controllers;
 
+import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ProxyConfiguration;
-import org.carlspring.strongbox.controllers.context.IntegrationTest;
 import org.carlspring.strongbox.controllers.support.BaseUrlEntityBody;
 import org.carlspring.strongbox.controllers.support.PortEntityBody;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;


### PR DESCRIPTION
Related issue: #490 

Added `setPort` method, that allows to update a port passing it as a JSON in the request body.
Added entity `PortEntityBody` that represents a wrapper for the port argument.
Added `ResponseStatusEnum`, an enum that lists the plain text body messages (OK, FAILED).
All methods from `ConfigurationManagementController` have been reviewed to return the proper message according to its status code.

I also implemented the proper test cases.