### PR TITLE
Convert the org.carlspring.strongbox.storage.repository.Repository class to use RepositoryPath objects instead of File-s [In progress]

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutProviderRegistry.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutProviderRegistry.java
@@ -11,9 +11,11 @@ import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -49,12 +51,14 @@ public class LayoutProviderRegistry extends AbstractMappedProviderRegistry<Layou
                 {
                     logger.debug("Emptying trash for repository " + repository.getId() + "...");
 
-                    final File basedirTrash = repository.getTrashDir();
+                    final Path basedirTrash = repository.getTrashDir();
 
-                    FileUtils.deleteDirectory(basedirTrash);
+                    Files.walk(basedirTrash)
+                         .map(Path::toFile)
+                         .sorted(Comparator.comparing(File::isDirectory))
+                         .forEach(File::delete);
 
-                    //noinspection ResultOfMethodCallIgnored
-                    basedirTrash.mkdirs();
+                    Files.createDirectories(basedirTrash);
                 }
                 else
                 {

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/repository/Repository.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/repository/Repository.java
@@ -6,8 +6,9 @@ import org.carlspring.strongbox.storage.repository.remote.RemoteRepository;
 import org.carlspring.strongbox.xml.repository.CustomRepositoryConfiguration;
 
 import javax.xml.bind.annotation.*;
-import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 
 /**
@@ -328,14 +329,14 @@ public class Repository
         return id;
     }
 
-    public File getTrashDir()
+    public Path getTrashDir()
     {
-        return new File(getBasedir(), ".trash");
+        return Paths.get(getBasedir(), ".trash");
     }
 
-    public File getTempDir()
+    public Path getTempDir()
     {
-        return new File(getBasedir(), ".temp");
+        return Paths.get(getBasedir(), ".temp");
     }
 
     public HttpConnectionPool getHttpConnectionPool()

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/downloader/IndexDownloadRequest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/downloader/IndexDownloadRequest.java
@@ -2,7 +2,7 @@ package org.carlspring.strongbox.storage.indexing.downloader;
 
 import org.carlspring.strongbox.storage.repository.Repository;
 
-import java.io.File;
+import java.nio.file.Path;
 
 import org.apache.maven.index.Indexer;
 
@@ -49,7 +49,7 @@ public class IndexDownloadRequest
         return repository.getRemoteRepository().getUrl();
     }
 
-    public File getRepositoryTempDir()
+    public Path getRepositoryTempDir()
     {
         return repository.getTempDir();
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/downloader/IndexDownloader.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/downloader/IndexDownloader.java
@@ -61,7 +61,7 @@ public class IndexDownloader
                                                                   resourceFetcherFactory.createIndexResourceFetcher(
                                                                           request.getRemoteRepositoryURL(),
                                                                           proxyRepositoryConnectionPoolConfigurationService.getHttpClient()));
-        updateRequest.setIndexTempDir(request.getRepositoryTempDir());
+        updateRequest.setIndexTempDir(request.getRepositoryTempDir().toFile());
 
         IndexUpdateResult updateResult = indexUpdater.fetchAndUpdateIndex(updateRequest);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -14,8 +14,11 @@ import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.google.common.base.Throwables;
 import org.junit.Before;
@@ -27,16 +30,17 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 public class ClearTrashCronJobFromMaven2RepositoryTestIT
         extends BaseCronJobWithMavenIndexingTestCase
 {
@@ -163,10 +167,10 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
     public void testRemoveTrashInRepository()
             throws Exception
     {
-        File[] dirs = getDirs();
+        Stream<Path> dirs = getDirs();
 
         assertTrue("There is no path to the repository trash!", dirs != null);
-        assertEquals("The repository trash isn't empty!", 0, dirs.length);
+        assertEquals("The repository trash isn't empty!", 0, dirs.count());
 
         LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository1.getLayout());
         String path = "org/carlspring/strongbox/clear/strongbox-test-one/1.0";
@@ -175,7 +179,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
         dirs = getDirs();
 
         assertTrue("There is no path to the repository trash!", dirs != null);
-        assertEquals("The repository trash is empty!", 1, dirs.length);
+        assertEquals("The repository trash is empty!", 1, dirs.count());
 
         final String jobName = expectedJobName;
         jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
@@ -183,10 +187,18 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
             if (jobName1.equals(jobName) && statusExecuted)
             {
 
-                File[] dirs1 = getDirs();
+                Stream<Path> dirs1;
+                try
+                {
+                    dirs1 = getDirs();
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
 
                 assertTrue("There is no path to the repository trash!", dirs1 != null);
-                assertEquals("The repository trash isn't empty!", 0, dirs1.length);
+                assertEquals("The repository trash isn't empty!", 0, dirs1.count());
 
                 removeRepositories();
             }
@@ -197,55 +209,64 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
         assertTrue("Failed to execute task!", expectEvent());
     }
 
-    private File[] getDirs()
+    private Stream<Path> getDirs()
+            throws IOException
     {
-        return repository1.getTrashDir()
-                          .listFiles();
+        return Files.list(repository1.getTrashDir());
     }
 
     @Test
     public void testRemoveTrashAllRepositories()
             throws Exception
     {
-        final File basedirTrash1 = repository2.getTrashDir();
-        File[] dirs1 = basedirTrash1.listFiles();
+        final Path basedirTrash1 = repository2.getTrashDir();
+        Stream<Path> dirs1 = Files.list(basedirTrash1);
 
         assertTrue("There is no path to the repository trash!", dirs1 != null);
-        assertEquals("The repository trash isn't empty!", 0, dirs1.length);
+        assertEquals("The repository trash isn't empty!", 0, dirs1.count());
 
         LayoutProvider layoutProvider1 = layoutProviderRegistry.getProvider(repository2.getLayout());
         String path1 = "org/carlspring/strongbox/clear/strongbox-test-two/1.0";
         layoutProvider1.delete(STORAGE0, REPOSITORY_RELEASES_2, path1, false);
 
-        final File basedirTrash2 = repository3.getTrashDir();
-        File[] dirs2 = basedirTrash2.listFiles();
+        final Path basedirTrash2 = repository3.getTrashDir();
+        Stream<Path> dirs2 = Files.list(basedirTrash2);
 
         assertTrue("There is no path to the repository trash!", dirs2 != null);
-        assertEquals("The repository trash isn't empty!", 0, dirs2.length);
+        assertEquals("The repository trash isn't empty!", 0, dirs2.count());
 
         LayoutProvider layoutProvider2 = layoutProviderRegistry.getProvider(repository3.getLayout());
         String path2 = "org/carlspring/strongbox/clear/strongbox-test-one/1.0";
         layoutProvider2.delete(STORAGE1, REPOSITORY_RELEASES_1, path2, false);
 
-        dirs1 = basedirTrash1.listFiles();
-        dirs2 = basedirTrash1.listFiles();
+        dirs1 = Files.list(basedirTrash1);
+        dirs2 = Files.list(basedirTrash2);
 
         assertTrue("There is no path to the repository trash!", dirs1 != null);
-        assertEquals("The repository trash is empty!", 1, dirs1.length);
+        assertEquals("The repository trash is empty!", 1, dirs1.count());
         assertTrue("There is no path to the repository trash!", dirs2 != null);
-        assertEquals("The repository trash is empty!", 1, dirs2.length);
+        assertEquals("The repository trash is empty!", 1, dirs2.count());
 
         // Checking if job was executed
         String jobName = expectedJobName;
         jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
         {
-            File[] dirs11 = basedirTrash1.listFiles();
-            File[] dirs22 = basedirTrash2.listFiles();
+            Stream<Path> dirs11;
+            Stream<Path> dirs22;
+            try
+            {
+                dirs11 = Files.list(basedirTrash1);
+                dirs22 = Files.list(basedirTrash2);
+            }
+            catch (IOException e)
+            {
+                throw new RuntimeException(e);
+            }
 
             assertTrue("There is no path to the repository trash!", dirs11 != null);
-            assertEquals("The repository trash isn't empty!", 0, dirs11.length);
+            assertEquals("The repository trash isn't empty!", 0, dirs11.count());
             assertTrue("There is no path to the repository trash!", dirs22 != null);
-            assertEquals("The repository trash isn't empty!", 0, dirs22.length);
+            assertEquals("The repository trash isn't empty!", 0, dirs22.count());
 
             removeRepositories();
         });


### PR DESCRIPTION
Related issue: #578 

Refactoring in `org.carlspring.strongbox.storage.repository.Repository `class (and its usages)  to use `java.nio` objects instead of `java.io` ones.