### PR TITLE
Upgrade org.apache.commons:commons-compress to version 1.16.1

### DIFF
--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -467,7 +467,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.15</version>
+                <version>1.16.1</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>


### PR DESCRIPTION
Related issue: #654 

Updated `pom.xml` from `strongbox-parent`.

The modules `strongbox-web-core` and `strongbox-storage-npm-layout-provider` are using this dependency too.