### PR TITLE
Create a new endpoint in ServerConfigurationController which will handle a form for submitting both baseUrl and port

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/ServerConfigurationController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/ServerConfigurationController.java
@@ -175,7 +175,7 @@ public class ServerConfigurationController
         configurationManagementService.setBaseUrl(serverSettingsForm.getBaseUrl());
         configurationManagementService.setPort(serverSettingsForm.getPort());
 
-        return ResponseEntity.ok(getResponseEntityBody(SUCCESSFUL_SAVE_SERVER_SETTINGS, acceptHeader));
+        return getSuccessfulResponseEntity(SUCCESSFUL_SAVE_SERVER_SETTINGS, acceptHeader);
     }
 
     private Object getBaseUrlEntityBody(String baseUrl,

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/forms/configuration/ServerSettingsForm.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/forms/configuration/ServerSettingsForm.java
@@ -1,0 +1,51 @@
+package org.carlspring.strongbox.forms.configuration;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+
+/**
+ * @author Pablo Tirado
+ */
+public class ServerSettingsForm
+{
+
+    @NotBlank(message = "A base URL must be specified.")
+    private String baseUrl;
+
+    @Min(value = 1, message = "Port number must be an integer between 1 and 65535.")
+    @Max(value = 65535, message = "Port number must be an integer between 1 and 65535.")
+    private int port;
+
+    public ServerSettingsForm()
+    {
+    }
+
+    public ServerSettingsForm(@NotBlank(message = "A base URL must be specified.") String baseUrl,
+                              @Min(value = 1, message = "Port number must be an integer between 1 and 65535.")
+                              @Max(value = 65535, message = "Port number must be an integer between 1 and 65535.") int port)
+    {
+        this.baseUrl = baseUrl;
+        this.port = port;
+    }
+
+    public String getBaseUrl()
+    {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl)
+    {
+        this.baseUrl = baseUrl;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public void setPort(int port)
+    {
+        this.port = port;
+    }
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ServerConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ServerConfigurationControllerTestIT.java
@@ -3,14 +3,19 @@ package org.carlspring.strongbox.controllers.configuration;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.controllers.support.BaseUrlEntityBody;
 import org.carlspring.strongbox.controllers.support.PortEntityBody;
+import org.carlspring.strongbox.forms.configuration.ServerSettingsForm;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.carlspring.strongbox.controllers.configuration.ServerConfigurationController.FAILED_SAVE_SERVER_SETTINGS;
+import static org.carlspring.strongbox.controllers.configuration.ServerConfigurationController.SUCCESSFUL_SAVE_SERVER_SETTINGS;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 /**
@@ -22,12 +27,23 @@ public class ServerConfigurationControllerTestIT
         extends RestAssuredBaseTest
 {
 
+    @Override
+    public void init()
+            throws Exception
+    {
+        super.init();
+
+        setContextBaseUrl(getContextBaseUrl() + "/api/configuration/strongbox");
+    }
+
     @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_PORT",
+                                  "CONFIGURATION_VIEW_PORT" })
     public void testSetAndGetPort()
     {
         int newPort = 18080;
 
-        String url = getContextBaseUrl() + "/api/configuration/strongbox/port/" + newPort;
+        String url = getContextBaseUrl() + "/port/" + newPort;
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .when()
@@ -36,7 +52,7 @@ public class ServerConfigurationControllerTestIT
                .statusCode(HttpStatus.OK.value()) // check http status code
                .body("message", equalTo("The port was updated."));
 
-        url = getContextBaseUrl() + "/api/configuration/strongbox/port";
+        url = getContextBaseUrl() + "/port";
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .when()
@@ -47,12 +63,14 @@ public class ServerConfigurationControllerTestIT
     }
 
     @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_PORT",
+                                  "CONFIGURATION_VIEW_PORT" })
     public void testSetAndGetPortWithBody()
     {
         int newPort = 18080;
         PortEntityBody portEntity = new PortEntityBody(newPort);
 
-        String url = getContextBaseUrl() + "/api/configuration/strongbox/port";
+        String url = getContextBaseUrl() + "/port";
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -63,7 +81,7 @@ public class ServerConfigurationControllerTestIT
                .statusCode(HttpStatus.OK.value()) // check http status code
                .body("message", equalTo("The port was updated."));
 
-        url = getContextBaseUrl() + "/api/configuration/strongbox/port";
+        url = getContextBaseUrl() + "/port";
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .when()
@@ -74,12 +92,14 @@ public class ServerConfigurationControllerTestIT
     }
 
     @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_BASE_URL",
+                                  "CONFIGURATION_VIEW_BASE_URL" })
     public void testSetAndGetBaseUrl()
     {
         String newBaseUrl = "http://localhost:" + 40080 + "/newurl";
         BaseUrlEntityBody baseUrlEntity = new BaseUrlEntityBody(newBaseUrl);
 
-        String url = getContextBaseUrl() + "/api/configuration/strongbox/baseUrl";
+        String url = getContextBaseUrl() + "/baseUrl";
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -90,7 +110,7 @@ public class ServerConfigurationControllerTestIT
                .statusCode(HttpStatus.OK.value()) // check http status code
                .body("message", equalTo("The base URL was updated."));
 
-        url = getContextBaseUrl() + "/api/configuration/strongbox/baseUrl";
+        url = getContextBaseUrl() + "/baseUrl";
 
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .when()
@@ -98,5 +118,85 @@ public class ServerConfigurationControllerTestIT
                .then()
                .statusCode(HttpStatus.OK.value())
                .body("baseUrl", equalTo(newBaseUrl));
+    }
+
+    public void serverSettingsShouldBeSaved(String acceptHeader,
+                                            String baseUrl,
+                                            int port)
+    {
+        // assign settings to server
+        ServerSettingsForm serverSettingsForm = new ServerSettingsForm(baseUrl, port);
+
+        String url = getContextBaseUrl() + "/serverSettings";
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(acceptHeader)
+               .body(serverSettingsForm)
+               .when()
+               .post(url)
+               .peek() // Use peek() to print the output
+               .then()
+               .statusCode(HttpStatus.OK.value()) // check http status code
+               .body(containsString(SUCCESSFUL_SAVE_SERVER_SETTINGS));
+    }
+
+    @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_BASE_URL",
+                                  "CONFIGURATION_SET_PORT" })
+    public void testServerSettingsShouldBeSavedWithResponseInJson()
+    {
+        String newBaseUrl = "http://localhost:" + 40080 + "/newurl";
+        int newPort = 18080;
+        serverSettingsShouldBeSaved(MediaType.APPLICATION_JSON_VALUE, newBaseUrl, newPort);
+    }
+
+    @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_BASE_URL",
+                                  "CONFIGURATION_SET_PORT" })
+    public void testServerSettingsShouldBeSavedWithResponseInText()
+    {
+        String newBaseUrl = "http://localhost:" + 40080 + "/newurl";
+        int newPort = 18080;
+        serverSettingsShouldBeSaved(MediaType.TEXT_PLAIN_VALUE, newBaseUrl, newPort);
+    }
+
+    public void serverSettingsShouldNotBeSaved(String acceptHeader,
+                                               String baseUrl,
+                                               int port)
+    {
+        // assign settings to server
+        ServerSettingsForm serverSettingsForm = new ServerSettingsForm(baseUrl, port);
+
+        String url = getContextBaseUrl() + "/serverSettings";
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(acceptHeader)
+               .body(serverSettingsForm)
+               .when()
+               .post(url)
+               .peek() // Use peek() to print the output
+               .then()
+               .statusCode(HttpStatus.BAD_REQUEST.value()) // check http status code
+               .body(containsString(FAILED_SAVE_SERVER_SETTINGS));
+    }
+
+    @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_BASE_URL",
+                                  "CONFIGURATION_SET_PORT" })
+    public void testWrongServerSettingsShouldNotBeSavedWithResponseInJson()
+    {
+        String newBaseUrl = "";
+        int newPort = 0;
+        serverSettingsShouldNotBeSaved(MediaType.APPLICATION_JSON_VALUE, newBaseUrl, newPort);
+    }
+
+    @Test
+    @WithMockUser(authorities = { "CONFIGURATION_SET_BASE_URL",
+                                  "CONFIGURATION_SET_PORT" })
+    public void testWrongServerSettingsShouldNotBeSavedWithResponseInText()
+    {
+        String newBaseUrl = null;
+        int newPort = 65536;
+        serverSettingsShouldNotBeSaved(MediaType.TEXT_PLAIN_VALUE, newBaseUrl, newPort);
     }
 }


### PR DESCRIPTION
Related issue: #661 

New method created:
Name:`setServerSettings(ServerSettingsForm, BindingResult, String)`
Endpoint: `/serverSettings`

The proper tests cases have been modified and new cases have been added.