### PR TITLE
Issue 641: Add prefix to keys from ConfigurationResourceResolver.getConfigurationResource method.

### DIFF
--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/test/java/org/carlspring/strongbox/authentication/api/impl/ldap/LdapAuthenticationProviderTest.java
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/test/java/org/carlspring/strongbox/authentication/api/impl/ldap/LdapAuthenticationProviderTest.java
@@ -98,7 +98,7 @@ public class LdapAuthenticationProviderTest
     protected Resource getAuthenticationConfigurationResource()
             throws IOException
     {
-        return ConfigurationResourceResolver.getConfigurationResource("authentication.providers.xml",
+        return ConfigurationResourceResolver.getConfigurationResource("strongbox.authentication.providers.xml",
                                                                       "etc/conf/strongbox-authentication-providers.xml");
     }
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/AuthenticatorsScanner.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/AuthenticatorsScanner.java
@@ -83,7 +83,7 @@ public class AuthenticatorsScanner
     private Resource getAuthenticationConfigurationResource()
             throws IOException
     {
-        return ConfigurationResourceResolver.getConfigurationResource("authentication.providers.xml",
+        return ConfigurationResourceResolver.getConfigurationResource("strongbox.authentication.providers.xml",
                                                                       "etc/conf/strongbox-authentication-providers.xml");
     }
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
@@ -40,7 +40,7 @@ public class ExternalAuthenticatorsHelper
         try
         {
             authenticatorsDirectory = Paths.get(
-                    ConfigurationResourceResolver.getConfigurationResource("authentication.lib",
+                    ConfigurationResourceResolver.getConfigurationResource("strongbox.authentication.lib",
                                                                            "webapp/WEB-INF/lib").getURI());
         }
         catch (FileNotFoundException e)

--- a/strongbox-security/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/managers/AuthenticationManager.java
+++ b/strongbox-security/strongbox-security-api/src/main/java/org/carlspring/strongbox/security/managers/AuthenticationManager.java
@@ -35,7 +35,7 @@ public class AuthenticationManager
     public void load()
             throws IOException, JAXBException
     {
-        Resource resource = ConfigurationResourceResolver.getConfigurationResource("security.authentication.xml",
+        Resource resource = ConfigurationResourceResolver.getConfigurationResource("strongbox.security.authentication.xml",
                                                                                    "etc/conf/security-authentication.xml");
 
         logger.info("Loading Strongbox configuration from " + resource.toString() + "...");
@@ -47,7 +47,7 @@ public class AuthenticationManager
     public void store()
             throws IOException, JAXBException
     {
-        Resource resource = ConfigurationResourceResolver.getConfigurationResource("security.authentication.xml",
+        Resource resource = ConfigurationResourceResolver.getConfigurationResource("strongbox.security.authentication.xml",
                                                                                    "etc/conf/security-authentication.xml");
 
         parser.store(configuration, resource);

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/config/UsersConfig.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/config/UsersConfig.java
@@ -196,7 +196,7 @@ public class UsersConfig
     private Resource getUsersConfigurationResource()
             throws IOException
     {
-        return ConfigurationResourceResolver.getConfigurationResource("users.config.xml",
+        return ConfigurationResourceResolver.getConfigurationResource("strongbox.users.config.xml",
                                                                       "etc/conf/strongbox-security-users.xml");
     }
 

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/security/AuthorizationConfigFileManager.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/security/AuthorizationConfigFileManager.java
@@ -2,8 +2,6 @@ package org.carlspring.strongbox.users.security;
 
 import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.xml.parsers.GenericParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
@@ -24,7 +22,7 @@ public class AuthorizationConfigFileManager
     private Resource getConfigurationResource()
             throws IOException
     {
-        return ConfigurationResourceResolver.getConfigurationResource("authorization.config.xml",
+        return ConfigurationResourceResolver.getConfigurationResource("strongbox.authorization.config.xml",
                                                                       "etc/conf/strongbox-authorization.xml");
     }
 

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -77,7 +77,7 @@
                     <systemPropertyVariables>
                         <strongbox.home>${project.build.directory}/strongbox</strongbox.home>
                         <strongbox.vault>${project.build.directory}/strongbox-vault</strongbox.vault>
-                        <authentication.providers.xml>${project.build.testOutputDirectory}/etc/conf/strongbox-authentication-providers.xml</authentication.providers.xml>
+                        <strongbox.authentication.providers.xml>${project.build.testOutputDirectory}/etc/conf/strongbox-authentication-providers.xml</strongbox.authentication.providers.xml>
                         <strongbox.storage.booter.basedir>${project.build.directory}/strongbox-vault/storages</strongbox.storage.booter.basedir>
                         <strongbox.config.xml>${project.build.directory}/strongbox/etc/conf/strongbox.xml</strongbox.config.xml>
                         <strongbox.host>${strongbox.host}</strongbox.host>
@@ -95,7 +95,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <authentication.providers.xml>${project.build.testOutputDirectory}/etc/conf/strongbox-authentication-providers.xml</authentication.providers.xml>
+                        <strongbox.authentication.providers.xml>${project.build.testOutputDirectory}/etc/conf/strongbox-authentication-providers.xml</strongbox.authentication.providers.xml>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Related issue: #641

All property keys from `ConfigurationResourceResolver.getConfigurationResource` have "strongbox." prefix now.