### PR TITLE
Issue 681: Refactor ProxyConfiguration to use Form Validation and make sure it follows the How-To-Write-Controllers guide

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -4,6 +4,7 @@ import org.carlspring.strongbox.configuration.StrongboxSecurityConfig;
 import org.carlspring.strongbox.converters.PrivilegeListFormToPrivilegeListConverter;
 import org.carlspring.strongbox.converters.RoleFormToRoleConverter;
 import org.carlspring.strongbox.converters.RoleListFormToRoleListConverter;
+import org.carlspring.strongbox.converters.configuration.ProxyConfigurationFormToProxyConfigurationConverter;
 import org.carlspring.strongbox.converters.users.AccessModelFormToAccessModelConverter;
 import org.carlspring.strongbox.converters.users.UserFormToUserConverter;
 import org.carlspring.strongbox.cron.config.CronTasksConfig;
@@ -187,6 +188,7 @@ public class WebConfig
         registry.addConverter(new PrivilegeListFormToPrivilegeListConverter());
         registry.addConverter(new UserFormToUserConverter());
         registry.addConverter(new AccessModelFormToAccessModelConverter());
+        registry.addConverter(new ProxyConfigurationFormToProxyConfigurationConverter());
     }
 
     @Bean

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/converters/configuration/ProxyConfigurationFormToProxyConfigurationConverter.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/converters/configuration/ProxyConfigurationFormToProxyConfigurationConverter.java
@@ -1,0 +1,28 @@
+package org.carlspring.strongbox.converters.configuration;
+
+import org.carlspring.strongbox.configuration.ProxyConfiguration;
+import org.carlspring.strongbox.forms.configuration.ProxyConfigurationForm;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * @author Pablo Tirado
+ */
+public class ProxyConfigurationFormToProxyConfigurationConverter
+        implements Converter<ProxyConfigurationForm, ProxyConfiguration>
+{
+
+    @Override
+    public ProxyConfiguration convert(ProxyConfigurationForm proxyConfigurationForm)
+    {
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setHost(proxyConfigurationForm.getHost());
+        proxyConfiguration.setPort(proxyConfigurationForm.getPort());
+        proxyConfiguration.setType(proxyConfigurationForm.getType());
+        proxyConfiguration.setUsername(proxyConfigurationForm.getUsername());
+        proxyConfiguration.setPassword(proxyConfigurationForm.getPassword());
+        proxyConfiguration.setNonProxyHosts(proxyConfigurationForm.getNonProxyHosts());
+
+        return proxyConfiguration;
+    }
+}

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/forms/configuration/ProxyConfigurationForm.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/forms/configuration/ProxyConfigurationForm.java
@@ -1,0 +1,95 @@
+package org.carlspring.strongbox.forms.configuration;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+/**
+ * @author Pablo Tirado
+ */
+public class ProxyConfigurationForm
+{
+
+    @NotBlank(message = "A host must be specified.")
+    private String host;
+
+    @Min(value = 1, message = "Port number must be an integer between 1 and 65535.")
+    @Max(value = 65535, message = "Port number must be an integer between 1 and 65535.")
+    private int port;
+
+    @NotBlank(message = "A proxy type must be specified.")
+    @Pattern(regexp = "DIRECT|HTTP|SOCKS4|SOCKS5",
+             flags = Pattern.Flag.CASE_INSENSITIVE,
+             message = "Proxy type must contain one the following strings as value: DIRECT, HTTP, SOCKS4, SOCKS5")
+    private String type;
+
+    private String username;
+
+    private String password;
+
+    private List<String> nonProxyHosts = Lists.newArrayList();
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public void setHost(String host)
+    {
+        this.host = host;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    public void setPort(int port)
+    {
+        this.port = port;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String type)
+    {
+        this.type = type;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername(String username)
+    {
+        this.username = username;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public void setPassword(String password)
+    {
+        this.password = password;
+    }
+
+    public List<String> getNonProxyHosts()
+    {
+        return nonProxyHosts;
+    }
+
+    public void setNonProxyHosts(List<String> nonProxyHosts)
+    {
+        this.nonProxyHosts = nonProxyHosts;
+    }
+}

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ProxyConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ProxyConfigurationControllerTestIT.java
@@ -4,15 +4,22 @@ import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.configuration.ProxyConfiguration;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import com.google.common.collect.Lists;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static junit.framework.TestCase.assertNotNull;
+import static org.carlspring.strongbox.controllers.configuration.ProxyConfigurationController.FAILED_UPDATE;
+import static org.carlspring.strongbox.controllers.configuration.ProxyConfigurationController.FAILED_UPDATE_FORM_ERROR;
+import static org.carlspring.strongbox.controllers.configuration.ProxyConfigurationController.SUCCESSFUL_UPDATE;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -24,6 +31,12 @@ public class ProxyConfigurationControllerTestIT
         extends RestAssuredBaseTest
 {
 
+    @Before
+    public void setUp()
+    {
+        setContextBaseUrl("/api/configuration/strongbox/proxy-configuration");
+    }
+
     static ProxyConfiguration createProxyConfiguration()
     {
         ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
@@ -32,7 +45,7 @@ public class ProxyConfigurationControllerTestIT
         proxyConfiguration.setUsername("user1");
         proxyConfiguration.setPassword("pass2");
         proxyConfiguration.setType("http");
-        List<String> nonProxyHosts = new ArrayList<>();
+        List<String> nonProxyHosts = Lists.newArrayList();
         nonProxyHosts.add("localhost");
         nonProxyHosts.add("some-hosts.com");
         proxyConfiguration.setNonProxyHosts(nonProxyHosts);
@@ -40,25 +53,41 @@ public class ProxyConfigurationControllerTestIT
         return proxyConfiguration;
     }
 
-    @Test
-    public void testSetAndGetGlobalProxyConfiguration()
+    private static ProxyConfiguration createWrongProxyConfiguration()
+    {
+        ProxyConfiguration proxyConfiguration = new ProxyConfiguration();
+        proxyConfiguration.setHost("");
+        proxyConfiguration.setPort(0);
+        proxyConfiguration.setUsername("user1");
+        proxyConfiguration.setPassword("pass2");
+        proxyConfiguration.setType("TEST");
+        List<String> nonProxyHosts = Lists.newArrayList();
+        nonProxyHosts.add("localhost");
+        nonProxyHosts.add("some-hosts.com");
+        proxyConfiguration.setNonProxyHosts(nonProxyHosts);
+
+        return proxyConfiguration;
+    }
+
+    private void testSetAndGetGlobalProxyConfiguration(String acceptHeader)
     {
         ProxyConfiguration proxyConfiguration = createProxyConfiguration();
 
-        String url = getContextBaseUrl() + "/api/configuration/strongbox/proxy-configuration";
+        String url = getContextBaseUrl();
 
         given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(acceptHeader)
                .body(proxyConfiguration)
                .when()
                .put(url)
                .then()
-               .statusCode(200);
-
-        url = getContextBaseUrl() + "/api/configuration/strongbox/proxy-configuration";
+               .statusCode(HttpStatus.OK.value())
+               .body(containsString(SUCCESSFUL_UPDATE));
 
         logger.debug("Current proxy host: " + proxyConfiguration.getHost());
 
-        ProxyConfiguration pc = given().contentType(MediaType.APPLICATION_XML_VALUE)
+        ProxyConfiguration pc = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                       .accept(MediaType.APPLICATION_JSON_VALUE)
                                        .when()
                                        .get(url)
                                        .as(ProxyConfiguration.class);
@@ -71,5 +100,85 @@ public class ProxyConfigurationControllerTestIT
         assertEquals("Failed to get proxy configuration!", proxyConfiguration.getType(), pc.getType());
         assertEquals("Failed to get proxy configuration!", proxyConfiguration.getNonProxyHosts(),
                      pc.getNonProxyHosts());
+    }
+
+    @WithMockUser(authorities = {"CONFIGURATION_SET_GLOBAL_PROXY_CFG", "CONFIGURATION_VIEW_GLOBAL_PROXY_CFG"})
+    @Test
+    public void testSetAndGetGlobalProxyConfigurationWithTextAcceptHeader()
+    {
+        testSetAndGetGlobalProxyConfiguration(MediaType.TEXT_PLAIN_VALUE);
+    }
+
+    @WithMockUser(authorities = {"CONFIGURATION_SET_GLOBAL_PROXY_CFG", "CONFIGURATION_VIEW_GLOBAL_PROXY_CFG"})
+    @Test
+    public void testSetAndGetGlobalProxyConfigurationWithJsonAcceptHeader()
+    {
+        testSetAndGetGlobalProxyConfiguration(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    private void testSetGlobalProxyConfigurationNotFound(String acceptHeader)
+    {
+        ProxyConfiguration proxyConfiguration = createProxyConfiguration();
+
+        String url = getContextBaseUrl();
+        String storageId = "storage-not-found";
+        String repositoryId = "repo-not-found";
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(acceptHeader)
+               .body(proxyConfiguration)
+               .param("storageId", storageId)
+               .param("repositoryId", repositoryId)
+               .when()
+               .put(url)
+               .then()
+               .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+               .body(containsString(FAILED_UPDATE));
+
+    }
+
+    @WithMockUser(authorities = "CONFIGURATION_SET_GLOBAL_PROXY_CFG")
+    @Test
+    public void testSetGlobalProxyConfigurationNotFoundWithTextAcceptHeader()
+    {
+        testSetGlobalProxyConfigurationNotFound(MediaType.TEXT_PLAIN_VALUE);
+    }
+
+    @WithMockUser(authorities = "CONFIGURATION_SET_GLOBAL_PROXY_CFG")
+    @Test
+    public void testSetGlobalProxyConfigurationNotFoundWithJsonAcceptHeader()
+    {
+        testSetGlobalProxyConfigurationNotFound(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    private void testSetGlobalProxyConfigurationBadRequest(String acceptHeader)
+    {
+        ProxyConfiguration proxyConfiguration = createWrongProxyConfiguration();
+
+        String url = getContextBaseUrl();
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(acceptHeader)
+               .body(proxyConfiguration)
+               .when()
+               .put(url)
+               .then()
+               .statusCode(HttpStatus.BAD_REQUEST.value())
+               .body(containsString(FAILED_UPDATE_FORM_ERROR));
+
+    }
+
+    @WithMockUser(authorities = "CONFIGURATION_SET_GLOBAL_PROXY_CFG")
+    @Test
+    public void testSetGlobalProxyConfigurationBadRequestWithTextAcceptHeader()
+    {
+        testSetGlobalProxyConfigurationBadRequest(MediaType.TEXT_PLAIN_VALUE);
+    }
+
+    @WithMockUser(authorities = "CONFIGURATION_SET_GLOBAL_PROXY_CFG")
+    @Test
+    public void testSetGlobalProxyConfigurationBadRequestWithJsonAcceptHeader()
+    {
+        testSetGlobalProxyConfigurationBadRequest(MediaType.APPLICATION_JSON_VALUE);
     }
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
@@ -192,7 +192,8 @@ public class StoragesConfigurationControllerTestIT
 
         url = getContextBaseUrl() + "/api/configuration/strongbox/proxy-configuration";
 
-        given().params("storageId", storageId, "repositoryId", repositoryId1)
+        given().accept(MediaType.APPLICATION_JSON_VALUE)
+               .params("storageId", storageId, "repositoryId", repositoryId1)
                .when()
                .get(url)
                .peek() // Use peek() to print the ouput


### PR DESCRIPTION
Related issue: #681

Methods modified in `ProxyConfigurationController` to use Form Validation and to follow the controllers guide.

The proper tests cases have been modified and new cases have been added.