### PR TITLE
Issue 618: Upgrade the Jackson dependencies to 2.9.5

### DIFF
--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -65,7 +65,7 @@
         <version.guava>24.0-jre</version.guava>
         <version.hamcrest>1.3</version.hamcrest>
         <version.httpclient>4.5</version.httpclient>
-        <version.jackson>2.9.0</version.jackson>
+        <version.jackson>2.9.5</version.jackson>
         <version.jcl>1.7.25</version.jcl>
         <version.jsr305>3.0.2</version.jsr305>
         <version.findbugs.annotations>3.0.1</version.findbugs.annotations>

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/domain/AccessModel.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/domain/AccessModel.java
@@ -4,6 +4,7 @@ import javax.persistence.Embeddable;
 import java.io.Serializable;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,14 +21,17 @@ public class AccessModel
 
     private static final Logger logger = LoggerFactory.getLogger(AccessModel.class);
 
+    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     private Map<String, Collection<String>> repositoryPrivileges;
 
     // maps URL tails including wildcards for regular expressions on set of privileges that was assigned
     // example:
     //      key:    storage0/act-releases-1/org/carlspring/strongbox/bar/.*
     //      value:  {ARTIFACTS_VIEW, ARTIFACTS_RESOLVE, ARTIFACTS_DEPLOY}
+    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     private Map<String, Collection<String>> urlToPrivilegesMap;
 
+    @JsonSerialize(typing = JsonSerialize.Typing.STATIC)
     private Map<String, Collection<String>> wildCardPrivilegesMap;
 
     public AccessModel()


### PR DESCRIPTION
Related issue: #618 

The `pom.xml` from parent has been modified to set the specified version.
A fix has been set for `Map` (that will be included in 2.9.6) as stated in this issue:
[Failed to specialize `Map` type during serialization where type key type incompatibility overidden via "raw" types](https://github.com/FasterXML/jackson-databind/issues/1964)