### PR TITLE
Issue-795: use awaitility for asynchronous tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,5 @@ To accept, please:
 | Guido Grazioli               |                                          | London, United Kingdom                  | 2018-01-15 |
 | Maxim Antonov                |                                          | Moscow, Russian Federation              | 2018-01-14 |
 | Aditya Srinivasan            |                                          | Washington DC, USA                      | 2018-02-02 |
-| Sevastyan Pigarev			         | 										                               | Barnaul, Russian Federation				         | 2018-03-27 |
+| Sevastyan Pigarev			   | 										  | Barnaul, Russian Federation				| 2018-03-27 |
+| Michael Altenburger          | 										  | Vienna, Austria         				| 2018-09-29 |

--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -97,6 +97,7 @@
         <version.reflections>0.9.11</version.reflections>
         <version.liquibase-slf4j>2.0.0</version.liquibase-slf4j>
         <version.jtwig>5.86.1.RELEASE</version.jtwig>
+        <version.awaitility>3.1.2</version.awaitility>
         <!-- Version properties. -->
     </properties>
 
@@ -1139,6 +1140,11 @@
                         <artifactId>hazelcast</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${version.awaitility}</version>
             </dependency>
         
         </dependencies>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/pom.xml
@@ -333,6 +333,10 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithMavenIndexingTestCase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithMavenIndexingTestCase.java
@@ -49,7 +49,7 @@ public class BaseCronJobWithMavenIndexingTestCase
 
     protected CronTaskEvent receivedEvent;
 
-    protected AtomicBoolean receivedExpectedEvent;
+    protected AtomicBoolean receivedExpectedEvent = new AtomicBoolean(false);
 
     protected String expectedJobName;
     

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Throwables;
 import org.apache.commons.lang.time.DateUtils;
@@ -32,6 +33,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 
 /**
@@ -145,7 +148,7 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT
                              properties.put("minSizeInBytes", Long.valueOf(sizeInBytes - 1).toString());
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
@@ -43,6 +44,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -198,7 +201,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
 
         addCronJobConfig(jobName, ClearRepositoryTrashCronJob.class, STORAGE0, REPOSITORY_RELEASES_1);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     private File[] getDirs() 
@@ -284,7 +287,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
 
             addCronJobConfig(jobName, ClearRepositoryTrashCronJob.class, null, null);
 
-            assertTrue("Failed to execute task!", expectEvent());
+            await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
         }
         finally
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
@@ -1,10 +1,12 @@
 package org.carlspring.strongbox.cron.jobs;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -185,7 +187,7 @@ public class DownloadRemoteMavenIndexCronJobTestIT
         addCronJobConfig(jobName, DownloadRemoteMavenIndexCronJob.class, STORAGE0,
                          REPOSITORY_PROXIED_RELEASES);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
@@ -1,10 +1,12 @@
 package org.carlspring.strongbox.cron.jobs;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -170,7 +172,7 @@ public class RebuildMavenIndexesCronJobTestIT
         addCronJobConfig(jobName, RebuildMavenIndexesCronJob.class, STORAGE0, REPOSITORY_RELEASES_1,
                          properties -> properties.put("basePath", ARTIFACT_BASE_PATH_STRONGBOX_INDEXES));
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -213,7 +215,7 @@ public class RebuildMavenIndexesCronJobTestIT
 
         addCronJobConfig(jobName, RebuildMavenIndexesCronJob.class, STORAGE0, REPOSITORY_RELEASES_1);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenMetadataCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenMetadataCronJobTestIT.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
@@ -31,6 +32,8 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -191,7 +194,7 @@ public class RebuildMavenMetadataCronJobTestIT
         addCronJobConfig(jobName, RebuildMavenMetadataCronJob.class, STORAGE0, REPOSITORY_SNAPSHOTS,
                          properties -> properties.put("basePath", ARTIFACT_BASE_PATH_STRONGBOX_METADATA));
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -241,7 +244,7 @@ public class RebuildMavenMetadataCronJobTestIT
 
         addCronJobConfig(jobName, RebuildMavenMetadataCronJob.class, STORAGE0, REPOSITORY_SNAPSHOTS);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -291,7 +294,7 @@ public class RebuildMavenMetadataCronJobTestIT
 
         addCronJobConfig(jobName, RebuildMavenMetadataCronJob.class, STORAGE0, null);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -341,6 +344,6 @@ public class RebuildMavenMetadataCronJobTestIT
 
         addCronJobConfig(jobName, RebuildMavenMetadataCronJob.class, null, null);
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateMavenChecksumCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateMavenChecksumCronJobTestIT.java
@@ -1,5 +1,6 @@
 package org.carlspring.strongbox.cron.jobs;
 
+import static org.awaitility.Awaitility.await;
 import static org.carlspring.strongbox.util.TestFileUtils.deleteIfExists;
 import static org.junit.Assert.assertTrue;
 
@@ -7,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
@@ -202,7 +204,7 @@ public class RegenerateMavenChecksumCronJobTestIT
                              properties.put("forceRegeneration", "false");
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -265,7 +267,7 @@ public class RegenerateMavenChecksumCronJobTestIT
         addCronJobConfig(jobName, RegenerateChecksumCronJob.class, STORAGE0, REPOSITORY_SNAPSHOTS,
                          properties -> properties.put("forceRegeneration", "false"));
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -326,7 +328,7 @@ public class RegenerateMavenChecksumCronJobTestIT
         addCronJobConfig(jobName, RegenerateChecksumCronJob.class, STORAGE0, null,
                          properties -> properties.put("forceRegeneration", "false"));
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -386,7 +388,7 @@ public class RegenerateMavenChecksumCronJobTestIT
         addCronJobConfig(jobName, RegenerateChecksumCronJob.class, null, null,
                          properties -> properties.put("forceRegeneration", "false"));
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -1,5 +1,6 @@
 package org.carlspring.strongbox.cron.jobs;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -9,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
@@ -216,7 +218,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                              properties.put("keepPeriod", "0");
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -260,7 +262,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                              properties.put("keepPeriod", "0");
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -307,7 +309,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                              properties.put("keepPeriod", "0");
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     @Test
@@ -348,7 +350,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                              properties.put("keepPeriod", "3");
                          });
 
-        assertTrue("Failed to execute task!", expectEvent());
+        await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent);
     }
 
     private String getSnapshotArtifactVersion(File artifactFile)


### PR DESCRIPTION
Fixes #795 

I used the default polling interval of awaitility, just tell me if you want a specific one. I will scan and mail the ICLA pdf tomorrow 