### PR TITLE
cleanup sonar warnings after merge

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
@@ -8,7 +8,6 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.Collection;
 
-import com.google.common.base.Throwables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.util.Assert;
 

--- a/strongbox-data-service/src/main/java/com/orientechnologies/orient/object/jpa/OJPAObjectDatabaseTxEntityManagerFactory.java
+++ b/strongbox-data-service/src/main/java/com/orientechnologies/orient/object/jpa/OJPAObjectDatabaseTxEntityManagerFactory.java
@@ -15,7 +15,6 @@ import java.sql.SQLException;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import com.google.common.base.Throwables;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.jdbc.OrientDataSource;
 import com.orientechnologies.orient.jdbc.OrientJdbcConnection;

--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/main/java/org/carlspring/strongbox/authentication/external/ldap/LdapConfiguration.java
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/main/java/org/carlspring/strongbox/authentication/external/ldap/LdapConfiguration.java
@@ -9,10 +9,10 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.net.ServerSocket;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.security.config.ldap.LdapServerBeanDefinitionParser;
@@ -162,7 +162,7 @@ public class LdapConfiguration
         }
         catch (Exception ex)
         {
-            throw new RuntimeException(ex);
+            throw new UndeclaredThrowableException(ex);
         }
         registerSingleton(applicationContext, container);
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/AuthenticatorsScanner.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/AuthenticatorsScanner.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
@@ -14,7 +14,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
@@ -43,8 +43,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import com.google.common.base.Throwables;
-
 /**
  * @author mtodorov
  */

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/IndexedMavenArtifactDeletedEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/IndexedMavenArtifactDeletedEventListener.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 
-import com.google.common.base.Throwables;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/MavenArtifactDeletedEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/MavenArtifactDeletedEventListener.java
@@ -7,8 +7,6 @@ import org.carlspring.strongbox.storage.repository.Repository;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 
-import com.google.common.base.Throwables;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
@@ -3,10 +3,8 @@ package org.carlspring.strongbox.storage.metadata;
 import org.carlspring.commons.io.MultipleDigestOutputStream;
 import org.carlspring.strongbox.artifact.MavenArtifact;
 import org.carlspring.strongbox.artifact.MavenArtifactUtils;
-import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.datastore.StorageProviderRegistry;
-import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathLock;
 import org.carlspring.strongbox.providers.layout.LayoutProvider;
@@ -31,12 +29,9 @@ import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 
-import com.google.common.base.Throwables;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Plugin;
@@ -159,7 +154,7 @@ public class MavenMetadataManager
                      }
                      catch (Exception ex)
                      {
-                         throw new RuntimeException(ex);
+                         throw new UndeclaredThrowableException(ex);
                      }
                  }
         );

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
@@ -18,7 +18,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Throwables;
 import org.apache.commons.lang.time.DateUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.hamcrest.CoreMatchers;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/RetryDownloadArtifactTestBase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/RetryDownloadArtifactTestBase.java
@@ -20,17 +20,11 @@ import org.carlspring.strongbox.services.ArtifactEntryService;
 import org.carlspring.strongbox.storage.repository.remote.RemoteRepository;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
 
-import com.google.common.base.Throwables;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,7 +33,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
-import com.google.common.base.Throwables;
 import com.hazelcast.config.Config;
 
 /**

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
@@ -28,11 +28,9 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 
 /**
  * @author Guido Grazioli

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/TrashControllerUndeleteTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/TrashControllerUndeleteTest.java
@@ -31,8 +31,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.google.common.base.Throwables;
-
 /**
  * @author Martin Todorov
  * @author Alex Oreshkevich

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
@@ -79,8 +79,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
-import com.google.common.base.Throwables;
-
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
 import io.restassured.response.ExtractableResponse;

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactIndexControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactIndexControllerTest.java
@@ -27,8 +27,6 @@ import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.google.common.base.Throwables;
-
 import io.restassured.http.Header;
 import io.restassured.module.mockmvc.response.MockMvcResponse;
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenSearchControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenSearchControllerTest.java
@@ -26,8 +26,6 @@ import org.junit.runner.RunWith;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.google.common.base.Throwables;
-
 /**
  * @author Alex Oreshkevich
  * @author Martin Todorov


### PR DESCRIPTION
This PR fixes sonar warnings steaming from the changes in PR #856 and therefore is part of the fix for issue #842 (however it does not close it as a separate PR for internal deprecations will be made)