### PR TITLE
checkstyle - intial version of ruleset added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,5 +101,34 @@
                 </plugins>
             </build>
         </profile>
+		
+		<profile>
+            <id>checkstyle</id>
+
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+
+            <build>
+                <plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<version>3.0.0</version>
+						<dependencies>
+							<dependency>
+								<groupId>com.puppycrawl.tools</groupId>
+								<artifactId>checkstyle</artifactId>
+								<version>8.13</version>
+							</dependency>
+						</dependencies>
+						<configuration>
+							<configLocation>strongbox-checks.xml</configLocation>
+							<consoleOutput>true</consoleOutput>
+						</configuration>
+					</plugin>
+				</plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/strongbox-checks.xml
+++ b/strongbox-checks.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <property name="severity" value="warning"/> <!-- later change to error -->
+    <property name="charset" value="UTF-8"/>
+    <property name="fileExtensions" value="java"/>
+    
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="NewlineAtEndOfFile"/>
+        
+    <module name="TreeWalker">
+        <property name="tabWidth" value="4"/>
+
+        <module name="AnnotationLocation">
+            <property name="allowSamelineSingleParameterlessAnnotation" value="false"/>
+        </module>
+        <module name="AnnotationUseStyle"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="AvoidNestedBlocks"/>
+        <module name="CommentsIndentation"/>
+        <module name="ConstantName">
+            <property name="format" value="^log(ger)?|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+        </module>
+        <module name="DeclarationOrder"/>   
+        <module name="DefaultComesLast"/>
+        <module name="EmptyBlock"/>    
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>    
+        <module name="EmptyStatement"/>
+        <module name="EqualsAvoidNull"/>    
+        <module name="EqualsHashCode"/>
+        <module name="FallThrough"/>
+        <module name="GenericWhitespace"/>
+        <module name="Indentation"/>
+        <module name="InnerTypeLast"/>
+        <module name="InterfaceIsType"/>
+        <module name="LeftCurly">
+            <property name="option" value="nl"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="MissingDeprecated">
+            <property name="skipNoJavadoc" value="true" />
+        </module>
+        <module name="MissingSwitchDefault"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="NeedBraces"/>
+        <module name="NoLineWrap"/>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="DOT, AT, INC, DEC"/>
+            <property name="allowLineBreaks" value="false"/>
+        </module>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens" value="DOT"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
+        <module name="NoWhitespaceBefore"/>
+        <module name="OneStatementPerLine"/>
+        <module name="OneTopLevelClass"/>
+        <module name="OperatorWrap">
+		    <property name="option" value="eol"/>
+		</module>
+        <module name="OuterTypeFilename"/>
+        <module name="PackageDeclaration"/>
+        <module name="ParenPad"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="RequireThis">
+            <property name="checkMethods" value="false"/>
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT, LAMBDA"/>
+        </module>
+        <module name="SimplifyBooleanReturn"/>
+        <module name="StringLiteralEquality"/>
+        <module name="SeparatorWrap"/>
+        <module name="TodoComment">
+            <property name="format" value="(TODO)|(FIXME)"/>
+        </module>
+        <module name="UnnecessaryParentheses"/>
+        <module name="UnusedImports"/>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+  </module>
+</module>


### PR DESCRIPTION
Issue #538 
So I added the initial version of the checkstyle ruleset. I run in on the code, and it had many warnings, then I run in on the example code on the guildelines page and it was all good.

A few more things to mention:
- it will check only Java files for now
- read more on the checks [here](http://checkstyle.sourceforge.net/checks.html)
- I set the level to warning, but later it can be changed to error if you want
- each warning will mention the name of the check that causes the violation so you can read about it
- I went though the codebase and I haven't found any real javadoc, but it could be also configured later

To be able to run a check, you can add these lines to the main pom:
```
<build>
    <plugins>
        <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-checkstyle-plugin</artifactId>
            <version>3.0.0</version>
            <dependencies>
                <dependency>
                    <groupId>com.puppycrawl.tools</groupId>
                    <artifactId>checkstyle</artifactId>
                    <version>8.13</version>
                </dependency>
            </dependencies>
            <configuration>
                <configLocation>strongbox-checks.xml</configLocation>
                <consoleOutput>true</consoleOutput>
            </configuration>
        </plugin>
    </plugins>
</build>
```

And run checkstyle:check. You will see the list of warnings in the console. :)