### PR TITLE
Issue-942: The EnvironmentInfoController is not producing the proper results for the JVM args

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoController.java
@@ -32,6 +32,7 @@ public class EnvironmentInfoController
         extends BaseController
 {
 
+    private static final String SYSTEM_PROPERTIES_PREFIX = "-D";
     private ObjectMapper objectMapper;
 
     public EnvironmentInfoController(ObjectMapper objectMapper)
@@ -84,13 +85,27 @@ public class EnvironmentInfoController
                                .collect(Collectors.toList());
     }
 
+    private List<String> getSystemPropertiesAsString()
+    {
+        List<EnvironmentInfo> systemProperties = getSystemProperties();
+
+        return systemProperties.stream()
+                               .map(e -> SYSTEM_PROPERTIES_PREFIX + e.getName() + "=" + e.getValue())
+                               .collect(Collectors.toList());
+    }
+
     private List<String> getJvmArguments()
     {
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         List<String> arguments = runtimeMxBean.getInputArguments();
+        List<String> systemProperties = getSystemPropertiesAsString();
 
         return arguments.stream()
+                        .filter(argument -> !systemProperties.contains(argument))
                         .sorted(String::compareToIgnoreCase)
                         .collect(Collectors.toList());
+
     }
+
+
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/environment/EnvironmentInfoControllerTestIT.java
@@ -42,7 +42,7 @@ public class EnvironmentInfoControllerTestIT
     }
 
     @Test
-    public void testGetEnvironmentInfo()
+    void testGetEnvironmentInfo()
             throws Exception
     {
         String path = "/api/configuration/environment/info";
@@ -73,11 +73,11 @@ public class EnvironmentInfoControllerTestIT
         List<?> jvmArguments = returnedMap.get("jvm");
 
         assertNotNull(jvmArguments, "Failed to get JVM arguments list!");
-        assertFalse(jvmArguments.isEmpty(), "Returned JVM arguments are empty");
+        assertTrue(jvmArguments.isEmpty(), "Returned JVM arguments are not empty");
     }
 
     @Test
-    public void testGetEnvironmentInfoCheckSorted()
+    void testGetEnvironmentInfoCheckSorted()
             throws Exception
     {
         String path = "/api/configuration/environment/info";
@@ -91,7 +91,9 @@ public class EnvironmentInfoControllerTestIT
 
         // Environment variables
         JsonNode environmentNode = root.path("environment");
-        ObjectReader listEnvironmentInfoReader = mapper.readerFor(new TypeReference<List<EnvironmentInfo>>(){});
+        ObjectReader listEnvironmentInfoReader = mapper.readerFor(new TypeReference<List<EnvironmentInfo>>()
+        {
+        });
 
         List<EnvironmentInfo> environmentVariables = listEnvironmentInfoReader.readValue(environmentNode);
         Comparator<EnvironmentInfo> environmentInfoComparator = Comparator.comparing(EnvironmentInfo::getName,
@@ -113,7 +115,9 @@ public class EnvironmentInfoControllerTestIT
 
         // JVM arguments
         JsonNode jvmNode = root.path("jvm");
-        ObjectReader listStringReader = mapper.readerFor(new TypeReference<List<String>>(){});
+        ObjectReader listStringReader = mapper.readerFor(new TypeReference<List<String>>()
+        {
+        });
         List<String> jvmArguments = listStringReader.readValue(jvmNode);
         Comparator<String> stringComparator = String::compareToIgnoreCase;
         List<String> sortedJvmArguments = new ArrayList<>(jvmArguments);


### PR DESCRIPTION
Fixes #942.

When JVM args are recovered, I've added a filter to exclude system properties from them.