### PR TITLE
LayoutProvider.containsPath should be replaced with RepositoryFiles.artifactExists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,3 +70,4 @@ To accept, please:
 | Sevastyan Pigarev			         |                              										  | Barnaul, Russian Federation				         | 2018-03-27 |
 | Michael Altenburger          | 						                             				  | Vienna, Austria                     				| 2018-09-29 |
 | Benjamin March               |                             			          | Munich, Germany                     				| 2018-10-28 |
+| Konstantina Papadopoulou	   |										  | Thessaloniki, Greece					| 2018-12-28 |

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProvider.java
@@ -65,13 +65,6 @@ public abstract class AbstractLayoutProvider<T extends ArtifactCoordinates>
                      .collect(Collectors.toSet());
     }
 
-    @Override
-    public boolean containsPath(RepositoryPath repositoryPath)
-            throws IOException
-    {
-        return Files.exists(repositoryPath);
-    }
-
     public boolean isChecksum(RepositoryPath repositoryPath)
     {
         return isChecksum(repositoryPath.getFileName().toString());

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutProvider.java
@@ -14,12 +14,6 @@ import java.util.Set;
 public interface LayoutProvider<T extends ArtifactCoordinates>
 {
 
-    //TODO: probably we should move this method into `RepositoryProvider` as "contains" logic depends on Repository type
-    @Deprecated
-    boolean containsPath(RepositoryPath repositoryPath)
-            throws IOException;
-
-
     //TODO: we should perform delete logic in RepositoryPath and RepositoryFileSystemProvider
     @Deprecated
     void deleteMetadata(RepositoryPath repositoryPath)

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.springframework.stereotype.Component;
 
 /**
@@ -72,7 +73,7 @@ public class GroupRepositoryArtifactExistenceChecker
                 final LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(subRepository.getLayout());
                 RepositoryPath subRepositoryPath = repositoryPathResolver.resolve(subRepository, repositoryPath.relativize());
                 
-                if (layoutProvider.containsPath(subRepositoryPath))
+                if (RepositoryFiles.artifactExists(subRepositoryPath))
                 {
                     repositoryArtifactExistence.get(storageAndRepositoryId).setTrue();
                     return true;

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/deployment/RedeploymentValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/deployment/RedeploymentValidator.java
@@ -12,6 +12,7 @@ import org.carlspring.strongbox.storage.validation.artifact.version.VersionValid
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.IOException;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +74,7 @@ public class RedeploymentValidator
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository, coordinates);
         
         if (repository.acceptsReleases() &&
-            (!repository.allowsDeployment() && layoutProvider.containsPath(repositoryPath)))
+            (!repository.allowsDeployment() && RepositoryFiles.artifactExists(repositoryPath)))
         {
             throw new VersionValidationException("The " + repository.getStorage().getId() + ":" +
                                                  repository.toString() +

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidator.java
@@ -16,6 +16,7 @@ import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -122,7 +123,7 @@ public class ArtifactOperationsValidator
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
         
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository, coordinates);
-        if (layoutProvider.containsPath(repositoryPath) && !repository.allowsRedeployment())
+        if (RepositoryFiles.artifactExists(repositoryPath) && !repository.allowsRedeployment())
         {
             throw new ArtifactStorageException("Re-deployment of artifacts to " +
                                                repository.getStorage().getId() + ":" + repository.getId() +

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
@@ -33,6 +33,7 @@ import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.codehaus.plexus.util.WriterFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.javatuples.Pair;
@@ -69,7 +70,7 @@ public class MavenMetadataManager
         Repository repository = repositoryPath.getRepository();
         
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
-        if (!layoutProvider.containsPath(repositoryPath))
+        if (!RepositoryFiles.artifactExists(repositoryPath))
         {
             throw new IOException("Artifact " + artifact.toString() + " does not exist in repository " + repository +
                     " !");
@@ -163,7 +164,7 @@ public class MavenMetadataManager
     {
         Repository repository = artifactGroupDirectoryPath.getRepository();
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
-        if (!layoutProvider.containsPath(artifactGroupDirectoryPath))
+        if (!RepositoryFiles.artifactExists(artifactGroupDirectoryPath))
         {
             logger.error("Artifact metadata generation failed: " + artifactGroupDirectoryPath + ").");
             
@@ -358,7 +359,7 @@ public class MavenMetadataManager
         Repository repository = repositoryPath.getRepository();
         
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
-        if (!layoutProvider.containsPath(repositoryPath))
+        if (!RepositoryFiles.artifactExists(repositoryPath))
         {
             throw new IOException("Artifact " + artifact.toString() + " does not exist in repository " + repository +
                     " !");

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenSnapshotManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenSnapshotManager.java
@@ -59,7 +59,7 @@ public class MavenSnapshotManager
     {
         Repository repository = basePath.getRepository();
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
-        if (!layoutProvider.containsPath(basePath))
+        if (!RepositoryFiles.artifactExists(basePath))
         {
             logger.error("Removal of timestamped Maven snapshot artifact: " + basePath + ".");
             

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.awaitility.Awaitility.await;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,8 +139,8 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT
 
                 try
                 {
-                    assertFalse(layoutProvider.containsPath(repositoryPathResolver.resolve(repository, path)));
-                    assertTrue(layoutProvider.containsPath(repositoryPathResolver.resolve(repository,
+                    assertFalse(RepositoryFiles.artifactExists(repositoryPathResolver.resolve(repository, path)));
+                    assertTrue(RepositoryFiles.artifactExists(repositoryPathResolver.resolve(repository,
                                                                                           StringUtils.replace(path,
                                                                                                               "1.5/properties-injector-1.5.jar",
                                                                                                               "maven-metadata.xml"))));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenProxyRepositoryProviderTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenProxyRepositoryProviderTestIT.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -169,7 +170,7 @@ public class MavenProxyRepositoryProviderTestIT
 
         LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository.getLayout());
 
-        assertTrue(layoutProvider.containsPath(
+        assertTrue(RepositoryFiles.artifactExists(
                 repositoryPathResolver.resolve(repository, "org/carlspring/properties-injector/maven-metadata.xml")));
     }
 
@@ -196,7 +197,7 @@ public class MavenProxyRepositoryProviderTestIT
         FileUtils.copyDirectory(mavenCentralArtifactBaseBath.toFile(), carlspringArtifactBaseBath.toFile());
 
         // 4. confirm maven-metadata.xml lies in the carlspring repository
-        assertTrue(layoutProvider.containsPath(
+        assertTrue(RepositoryFiles.artifactExists(
                 repositoryPathResolver.resolve(repository, "javax/media/jai_core/maven-metadata.xml")));
 
         // 5. confirm some pre-merge state

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
@@ -12,6 +12,7 @@ import org.carlspring.strongbox.storage.repository.Repository;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 
 import org.codehaus.plexus.util.StringUtils;
 import org.hamcrest.CoreMatchers;
@@ -70,8 +71,8 @@ public class WhenRepositoryIsAliveCleanExpiredArtifactsTestIT
         final Repository repository = storage.getRepository(artifactEntry.getRepositoryId());
         final LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository.getLayout());
 
-        assertFalse(layoutProvider.containsPath(repositoryPathResolver.resolve(repository, getPath())));
-        assertTrue(layoutProvider.containsPath(repositoryPathResolver.resolve(repository, StringUtils.replace(getPath(),
+        assertFalse(RepositoryFiles.artifactExists(repositoryPathResolver.resolve(repository, getPath())));
+        assertTrue(RepositoryFiles.artifactExists(repositoryPathResolver.resolve(repository, StringUtils.replace(getPath(),
                                                                                                               "1.3/maven-commons-1.3.jar",
                                                                                                               "maven-metadata.xml"))));
     }


### PR DESCRIPTION
Hi,

This pull request fixes #884.

I dropped the `LayoutProvider.containsPath` method from `AbstractLayoutProvider` and `LayoutProvider` and I replaced `LayoutProvider.containsPath` with `RepositoryFiles.artifactExists` in
1) `GroupRepositoryArtifactExistenceChecker`
2) `RedeploymentValidator`
3) `ArtifactOperationsValidator`
4) `MavenSnapshotManager`
5) `MavenMetadataManager`
6) `MavenProxyRepoitoryProviderTestIT`
7) `WhenRepositoryIsAliveCleanExpiredArtifactsTestIT`
8) `CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT`
