### PR TITLE
Upgrade Jackson to 2.9.8 due to "Deserialization of Untrusted Data" vulnerability

### DIFF
--- a/strongbox-parent/pom.xml
+++ b/strongbox-parent/pom.xml
@@ -59,7 +59,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.hazelcast>3.10.2</version.hazelcast>
         <version.httpclient>4.5</version.httpclient>
-        <version.jackson>2.9.7</version.jackson>
+        <version.jackson>2.9.8</version.jackson>
         <version.jcl>1.7.25</version.jcl>
         <version.jsr305>3.0.2</version.jsr305>
         <version.findbugs.annotations>3.0.1</version.findbugs.annotations>


### PR DESCRIPTION
Fixes #966.
