### PR TITLE
Issue-1003: Saving group repositories does not preserve the order.

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
@@ -12,7 +12,7 @@ import org.carlspring.strongbox.xml.configuration.repository.MavenRepositoryConf
 
 import javax.inject.Inject;
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.*;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -260,6 +260,12 @@ public class StoragesConfigurationControllerTestIT
         repositoryForm0_1.setPolicy("release");
         repositoryForm0_1.setImplementation("file-system");
         repositoryForm0_1.setStatus("In Service");
+        Set<String> groupRepositories = new LinkedHashSet<>();
+        String groupRepository1 = "maven-central";
+        String groupRepository2 = "carlspring";
+        groupRepositories.add(groupRepository1);
+        groupRepositories.add(groupRepository2);
+        repositoryForm0_1.setGroupRepositories(groupRepositories);
 
         Integer maxConnectionsRepository2 = 30;
 
@@ -290,6 +296,11 @@ public class StoragesConfigurationControllerTestIT
         Repository repository0 = storage.getRepositories().get(repositoryForm0_1.getId());
         Repository repository1 = storage.getRepositories().get(repositoryForm0_2.getId());
 
+        Map<String, String> groupRepositoriesMap = repository0.getGroupRepositories();
+        Map<String, String> groupRepositoriesMapExpected = new LinkedHashMap<>();
+        groupRepositoriesMapExpected.put(groupRepository1, groupRepository1);
+        groupRepositoriesMapExpected.put(groupRepository2, groupRepository2);
+
         assertNotNull(storage, "Failed to get storage (" + storageId + ")!");
         assertFalse(storage.getRepositories().isEmpty(), "Failed to get storage (" + storageId + ")!");
         assertTrue(repository0.allowsRedeployment(),
@@ -305,6 +316,7 @@ public class StoragesConfigurationControllerTestIT
         assertFalse(
                 ((MavenRepositoryConfiguration) repository0.getRepositoryConfiguration()).isIndexingClassNamesEnabled(),
                 "Failed to get storage (" + storageId + ")!");
+        assertEquals(groupRepositoriesMapExpected, groupRepositoriesMap);
 
         assertTrue(repository1.allowsForceDeletion(),
                    "Failed to get storage (" + storageId + ")!");

--- a/strongbox-web-forms/src/main/java/org/carlspring/strongbox/forms/configuration/RepositoryForm.java
+++ b/strongbox-web-forms/src/main/java/org/carlspring/strongbox/forms/configuration/RepositoryForm.java
@@ -10,7 +10,10 @@ import org.carlspring.strongbox.validation.configuration.LayoutProviderValue;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.PositiveOrZero;
+import java.util.LinkedHashSet;
 import java.util.Set;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * @author Przemyslaw Fusik
@@ -73,7 +76,7 @@ public class RepositoryForm
     @Valid
     private CustomRepositoryConfigurationForm repositoryConfiguration;
 
-    private Set<String> groupRepositories;
+    private Set<String> groupRepositories ;
 
     private Set<String> artifactCoordinateValidators;
 
@@ -282,6 +285,7 @@ public class RepositoryForm
         return groupRepositories;
     }
 
+    @JsonDeserialize(as=LinkedHashSet.class)
     public void setGroupRepositories(final Set<String> groupRepositories)
     {
         this.groupRepositories = groupRepositories;


### PR DESCRIPTION
Fixes #1003.

When updated, the group repositories set was deserialized as `HashSet` by default. It's been forced to deserialize as a `LinkedHashSet`.