### PR TITLE
updated tarLongFileMode to posix to avoid issues with mac users

### DIFF
--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -333,7 +333,7 @@
                         <descriptor>src/main/assembly/distribution.xml</descriptor>
                     </descriptors>
                     <appendAssemblyId>false</appendAssemblyId>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
tarLongFileMode configuration sets the TarArchiver behavior on file paths with more than 100 characters length. 

GNU tar has restrictions on max value of UID/GUID in tar files. Consider using the more well defined POSIX tar format, which should support larger values. Use tarLongFileMode=posix in the assembly:single goal.

This will avoid such issues in the future for Mac users on IT-provisioned machines in which your user id and group id are very high.

known issue with maven assembly plugin configuration: https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#tarFileModes
