### PR TITLE
Issue1030: java.lang.RuntimeException: Could not delete the role

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/security/authorization/AuthorizationConfigController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/security/authorization/AuthorizationConfigController.java
@@ -123,7 +123,8 @@ public class AuthorizationConfigController
         catch (RuntimeException e)
         {
             String message = e.getMessage();
-            return getExceptionResponseEntity(HttpStatus.BAD_REQUEST, message, e, acceptHeader);
+            logger.error(message);
+            return getBadRequestResponseEntity(message, acceptHeader);
         }
 
         return processConfig(() -> SUCCESSFUL_DELETE_ROLE, acceptHeader);


### PR DESCRIPTION
#1030 This commit, improves handling of the exception and add logger, so that when you run the tests there is no longer NullPointerException stacktrace, and you get simple one line error: `could not delete the role.`