### PR TITLE
Issue-1059: Drop the org.apache.tomcat:catalina:6.0.53 dependency from the strongbox-event-api

### DIFF
--- a/strongbox-event-api/pom.xml
+++ b/strongbox-event-api/pom.xml
@@ -118,11 +118,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>catalina</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes #1059.

@sbespalov  
@fuss86 

Is this solution okay, or not? I decided to remove everything what is connected with `catalina` because if the there are no libraries related to it, maybe there is no sense to hold it. I ran integration tests, and everything built without any issues. Service from `strongbox-distribution` is also working and I was able to manage the `strongbox` without any other issues. If that solution is incorrect, just let me know how should it looks like and then I will improve this code.