### PR TITLE
Issue-1062: Make the *ArtifactControllerTests not print the contents of artifacts to the console

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
@@ -1138,7 +1138,6 @@ public class MavenArtifactControllerTest
                .contentType(MediaType.TEXT_PLAIN_VALUE)
                .when()
                .get(url)
-               .peek()
                .then()
                .statusCode(HttpStatus.OK.value());
     }
@@ -1164,7 +1163,6 @@ public class MavenArtifactControllerTest
                .contentType(MediaType.TEXT_PLAIN_VALUE)
                .when()
                .get(url)
-               .peek()
                .then()
                .statusCode(HttpStatus.OK.value());
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -151,7 +151,6 @@ public class NpmArtifactControllerTest
                .when()
                .get(contextBaseUrl + "/storages/" + STORAGE0 + "/" + REPOSITORY_RELEASES + "/" +
                     coordinates.toResource())
-               .peek()
                .then()
                .statusCode(HttpStatus.OK.value())
                .assertThat()


### PR DESCRIPTION
fixes #1062 
- Fixed MavenArtifactControllerTest to avoid printing the contents artifacts
- Fixed NpmArtifactControllerTest to avoid printing the contents artifacts

