### PR TITLE
TestArtifact annotation support

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
@@ -1,5 +1,21 @@
 package org.carlspring.strongbox.services;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.io.IOUtils;
 import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
 import org.carlspring.strongbox.configuration.Configuration;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
@@ -10,7 +26,6 @@ import org.carlspring.strongbox.io.StreamUtils;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.io.RepositoryPathLock;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.providers.io.RepositoryStreamSupport.RepositoryOutputStream;
 import org.carlspring.strongbox.providers.layout.LayoutFileSystemProvider;
@@ -25,24 +40,6 @@ import org.carlspring.strongbox.storage.validation.artifact.ArtifactCoordinatesV
 import org.carlspring.strongbox.storage.validation.artifact.ArtifactCoordinatesValidatorRegistry;
 import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
 import org.carlspring.strongbox.storage.validation.resource.ArtifactOperationsValidator;
-
-import javax.inject.Inject;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.NoSuchAlgorithmException;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.stream.Collectors;
-
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -1,0 +1,18 @@
+package org.carlspring.strongbox.artifact.generator;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+
+/**
+ * @author sbespalov
+ *
+ */
+public interface ArtifactGenerator
+{
+
+    Path generateArtifact(URI uri,
+                          int size)
+        throws IOException;
+
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/NullArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/NullArtifactGenerator.java
@@ -1,0 +1,92 @@
+package org.carlspring.strongbox.artifact.generator;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.carlspring.commons.io.RandomInputStream;
+import org.carlspring.strongbox.io.LayoutOutputStream;
+
+/**
+ * @author sbespalov
+ *
+ */
+public class NullArtifactGenerator implements ArtifactGenerator
+{
+
+    private final Path baseDir;
+
+    public NullArtifactGenerator()
+    {
+        this(Paths.get("."));
+    }
+
+    public NullArtifactGenerator(Path baseDir)
+    {
+        this.baseDir = baseDir;
+    }
+
+    @Override
+    public Path generateArtifact(URI uri,
+                                 int size)
+        throws IOException
+    {
+        Path path = baseDir.resolve(uri.toString());
+        Files.createDirectories(path.getParent());
+
+        try (OutputStream fileOutputStream = Files.newOutputStream(path,
+                                                                   StandardOpenOption.TRUNCATE_EXISTING,
+                                                                   StandardOpenOption.CREATE);
+                LayoutOutputStream layoutOutputStream = new LayoutOutputStream(fileOutputStream);
+                RandomInputStream ris = new RandomInputStream(size))
+        {
+            layoutOutputStream.addAlgorithm(MessageDigestAlgorithms.MD5);
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = ris.read(buffer)) > 0)
+            {
+                layoutOutputStream.write(buffer, 0, len);
+            }
+
+            layoutOutputStream.flush();
+            layoutOutputStream.getDigestMap()
+                              .entrySet()
+                              .stream()
+                              .forEach(e -> writeChecksum(path, e.getKey(), e.getValue()));
+
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new IOException(e);
+        }
+
+        return path;
+    }
+
+    private void writeChecksum(Path path,
+                               String algorithm,
+                               String value)
+    {
+        String fileName = path.getFileName().toString();
+        String checksumFileName = fileName + "." + algorithm.toLowerCase();
+        try
+        {
+            Files.write(path.resolveSibling(checksumFileName),
+                        value.getBytes(),
+                        StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
+        }
+        catch (IOException e)
+        {
+            throw new UndeclaredThrowableException(e);
+        }
+    }
+
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
@@ -1,22 +1,30 @@
 package org.carlspring.strongbox.storage.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.inject.Inject;
 
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.carlspring.strongbox.StorageApiTestConfig;
 import org.carlspring.strongbox.artifact.coordinates.NullArtifactCoordinates;
+import org.carlspring.strongbox.artifact.generator.NullArtifactGenerator;
 import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.providers.io.RootRepositoryPath;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepositoryManagementApplicationContext;
@@ -25,7 +33,6 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -35,11 +42,12 @@ import org.springframework.test.context.TestExecutionListeners;
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = { StorageApiTestConfig.class })
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(ExecutionMode.CONCURRENT)
+@Execution(CONCURRENT)
 public class RepositoryManagementTest
 {
 
     private static Set<Repository> resolvedRepositoryInstances = ConcurrentHashMap.newKeySet();
+    private static Set<byte[]> resolvedArtifactChecksums = ConcurrentHashMap.newKeySet();
 
     @Inject
     private RepositoryPathResolver repositoryPathResolver;
@@ -56,12 +64,17 @@ public class RepositoryManagementTest
         assertNull(TestRepositoryManagementApplicationContext.getInstance());
     }
 
-    @ExtendWith(RepositoryManagementTestExecutionListener.class)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @RepeatedTest(20)
     public void testRepositoryDirect(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repository = "r1", storage = "storage0") Repository r1,
                                      @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repository = "r2", storage = "storage0") Repository r2,
+                                     @TestArtifact(resource = "org/carlspring/test/artifact1.ext", generator = NullArtifactGenerator.class) Path standaloneArtifact,
+                                     @TestArtifact(repository = "r2", storage = "storage0", resource = "org/carlspring/test/artifact2.ext", generator = NullArtifactGenerator.class) Path repositoryArtifact,
                                      TestInfo testInfo)
+        throws IOException
     {
+        artifactShouldBeCorrectlyResolvedAndUnique(standaloneArtifact);
+        artifactShouldBeCorrectlyResolvedAndUnique(repositoryArtifact);
         parametersShouldBeCorrectlyResolvedAndUnique(r1, r2, testInfo);
     }
 
@@ -72,6 +85,19 @@ public class RepositoryManagementTest
                                       TestInfo testInfo)
     {
         parametersShouldBeCorrectlyResolvedAndUnique(r1, r2, testInfo);
+    }
+
+    private void artifactShouldBeCorrectlyResolvedAndUnique(Path artifact)
+        throws IOException
+    {
+        assertTrue(Files.exists(artifact));
+        assertEquals(1024L, Files.size(artifact));
+
+        String fileName = artifact.getFileName().toString();
+        String checksumFileName = fileName + "." + MessageDigestAlgorithms.MD5.toLowerCase();
+        Path artifactChecksum = artifact.resolveSibling(checksumFileName);
+        assertTrue(Files.exists(artifactChecksum));
+        assertTrue(resolvedArtifactChecksums.add(Files.readAllBytes(artifactChecksum)));
     }
 
     private void parametersShouldBeCorrectlyResolvedAndUnique(Repository r1,
@@ -86,7 +112,7 @@ public class RepositoryManagementTest
         // Check that repositories correctly resolved
         assertNotNull(configurationManager.getRepository("storage0", "r1"));
         assertNotNull(configurationManager.getRepository("storage0", "r2"));
-        
+
         // Check that paths created
         RootRepositoryPath p1 = repositoryPathResolver.resolve(r1);
         assertTrue(Files.exists(p1));

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/NullFileSystem.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/NullFileSystem.java
@@ -1,9 +1,11 @@
 package org.carlspring.strongbox.testing;
 
 import java.nio.file.FileSystem;
-import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.carlspring.strongbox.providers.io.LayoutFileSystem;
 import org.carlspring.strongbox.providers.io.StorageFileSystemProvider;
 import org.carlspring.strongbox.storage.repository.Repository;
@@ -21,7 +23,9 @@ public class NullFileSystem extends LayoutFileSystem
     @Override
     public Set<String> getDigestAlgorithmSet()
     {
-        return Collections.emptySet();
+        return Stream.of(MessageDigestAlgorithms.MD5)
+                     .collect(Collectors.toSet());
+
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/NullLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/NullLayoutProvider.java
@@ -3,9 +3,12 @@ package org.carlspring.strongbox.testing;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.carlspring.strongbox.artifact.coordinates.NullArtifactCoordinates;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
@@ -47,6 +50,12 @@ public class NullLayoutProvider extends AbstractLayoutProvider<NullArtifactCoord
         throws IOException
     {
         return new NullArtifactCoordinates(RepositoryFiles.relativizePath(repositoryPath));
+    }
+
+    protected Set<String> getDigestAlgorithmSet()
+    {
+        return Stream.of(MessageDigestAlgorithms.MD5)
+                     .collect(Collectors.toSet());
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactManagementTestExecutionListener.java
@@ -1,0 +1,106 @@
+package org.carlspring.strongbox.testing.artifact;
+
+import static org.carlspring.strongbox.testing.artifact.TestArtifactContext.id;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+
+import org.carlspring.strongbox.io.ProxyPathInvocationHandler;
+import org.carlspring.strongbox.testing.storage.repository.TestRepositoryManagementContext;
+import org.carlspring.strongbox.testing.storage.repository.TestRepositoryManagementContextSupport;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+
+/**
+ * @author sbespalov
+ *
+ */
+public class ArtifactManagementTestExecutionListener extends TestRepositoryManagementContextSupport<TestArtifact>
+{
+
+    public ArtifactManagementTestExecutionListener()
+    {
+        super(TestArtifact.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext,
+                                   ExtensionContext extensionContext)
+        throws ParameterResolutionException
+    {
+        Parameter parameter = parameterContext.getParameter();
+        TestArtifact testArtifact = parameter.getAnnotation(TestArtifact.class);
+
+        TestRepositoryManagementContext testApplicationContext = getTestRepositoryManagementContext();
+        testApplicationContext.register(testArtifact, new TestInfo()
+        {
+
+            @Override
+            public String getDisplayName()
+            {
+                return extensionContext.getDisplayName();
+            }
+
+            @Override
+            public Set<String> getTags()
+            {
+                return extensionContext.getTags();
+            }
+
+            @Override
+            public Optional<Class<?>> getTestClass()
+            {
+                return extensionContext.getTestClass();
+            }
+
+            @Override
+            public Optional<Method> getTestMethod()
+            {
+                return extensionContext.getTestMethod();
+            }
+
+        });
+        testApplicationContext.refresh();
+
+        return Proxy.newProxyInstance(ArtifactManagementTestExecutionListener.class.getClassLoader(),
+                                      new Class[] { Path.class },
+                                      new TestArtifactProxyInvocationHandler(
+                                              id(testArtifact)));
+    }
+
+    /**
+     * This class provides lazy initialization for resolved artifact Path
+     * instance.
+     * 
+     * @author sbespalov
+     *
+     */
+    private class TestArtifactProxyInvocationHandler extends ProxyPathInvocationHandler
+    {
+
+        private Path target;
+        private final String id;
+
+        private TestArtifactProxyInvocationHandler(String id)
+        {
+            this.id = id;
+        }
+
+        public Path getTarget()
+        {
+            if (target == null)
+            {
+                target = getTestRepositoryManagementContext().getTestArtifactContext(id).getArtifact();
+            }
+
+            return target;
+        }
+
+    }
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
@@ -1,0 +1,60 @@
+package org.carlspring.strongbox.testing.artifact;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.file.Path;
+
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
+import org.carlspring.strongbox.storage.Storage;
+import org.carlspring.strongbox.storage.repository.Repository;
+
+/**
+ * This annotation provide ability to inject Artifact {@link Path} instance as
+ * test method parameters.
+ * <br>
+ * The Artifact will also be deployed if {@link Storage} and {@link Repository}
+ * provided, in this case {@link RepositoryPath} instance will be injected.
+ * <br>
+ * If there is no {@link Storage} and {@link Repository} provided then Artifact
+ * will be just regular {@link Path} instance located in
+ * `{testMethodName}/{artifactURI}`.
+ * 
+ * @author sbespalov
+ *
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TestArtifact
+{
+
+    /**
+     * {@link Storage} ID.
+     */
+    String storage() default "";
+
+    /**
+     * {@link Repository} ID.
+     */
+    String repository() default "";
+
+    /**
+     * Layout specific artifact URI (ex.'path/to/artifact.zip').
+     */
+    String resource();
+
+    /**
+     * {@link ArtifactGenerator} class to use.
+     */
+    Class<? extends ArtifactGenerator> generator();
+
+    /**
+     * Artifact size in bytes.
+     */
+    int size() default 1024;
+
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -1,0 +1,108 @@
+package org.carlspring.strongbox.testing.artifact;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+import org.carlspring.strongbox.booters.PropertiesBooter;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
+import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
+import org.carlspring.strongbox.services.ArtifactManagementService;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.cglib.proxy.UndeclaredThrowableException;
+
+/**
+ * @author sbespalov
+ *
+ */
+public class TestArtifactContext
+{
+
+    private final TestArtifact testArtifact;
+    private final PropertiesBooter propertiesBooter;
+    private final ArtifactManagementService artifactManagementService;
+    private final RepositoryPathResolver repositoryPathResolver;
+    private final TestInfo testInfo;
+    private final Path artifactPath;
+
+    public TestArtifactContext(TestArtifact testArtifact,
+                               PropertiesBooter propertiesBooter,
+                               ArtifactManagementService artifactManagementService,
+                               RepositoryPathResolver repositoryPathResolver,
+                               TestInfo testInfo)
+        throws IOException
+    {
+        this.testArtifact = testArtifact;
+        this.propertiesBooter = propertiesBooter;
+        this.artifactManagementService = artifactManagementService;
+        this.repositoryPathResolver = repositoryPathResolver;
+        this.testInfo = testInfo;
+
+        artifactPath = createArtifact();
+    }
+
+    private Path createArtifact()
+        throws IOException
+    {
+        Class<? extends ArtifactGenerator> generatorClass = testArtifact.generator();
+
+        Path vaultDirectoryPath = Paths.get(propertiesBooter.getVaultDirectory(), ".temp",
+                                            testInfo.getTestClass().get().getSimpleName(),
+                                            testInfo.getTestMethod().get().getName());
+
+        ArtifactGenerator artifactGenerator;
+        try
+        {
+            artifactGenerator = generatorClass.getConstructor(Path.class).newInstance(vaultDirectoryPath);
+        }
+        catch (Exception e)
+        {
+            throw new IOException(e);
+        }
+
+        Path artifactPathLocal = artifactGenerator.generateArtifact(URI.create(testArtifact.resource()),
+                                                                    testArtifact.size());
+        if (testArtifact.repository().isEmpty())
+        {
+            return artifactPathLocal;
+        }
+
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(testArtifact.storage(),
+                                                                       testArtifact.repository(),
+                                                                       testArtifact.resource());
+        artifactManagementService.store(repositoryPath, Files.newInputStream(artifactPathLocal));
+        repositoryPath.getFileSystem()
+                      .provider()
+                      .resolveChecksumPathMap(repositoryPath)
+                      .values()
+                      .stream()
+                      .forEach(p -> {
+                          try
+                          {
+                              artifactManagementService.store(p,
+                                                              Files.newInputStream(artifactPathLocal.resolveSibling(p.getFileName())));
+                          }
+                          catch (IOException e)
+                          {
+                              throw new UndeclaredThrowableException(e);
+                          }
+                      });
+
+        Files.delete(artifactPathLocal);
+        return repositoryPath;
+    }
+
+    public static String id(TestArtifact testArtifact)
+    {
+        return String.format("%s", testArtifact.resource());
+    }
+
+    public Path getArtifact()
+    {
+        return artifactPath;
+    }
+
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -6,6 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import javax.annotation.PreDestroy;
+
 import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
 import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
@@ -18,7 +20,7 @@ import org.springframework.cglib.proxy.UndeclaredThrowableException;
  * @author sbespalov
  *
  */
-public class TestArtifactContext
+public class TestArtifactContext implements AutoCloseable
 {
 
     private final TestArtifact testArtifact;
@@ -95,14 +97,22 @@ public class TestArtifactContext
         return repositoryPath;
     }
 
-    public static String id(TestArtifact testArtifact)
-    {
-        return String.format("%s", testArtifact.resource());
-    }
-
     public Path getArtifact()
     {
         return artifactPath;
+    }
+
+    @PreDestroy
+    @Override
+    public void close()
+        throws Exception
+    {
+        Files.deleteIfExists(artifactPath);
+    }
+
+    public static String id(TestArtifact testArtifact)
+    {
+        return String.format("%s", testArtifact.resource());
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
@@ -9,53 +9,20 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
 
 /**
  * @author sbespalov
  *
  */
-public class RepositoryManagementTestExecutionListener
-        implements ParameterResolver, BeforeTestExecutionCallback, AfterTestExecutionCallback
+public class RepositoryManagementTestExecutionListener extends TestRepositoryManagementContextSupport<TestRepository>
 {
 
-    private TestRepositoryManagementContext getTestRepositoryManagementContext()
+    public RepositoryManagementTestExecutionListener()
     {
-        return TestRepositoryManagementApplicationContext.getInstance();
-    }
-
-    @Override
-    public void beforeTestExecution(ExtensionContext context)
-        throws Exception
-    {
-        TestRepositoryManagementApplicationContext.registerExtension(TestRepository.class, context);
-    }
-
-    @Override
-    public void afterTestExecution(ExtensionContext context)
-        throws Exception
-    {
-        TestRepositoryManagementApplicationContext.closeExtension(TestRepository.class, context);
-    }
-
-    @Override
-    public boolean supportsParameter(ParameterContext parameterContext,
-                                     ExtensionContext extensionContext)
-        throws ParameterResolutionException
-    {
-        boolean applying = getTestRepositoryManagementContext().tryToApply(TestRepository.class,
-                                                                                    parameterContext);
-        if (!applying)
-        {
-            getTestRepositoryManagementContext().refresh();
-        }
-
-        return applying;
+        super(TestRepository.class);
     }
 
     @Override
@@ -101,7 +68,7 @@ public class RepositoryManagementTestExecutionListener
         {
             if (target == null)
             {
-                target = ((TestRepositoryContext) getTestRepositoryManagementContext().getTestRepositoryContext(id)).getRepository();
+                target = getTestRepositoryManagementContext().getTestRepositoryContext(id).getRepository();
             }
 
             try

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -15,7 +15,6 @@ import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.ImmutableRepository;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.springframework.core.Ordered;
 
 /**
  * This class manages the resources used within {@link Repository}.
@@ -23,7 +22,7 @@ import org.springframework.core.Ordered;
  * @author sbespalov
  *
  */
-public class TestRepositoryContext implements AutoCloseable, Ordered, Comparable<TestRepositoryContext>
+public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepositoryContext>
 {
 
     private final TestRepository testRepository;
@@ -35,8 +34,6 @@ public class TestRepositoryContext implements AutoCloseable, Ordered, Comparable
     private final RepositoryManagementService repositoryManagementService;
 
     private boolean opened;
-
-    private int order;
 
     public TestRepositoryContext(TestRepository testRepository,
                                  ConfigurationManagementService configurationManagementService,
@@ -124,17 +121,6 @@ public class TestRepositoryContext implements AutoCloseable, Ordered, Comparable
     public int compareTo(TestRepositoryContext o)
     {
         return id(getTestRepository()).compareTo(id(o.getTestRepository()));
-    }
-
-    @Override
-    public int getOrder()
-    {
-        return order;
-    }
-
-    public void setOrder(int order)
-    {
-        this.order = order;
     }
 
     public static String id(TestRepository tr)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -1,5 +1,6 @@
 package org.carlspring.strongbox.testing.storage.repository;
 
+import static org.carlspring.strongbox.testing.artifact.TestArtifactContext.id;
 import static org.carlspring.strongbox.testing.storage.repository.TestRepositoryContext.id;
 
 import java.io.IOException;
@@ -17,6 +18,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.slf4j.Logger;
@@ -44,7 +48,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
 
     private Map<Class<? extends Annotation>, Boolean> extensionsToApply = new HashMap<>();
 
-    private static Map<String, ReentrantLock> testRepositorySync = new ConcurrentSkipListMap<>();
+    private static Map<String, ReentrantLock> idSync = new ConcurrentSkipListMap<>();
 
     public static void registerExtension(Class<? extends Annotation> extensionType,
                                          ExtensionContext context)
@@ -117,6 +121,11 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
         throws BeansException,
         IllegalStateException
     {
+        if (isActive())
+        {
+            return;
+        }
+
         Boolean allApplied = extensionsToApply.values()
                                               .stream()
                                               .filter(applied -> applied)
@@ -127,17 +136,17 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             return;
         }
 
-        lockRepositories();
+        lock();
         super.refresh();
     }
 
-    private void lockRepositories()
+    private void lock()
     {
-        Set<Entry<String, ReentrantLock>> entrySet = testRepositorySync.entrySet();
+        Set<Entry<String, ReentrantLock>> entrySet = idSync.entrySet();
         outer: for (Entry<String, ReentrantLock> entry : entrySet)
         {
-            String testRepositoryId = entry.getKey();
-            if (!Arrays.stream(getBeanDefinitionNames()).anyMatch(n -> n.equals(testRepositoryId)))
+            String resourceId = entry.getKey();
+            if (!Arrays.stream(getBeanDefinitionNames()).anyMatch(n -> n.equals(resourceId)))
             {
                 continue;
             }
@@ -149,27 +158,27 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
                 {
                     if (lock.tryLock() || lock.tryLock(100, TimeUnit.MILLISECONDS))
                     {
-                        logger.info(String.format("Test Repository [%s] locked.", testRepositoryId));
+                        logger.info(String.format("Test resource [%s] locked.", resourceId));
                         continue outer;
                     }
                 }
                 catch (InterruptedException e)
                 {
                     Thread.currentThread().interrupt();
-                    throw new ApplicationContextException(String.format("Failed to lock [%s].", testRepositoryId), e);
+                    throw new ApplicationContextException(String.format("Failed to lock [%s].", resourceId), e);
 
                 }
             }
 
             throw new ApplicationContextException(
-                    String.format("Failed to lock [%s] after [%s] attempts. Consider to use unique repository ID for your test.",
-                                  testRepositoryId,
+                    String.format("Failed to lock [%s] after [%s] attempts. Consider to use unique resource ID for your test.",
+                                  resourceId,
                                   REPOSITORY_LOCK_ATTEMPTS));
 
         }
     }
 
-    private void unlockRepositories()
+    private void unlock()
     {
         Comparator<Entry<String, ReentrantLock>> reversed = new Comparator<Entry<String, ReentrantLock>>()
         {
@@ -182,14 +191,15 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             }
 
         };
-        Set<Entry<String, ReentrantLock>> reversedEntrySet = testRepositorySync.entrySet()
+        Set<Entry<String, ReentrantLock>> reversedEntrySet = idSync.entrySet()
                                                                                .stream()
                                                                                .sorted(reversed)
                                                                                .collect(Collectors.toSet());
+        String[] beanDefinitionNames = getBeanDefinitionNames();
         for (Entry<String, ReentrantLock> entry : reversedEntrySet)
         {
-            String testRepositoryId = entry.getKey();
-            if (!Arrays.stream(getBeanDefinitionNames()).anyMatch(n -> n.equals(testRepositoryId)))
+            String id = entry.getKey();
+            if (!Arrays.stream(beanDefinitionNames).anyMatch(n -> n.equals(id)))
             {
                 continue;
             }
@@ -197,7 +207,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             ReentrantLock lock = entry.getValue();
             lock.unlock();
 
-            logger.info(String.format("Test Repository [%s] unlocked.", testRepositoryId));
+            logger.info(String.format("Test resource [%s] unlocked.", id));
         }
     }
 
@@ -215,7 +225,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             throw new ApplicationContextException("Failed to close context.", e);
         } finally
         {
-            unlockRepositories();
+            unlock();
         }
     }
 
@@ -255,11 +265,24 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
     }
 
     @Override
+    public TestArtifactContext getTestArtifactContext(String id)
+    {
+        return (TestArtifactContext) getBean(id);
+    }
+
+    @Override
     public void register(TestRepository testRepository)
     {
-        testRepositorySync.putIfAbsent(id(testRepository), new ReentrantLock());
-
+        idSync.putIfAbsent(id(testRepository), new ReentrantLock());
         registerBean(id(testRepository), TestRepositoryContext.class, testRepository);
+    }
+
+    @Override
+    public void register(TestArtifact testArtifact,
+                         TestInfo testInfo)
+    {
+        idSync.putIfAbsent(id(testArtifact), new ReentrantLock());
+        registerBean(id(testArtifact), TestArtifactContext.class, testArtifact, testInfo);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -34,7 +34,6 @@ import org.springframework.util.Assert;
 
 /**
  * @author sbespalov
- *
  */
 public class TestRepositoryManagementApplicationContext extends AnnotationConfigApplicationContext
         implements TestRepositoryManagementContext
@@ -223,7 +222,8 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
         catch (IOException e)
         {
             throw new ApplicationContextException("Failed to close context.", e);
-        } finally
+        } 
+        finally
         {
             unlock();
         }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
@@ -3,6 +3,9 @@ package org.carlspring.strongbox.testing.storage.repository;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ParameterContext;
 
 /**
@@ -19,9 +22,14 @@ public interface TestRepositoryManagementContext
 
     public void register(TestRepository testRepository);
 
+    public void register(TestArtifact testArtifact,
+                         TestInfo testInfo);
+
     Collection<TestRepositoryContext> getTestRepositoryContexts();
 
     TestRepositoryContext getTestRepositoryContext(String id);
+    
+    TestArtifactContext getTestArtifactContext(String id);
 
     void close();
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContextSupport.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContextSupport.java
@@ -1,0 +1,62 @@
+package org.carlspring.strongbox.testing.storage.repository;
+
+import java.lang.annotation.Annotation;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * @author sbespalov
+ *
+ * @param <T>
+ */
+public abstract class TestRepositoryManagementContextSupport<T extends Annotation>
+        implements ParameterResolver, BeforeTestExecutionCallback, AfterTestExecutionCallback
+{
+
+    private final Class<T> type;
+
+    public TestRepositoryManagementContextSupport(Class<T> type)
+    {
+        this.type = type;
+    }
+
+    protected TestRepositoryManagementContext getTestRepositoryManagementContext()
+    {
+        return TestRepositoryManagementApplicationContext.getInstance();
+    }
+
+    @Override
+    public void beforeTestExecution(ExtensionContext context)
+        throws Exception
+    {
+        TestRepositoryManagementApplicationContext.registerExtension(type, context);
+    }
+
+    @Override
+    public void afterTestExecution(ExtensionContext context)
+        throws Exception
+    {
+        TestRepositoryManagementApplicationContext.closeExtension(type, context);
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext,
+                                     ExtensionContext extensionContext)
+        throws ParameterResolutionException
+    {
+        boolean applying = getTestRepositoryManagementContext().tryToApply(type,
+                                                                           parameterContext);
+        if (!applying)
+        {
+            getTestRepositoryManagementContext().refresh();
+        }
+
+        return applying;
+    }
+
+}

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyFileSystemProvider.java
@@ -1,0 +1,264 @@
+package org.carlspring.strongbox.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Proxy;
+import java.net.URI;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryStream;
+import java.nio.file.DirectoryStream.Filter;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * This {@link FileSystemProvider} implementation allows to have original
+ * {@link Path} wrapped by {@link Proxy} wihout errors.
+ * 
+ * @author sbespalov
+ *
+ * @see ProxyPathInvocationHandler
+ * @see ProxyPathFileSystem
+ */
+public class ProxyFileSystemProvider extends FileSystemProvider
+{
+
+    private final FileSystemProvider delegate;
+
+    public ProxyFileSystemProvider(FileSystemProvider target)
+    {
+        this.delegate = target;
+    }
+
+    public int hashCode()
+    {
+        return delegate.hashCode();
+    }
+
+    public boolean equals(Object obj)
+    {
+        return delegate.equals(obj);
+    }
+
+    public String getScheme()
+    {
+        return delegate.getScheme();
+    }
+
+    public FileSystem newFileSystem(URI uri,
+                                    Map<String, ?> env)
+        throws IOException
+    {
+        return delegate.newFileSystem(uri, env);
+    }
+
+    public FileSystem getFileSystem(URI uri)
+    {
+        return delegate.getFileSystem(uri);
+    }
+
+    public String toString()
+    {
+        return delegate.toString();
+    }
+
+    public Path getPath(URI uri)
+    {
+        return delegate.getPath(uri);
+    }
+
+    public FileSystem newFileSystem(Path path,
+                                    Map<String, ?> env)
+        throws IOException
+    {
+        return delegate.newFileSystem(unwrap(path), env);
+    }
+
+    public InputStream newInputStream(Path path,
+                                      OpenOption... options)
+        throws IOException
+    {
+        return delegate.newInputStream(unwrap(path), options);
+    }
+
+    public OutputStream newOutputStream(Path path,
+                                        OpenOption... options)
+        throws IOException
+    {
+        return delegate.newOutputStream(unwrap(path), options);
+    }
+
+    public FileChannel newFileChannel(Path path,
+                                      Set<? extends OpenOption> options,
+                                      FileAttribute<?>... attrs)
+        throws IOException
+    {
+        return delegate.newFileChannel(unwrap(path), options, attrs);
+    }
+
+    public AsynchronousFileChannel newAsynchronousFileChannel(Path path,
+                                                              Set<? extends OpenOption> options,
+                                                              ExecutorService executor,
+                                                              FileAttribute<?>... attrs)
+        throws IOException
+    {
+        return delegate.newAsynchronousFileChannel(unwrap(path), options, executor, attrs);
+    }
+
+    public SeekableByteChannel newByteChannel(Path path,
+                                              Set<? extends OpenOption> options,
+                                              FileAttribute<?>... attrs)
+        throws IOException
+    {
+        return delegate.newByteChannel(unwrap(path), options, attrs);
+    }
+
+    public DirectoryStream<Path> newDirectoryStream(Path dir,
+                                                    Filter<? super Path> filter)
+        throws IOException
+    {
+        return delegate.newDirectoryStream(unwrap(dir), filter);
+    }
+
+    public void createDirectory(Path dir,
+                                FileAttribute<?>... attrs)
+        throws IOException
+    {
+        delegate.createDirectory(unwrap(dir), attrs);
+    }
+
+    public void createSymbolicLink(Path link,
+                                   Path target,
+                                   FileAttribute<?>... attrs)
+        throws IOException
+    {
+        delegate.createSymbolicLink(unwrap(link), unwrap(target), attrs);
+    }
+
+    public void createLink(Path link,
+                           Path existing)
+        throws IOException
+    {
+        delegate.createLink(unwrap(link), unwrap(existing));
+    }
+
+    public void delete(Path path)
+        throws IOException
+    {
+        delegate.delete(unwrap(path));
+    }
+
+    public boolean deleteIfExists(Path path)
+        throws IOException
+    {
+        return delegate.deleteIfExists(unwrap(path));
+    }
+
+    public Path readSymbolicLink(Path link)
+        throws IOException
+    {
+        return delegate.readSymbolicLink(unwrap(link));
+    }
+
+    public void copy(Path source,
+                     Path target,
+                     CopyOption... options)
+        throws IOException
+    {
+        delegate.copy(unwrap(source), unwrap(target), options);
+    }
+
+    public void move(Path source,
+                     Path target,
+                     CopyOption... options)
+        throws IOException
+    {
+        delegate.move(unwrap(source), unwrap(target), options);
+    }
+
+    public boolean isSameFile(Path path,
+                              Path path2)
+        throws IOException
+    {
+        return delegate.isSameFile(unwrap(path), unwrap(path2));
+    }
+
+    public boolean isHidden(Path path)
+        throws IOException
+    {
+        return delegate.isHidden(unwrap(path));
+    }
+
+    public FileStore getFileStore(Path path)
+        throws IOException
+    {
+        return delegate.getFileStore(unwrap(path));
+    }
+
+    public void checkAccess(Path path,
+                            AccessMode... modes)
+        throws IOException
+    {
+        delegate.checkAccess(unwrap(path), modes);
+    }
+
+    public <V extends FileAttributeView> V getFileAttributeView(Path path,
+                                                                Class<V> type,
+                                                                LinkOption... options)
+    {
+        return delegate.getFileAttributeView(unwrap(path), type, options);
+    }
+
+    public <A extends BasicFileAttributes> A readAttributes(Path path,
+                                                            Class<A> type,
+                                                            LinkOption... options)
+        throws IOException
+    {
+        return delegate.readAttributes(unwrap(path), type, options);
+    }
+
+    public Map<String, Object> readAttributes(Path path,
+                                              String attributes,
+                                              LinkOption... options)
+        throws IOException
+    {
+        return delegate.readAttributes(unwrap(path), attributes, options);
+    }
+
+    public void setAttribute(Path path,
+                             String attribute,
+                             Object value,
+                             LinkOption... options)
+        throws IOException
+    {
+        delegate.setAttribute(unwrap(path), attribute, value, options);
+    }
+
+    protected Path unwrap(Path path)
+    {
+        if (path == null)
+        {
+            return null;
+        }
+        else if (!Proxy.isProxyClass(path.getClass()))
+        {
+            return path;
+        }
+
+        return ((ProxyPathInvocationHandler) Proxy.getInvocationHandler(path)).getTarget();
+    }
+}

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyPathFileSystem.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyPathFileSystem.java
@@ -1,0 +1,111 @@
+package org.carlspring.strongbox.io;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Set;
+
+/**
+ * This {@link FileSystem} implementation allows to have original
+ * {@link Path} wrapped by {@link Proxy} wihout errors.
+ * 
+ * @author sbespalov
+ *
+ * @see ProxyPathInvocationHandler
+ * @see ProxyFileSystemProvider
+ */
+public class ProxyPathFileSystem extends FileSystem
+{
+
+    private final FileSystem target;
+
+    public ProxyPathFileSystem(FileSystem target)
+    {
+        this.target = target;
+    }
+
+    public int hashCode()
+    {
+        return target.hashCode();
+    }
+
+    public boolean equals(Object obj)
+    {
+        return target.equals(obj);
+    }
+
+    public FileSystemProvider provider()
+    {
+        return new ProxyFileSystemProvider(target.provider());
+    }
+
+    public void close()
+        throws IOException
+    {
+        target.close();
+    }
+
+    public boolean isOpen()
+    {
+        return target.isOpen();
+    }
+
+    public boolean isReadOnly()
+    {
+        return target.isReadOnly();
+    }
+
+    public String getSeparator()
+    {
+        return target.getSeparator();
+    }
+
+    public Iterable<Path> getRootDirectories()
+    {
+        return target.getRootDirectories();
+    }
+
+    public Iterable<FileStore> getFileStores()
+    {
+        return target.getFileStores();
+    }
+
+    public String toString()
+    {
+        return target.toString();
+    }
+
+    public Set<String> supportedFileAttributeViews()
+    {
+        return target.supportedFileAttributeViews();
+    }
+
+    public Path getPath(String first,
+                        String... more)
+    {
+        return target.getPath(first, more);
+    }
+
+    public PathMatcher getPathMatcher(String syntaxAndPattern)
+    {
+        return target.getPathMatcher(syntaxAndPattern);
+    }
+
+    public UserPrincipalLookupService getUserPrincipalLookupService()
+    {
+        return target.getUserPrincipalLookupService();
+    }
+
+    public WatchService newWatchService()
+        throws IOException
+    {
+        return target.newWatchService();
+    }
+
+}

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyPathInvocationHandler.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/io/ProxyPathInvocationHandler.java
@@ -1,0 +1,46 @@
+package org.carlspring.strongbox.io;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+
+/**
+ * This {@link InvocationHandler} should be used to avoid errors when
+ * {@link Path} wrapped by {@link Proxy}.
+ * 
+ * @author sbespalov
+ * 
+ * @see ProxyFileSystemProvider
+ * @see ProxyPathFileSystem
+ *
+ */
+public abstract class ProxyPathInvocationHandler implements InvocationHandler
+{
+
+    public abstract Path getTarget();
+
+    @Override
+    public Object invoke(Object proxy,
+                         Method method,
+                         Object[] args)
+        throws Throwable
+    {
+
+        if ("getFileSystem".equals(method.getName()))
+        {
+            return new ProxyPathFileSystem(getTarget().getFileSystem());
+        }
+
+        try
+        {
+            return method.invoke(getTarget(), args);
+        }
+        catch (InvocationTargetException e)
+        {
+            throw e.getTargetException();
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #1084 

How to use:
```
@ExtendWith({ RepositoryManagementTestExecutionListener.class,
              ArtifactManagementTestExecutionListener.class })
@Test
public void testArtifact(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME,
                                         repository = "r1", storage = "storage0")
                         Repository r1,
                         @TestArtifact(resource = "org/carlspring/test/artifact1.ext",
                                       generator = NullArtifactGenerator.class)
                         Path standaloneArtifact,
                         @TestArtifact(storage = "storage0",
                                       repository = "r1",
                                       resource = "org/carlspring/test/artifact2.ext",
                                       generator = NullArtifactGenerator.class)
                         Path repositoryArtifact)
{
    assertTrue(Files.exists(standaloneArtifact));
    assertEquals(1024L, Files.size(standaloneArtifact));
}
```