### PR TITLE
#1153: Moved NugetODataFilter.g4 under org/carlspring/strongbox/nuget/filter to improve compatibility with eclipse

### DIFF
--- a/strongbox-aql/pom.xml
+++ b/strongbox-aql/pom.xml
@@ -102,13 +102,8 @@
                             <goal>antlr4</goal>
                         </goals>
                         <configuration>
-                            <arguments>
-                                <argument>-package</argument>
-                                <argument>org.carlspring.strongbox.aql.grammar</argument>
-                            </arguments>
                             <sourceDirectory>${project.build.directory}/antlr4</sourceDirectory>
                             <visitor>true</visitor>
-                            <outputDirectory>${project.build.directory}/generated-sources/antlr4/org/carlspring/strongbox/aql/grammar</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/strongbox-aql/src/main/groovy/aql-dynamic-grammar.groovy
+++ b/strongbox-aql/src/main/groovy/aql-dynamic-grammar.groovy
@@ -10,9 +10,9 @@ layoutMap.each{ k, v -> println "${v.getArtifactCoordinates()}" }
 JtwigTemplate template = JtwigTemplate.fileTemplate("$project.basedir/src/main/twig/AQL.g4.twig")
 JtwigModel model = JtwigModel.newModel().with("layoutMap", layoutMap)
 
-new File("$project.basedir/target/antlr4").mkdirs()
+new File("$project.basedir/target/antlr4/org/carlspring/strongbox/aql/grammar").mkdirs()
 
-def out = new File("$project.basedir/target/antlr4","AQL.g4").newOutputStream()
+def out = new File("$project.basedir/target/antlr4/org/carlspring/strongbox/aql/grammar","AQL.g4").newOutputStream()
 try 
 {
     template.render(model, out)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
@@ -175,7 +175,6 @@
                         </goals>
                         <configuration>
                             <visitor>true</visitor>
-                            <outputDirectory>${project.build.directory}/generated-sources/antlr4/org/carlspring/strongbox/nuget/filter</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/antlr4/org/carlspring/strongbox/nuget/filter/NugetODataFilter.g4
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/antlr4/org/carlspring/strongbox/nuget/filter/NugetODataFilter.g4
@@ -1,9 +1,5 @@
 grammar NugetODataFilter;
 
-@header {
-    package org.carlspring.strongbox.nuget.filter;
-}
-
 filter
 :
     filterExp


### PR DESCRIPTION
This PR fixes #1153 which is a step towards making the docs for #1149 less obscure.

Basically the idea is to have the ANTLR g4 files under the directory specifying their package. See Default Directories section [here](https://www.antlr.org/api/maven-plugin/latest/)