### PR TITLE
issues/1145: MavenArtifactGenerator implements ArtifactGenerator interface

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
@@ -172,6 +172,12 @@ public class ConfigurationManagementServiceImpl
     {
         modifyInLock(configuration -> configuration.addStorage(storage));
     }
+    
+    @Override
+    public void addStorageIfNotExists(MutableStorage storage)
+    {
+        modifyInLock(configuration -> configuration.addStorageIfNotExist(storage));
+    }
 
     @Override
     public void removeStorage(String storageId)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
@@ -68,7 +68,7 @@ public class RepositoryManagementTest
     @RepeatedTest(20)
     public void testRepositoryDirect(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repository = "r1", storage = "storage0") Repository r1,
                                      @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repository = "r2", storage = "storage0") Repository r2,
-                                     @TestArtifact(resource = "org/carlspring/test/artifact1.ext", generator = NullArtifactGenerator.class) Path standaloneArtifact,
+                                     @TestArtifact(resource = "artifact1.ext", generator = NullArtifactGenerator.class) Path standaloneArtifact,
                                      @TestArtifact(repository = "r2", storage = "storage0", resource = "org/carlspring/test/artifact2.ext", generator = NullArtifactGenerator.class) Path repositoryArtifact,
                                      TestInfo testInfo)
         throws IOException

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -17,6 +17,8 @@ import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.services.ArtifactManagementService;
 import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cglib.proxy.UndeclaredThrowableException;
 
 /**
@@ -25,6 +27,8 @@ import org.springframework.cglib.proxy.UndeclaredThrowableException;
  */
 public class TestArtifactContext implements AutoCloseable
 {
+    
+    private static final Logger logger = LoggerFactory.getLogger(TestArtifactContext.class);
 
     private final TestArtifact testArtifact;
     private final PropertiesBooter propertiesBooter;
@@ -52,6 +56,7 @@ public class TestArtifactContext implements AutoCloseable
     private Path createArtifact()
         throws IOException
     {
+        logger.info(String.format("Create [%s] resource [%s] ", TestArtifact.class.getSimpleName(), id(testArtifact)));
         Class<? extends ArtifactGenerator> generatorClass = testArtifact.generator();
 
         Path vaultDirectoryPath = Paths.get(propertiesBooter.getVaultDirectory(), ".temp",

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -15,6 +15,9 @@ import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.ImmutableRepository;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class manages the resources used within {@link Repository}.
@@ -25,6 +28,8 @@ import org.carlspring.strongbox.storage.repository.Repository;
 public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepositoryContext>
 {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestRepositoryContext.class);
+    
     private final TestRepository testRepository;
 
     private final ConfigurationManagementService configurationManagementService;
@@ -78,7 +83,7 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         throws IOException,
         RepositoryManagementStrategyException
     {
-
+        logger.info(String.format("Create [%s] with id [%s] ", TestRepository.class.getSimpleName(), id(testRepository)));
         Storage storage = configurationManagementService.getConfiguration().getStorage(testRepository.storage());
         Objects.requireNonNull(storage, String.format("Storage [%s] not found.", testRepository.storage()));
 
@@ -125,7 +130,12 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
 
     public static String id(TestRepository tr)
     {
-        return String.format("%s/%s", tr.storage(), tr.repository());
+        return id(tr.storage(), tr.repository());
     }
 
+    public static String id(String storageId, String repositoryId)
+    {
+        return String.format("%s/%s", storageId, repositoryId);
+    }
+    
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -11,12 +11,10 @@ import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
 import org.carlspring.strongbox.services.ConfigurationManagementService;
 import org.carlspring.strongbox.services.RepositoryManagementService;
-import org.carlspring.strongbox.storage.MutableStorage;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.ImmutableRepository;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -128,7 +128,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
 
         Boolean allApplied = extensionsToApply.values()
                                               .stream()
-                                              .allMatch(applied -> true == applied);
+                                              .allMatch(applied -> applied);
         if (!Boolean.TRUE.equals(allApplied))
         {
             return;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -128,9 +128,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
 
         Boolean allApplied = extensionsToApply.values()
                                               .stream()
-                                              .filter(applied -> applied)
-                                              .findFirst()
-                                              .orElse(false);
+                                              .allMatch(applied -> true == applied);
         if (!Boolean.TRUE.equals(allApplied))
         {
             return;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -40,7 +41,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
         implements TestRepositoryManagementContext
 {
 
-    private static final int REPOSITORY_LOCK_ATTEMPTS = 10;
+    private static final int REPOSITORY_LOCK_ATTEMPTS = 30;
 
     private static final Logger logger = LoggerFactory.getLogger(TestRepositoryManagementApplicationContext.class);
 
@@ -181,7 +182,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             }
 
             ReentrantLock lock = entry.getValue();
-            for (int i = 0; i < 10; i++)
+            for (int i = 0; i < REPOSITORY_LOCK_ATTEMPTS; i++)
             {
                 try
                 {
@@ -313,6 +314,13 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
     {
         idSync.putIfAbsent(id(testArtifact), new ReentrantLock());
         registerBean(id(testArtifact), TestArtifactContext.class, testArtifact, testInfo);
+        if (testArtifact.repository().isEmpty())
+        {
+            return;
+        }
+        
+        BeanDefinition beanDefinition = getBeanDefinition(id(testArtifact));
+        beanDefinition.setDependsOn(id(testArtifact.storage(), testArtifact.repository()));
     }
 
 }

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/configuration/MutableConfiguration.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/configuration/MutableConfiguration.java
@@ -162,6 +162,18 @@ public class MutableConfiguration
 
         storages.put(key, storage);
     }
+    
+    public void addStorageIfNotExist(MutableStorage storage)
+    {
+        String key = storage.getId();
+        if (key == null || key.isEmpty())
+        {
+            throw new IllegalArgumentException("Null keys are not supported!");
+        }
+
+        storages.put(key, storage);
+    }
+
 
     public MutableStorage getStorage(String storageId)
     {

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/services/ConfigurationManagementService.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/services/ConfigurationManagementService.java
@@ -35,6 +35,8 @@ public interface ConfigurationManagementService
                                MutableProxyConfiguration proxyConfiguration);
 
     void saveStorage(MutableStorage storage);
+    
+    void addStorageIfNotExists(MutableStorage storage);
 
     void removeStorage(String storageId);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -7,8 +7,10 @@ import org.carlspring.commons.io.RandomInputStream;
 import org.carlspring.maven.commons.util.ArtifactUtils;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
@@ -28,15 +30,14 @@ import org.slf4j.LoggerFactory;
 /**
  * @author mtodorov
  */
-public class MavenArtifactGenerator
+public class MavenArtifactGenerator implements ArtifactGenerator
 {
 
     private static final Logger logger = LoggerFactory.getLogger(MavenArtifactGenerator.class);
 
     public static final String PACKAGING_JAR = "jar";
 
-    protected String basedir;
-
+    protected Path basedir;
 
     public MavenArtifactGenerator()
     {
@@ -44,12 +45,35 @@ public class MavenArtifactGenerator
 
     public MavenArtifactGenerator(String basedir)
     {
-        this.basedir = basedir;
+        this.basedir = Paths.get(basedir);
     }
 
     public MavenArtifactGenerator(File basedir)
     {
-        this.basedir = basedir.getAbsolutePath();
+        this.basedir = basedir.toPath();
+    }
+
+    public MavenArtifactGenerator(Path basedir)
+    {
+        this.basedir = basedir;
+    }
+    
+    @Override
+    public Path generateArtifact(URI uri,
+                                 int size)
+        throws IOException
+    {
+        Artifact artifact = ArtifactUtils.convertPathToArtifact(uri.toString());
+        try
+        {
+            generate(artifact);
+        }
+        catch (NoSuchAlgorithmException|XmlPullParserException e)
+        {
+            throw new IOException(e);
+        }
+        
+        return basedir.resolve(ArtifactUtils.convertArtifactToPath(artifact));
     }
 
     public void generate(String gavtc, String packaging, String... versions)
@@ -109,7 +133,7 @@ public class MavenArtifactGenerator
             throws NoSuchAlgorithmException,
                    IOException
     {
-        File artifactFile = new File(basedir, ArtifactUtils.convertArtifactToPath(artifact));
+        File artifactFile = basedir.resolve(ArtifactUtils.convertArtifactToPath(artifact)).toFile();
 
         // Make sure the artifact's parent directory exists before writing the model.
         //noinspection ResultOfMethodCallIgnored
@@ -139,7 +163,7 @@ public class MavenArtifactGenerator
 
         try
         {
-            metadataFile = new File(basedir, metadataPath);
+            metadataFile = basedir.resolve(metadataPath).toFile();
             
             if (metadataFile.exists())
             {
@@ -169,7 +193,7 @@ public class MavenArtifactGenerator
     private void addMavenPomFile(Artifact artifact, ZipOutputStream zos) throws IOException
     {
         final Artifact pomArtifact = ArtifactUtils.getPOMArtifact(artifact);
-        File pomFile = new File(basedir, ArtifactUtils.convertArtifactToPath(pomArtifact));
+        File pomFile = basedir.resolve(ArtifactUtils.convertArtifactToPath(pomArtifact)).toFile();
 
         ZipEntry ze = new ZipEntry("META-INF/maven/" +
                                    artifact.getGroupId() + "/" +
@@ -248,7 +272,7 @@ public class MavenArtifactGenerator
                    NoSuchAlgorithmException
     {
         final Artifact pomArtifact = ArtifactUtils.getPOMArtifact(artifact);
-        File pomFile = new File(basedir, ArtifactUtils.convertArtifactToPath(pomArtifact));
+        File pomFile = basedir.resolve(ArtifactUtils.convertArtifactToPath(pomArtifact)).toFile();
 
         // Make sure the artifact's parent directory exists before writing the model.
         //noinspection ResultOfMethodCallIgnored
@@ -308,12 +332,7 @@ public class MavenArtifactGenerator
 
     public String getBasedir()
     {
-        return basedir;
-    }
-
-    public void setBasedir(String basedir)
-    {
-        this.basedir = basedir;
+        return basedir.toAbsolutePath().toString();
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenTestCaseWithArtifactGeneration.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenTestCaseWithArtifactGeneration.java
@@ -153,7 +153,7 @@ public class MavenTestCaseWithArtifactGeneration
             protected OutputStream newOutputStream(File artifactFile)
                 throws IOException
             {
-                Path basePath = Paths.get(basedir);
+                Path basePath = basedir;
                 Path artifactPath = artifactFile.toPath();
 
                 String path = FilenameUtils.separatorsToUnix(basePath.relativize(artifactPath).toString());

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
@@ -81,7 +81,8 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
                                                 @TestArtifact(storage = S1, repository = R1, resource = A1, generator = MavenArtifactGenerator.class) Path artifact1,
                                                 @TestArtifact(storage = S1, repository = R1, resource = A2, generator = MavenArtifactGenerator.class) Path artifact2,
                                                 @TestArtifact(storage = S1, repository = R1, resource = A3, generator = MavenArtifactGenerator.class) Path artifact3)
-            throws Exception {
+            throws Exception
+    {
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("query", "layout:maven+groupId:org.carlspring.strongbox.*")
                 .when()
@@ -106,4 +107,5 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
                .statusCode(HttpStatus.BAD_REQUEST.value())
                .body("error", Matchers.equalTo("Unknown layout [unknown-layout]."));
     }
+    
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
@@ -4,7 +4,6 @@ import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 
 import java.nio.file.Path;
 
-import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.rest.common.MavenRestAssuredBaseTest;
@@ -21,27 +20,27 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
-
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates.LAYOUT_NAME;
 /**
  * @author sbespalov
  *
  */
 @IntegrationTest
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD)
 public class AqlControllerTest extends MavenRestAssuredBaseTest
 {
 
-    private static final String ARTIFACT_TRHEE = "org/carlspring/strongbox/searches/test-project/1.0.11.3.2/test-project-1.0.11.3.2.jar";
+    private static final String A3 = "org/carlspring/strongbox/searches/test-project/1.0.11.3.2/test-project-1.0.11.3.2.jar";
 
-    private static final String ARTIFACT_TWO = "org/carlspring/strongbox/searches/test-project/1.0.11.3.1/test-project-1.0.11.3.1.jar";
+    private static final String A2 = "org/carlspring/strongbox/searches/test-project/1.0.11.3.1/test-project-1.0.11.3.1.jar";
 
-    private static final String ARTIFACT_ONE = "org/carlspring/strongbox/searches/test-project/1.0.11.3/test-project-1.0.11.3.jar";
+    private static final String A1 = "org/carlspring/strongbox/searches/test-project/1.0.11.3/test-project-1.0.11.3.jar";
 
-    private static final String STORAGE_SC_TEST = "storage-sc-test";
+    private static final String S1 = "storage-sc-test";
 
-    private static final String REPOSITORY_RELEASES = "sc-releases-search";
-
+    private static final String R1 = "sc-releases-search";
+    
     @Override
     @BeforeEach
     public void init()
@@ -49,21 +48,21 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
     {
         super.init();
 
-        createStorage(STORAGE_SC_TEST);
+        createStorage(S1);
     }
 
     @Test
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
-    public void testSearchExcludeVersion(@TestRepository(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, layout = MavenArtifactCoordinates.LAYOUT_NAME) Repository repository,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_ONE, generator = MavenArtifactGenerator.class) Path artifact1,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TWO, generator = MavenArtifactGenerator.class) Path artifact2,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TRHEE, generator = MavenArtifactGenerator.class) Path artifact3)
+    public void testSearchExcludeVersion(@TestRepository(storage = S1, repository = R1, layout = LAYOUT_NAME) Repository repository,
+                                         @TestArtifact(storage = S1, repository = R1, resource = A1, generator = MavenArtifactGenerator.class) Path artifact1,
+                                         @TestArtifact(storage = S1, repository = R1, resource = A2, generator = MavenArtifactGenerator.class) Path artifact2,
+                                         @TestArtifact(storage = S1, repository = R1, resource = A3, generator = MavenArtifactGenerator.class) Path artifact3)
         throws Exception
     {
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .queryParam("query",
                            String.format("storage:%s+repository:%s+groupId:org.carlspring.strongbox.searches+!version:1.0.11.3.1",
-                                         STORAGE_SC_TEST, REPOSITORY_RELEASES))
+                                         S1, R1))
                .when()
                .get(getContextBaseUrl() + "/api/aql")
                .peek()
@@ -80,7 +79,7 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                .queryParam("query",
                            String.format("storage:%s+repository:%s+groupId:org.carlspring.strongbox.searches-version:1.0.11.3.1",
-                                         STORAGE_SC_TEST, REPOSITORY_RELEASES))
+                                         S1, R1))
                .when()
                .get(getContextBaseUrl() + "/api/aql")
                .then()
@@ -90,10 +89,10 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
 
     @Test
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
-    public void testSearchValidMavenCoordinates(@TestRepository(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, layout = MavenArtifactCoordinates.LAYOUT_NAME) Repository repository,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_ONE, generator = MavenArtifactGenerator.class) Path artifact1,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TWO, generator = MavenArtifactGenerator.class) Path artifact2,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TRHEE, generator = MavenArtifactGenerator.class) Path artifact3)
+    public void testSearchValidMavenCoordinates(@TestRepository(storage = S1, repository = R1, layout = LAYOUT_NAME) Repository repository,
+                                                @TestArtifact(storage = S1, repository = R1, resource = A1, generator = MavenArtifactGenerator.class) Path artifact1,
+                                                @TestArtifact(storage = S1, repository = R1, resource = A2, generator = MavenArtifactGenerator.class) Path artifact2,
+                                                @TestArtifact(storage = S1, repository = R1, resource = A3, generator = MavenArtifactGenerator.class) Path artifact3)
             throws Exception {
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("query", "layout:maven+groupId:org.carlspring.strongbox.*")

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
@@ -17,16 +17,26 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author sbespalov
  *
  */
 @IntegrationTest
+@Execution(CONCURRENT)
 public class AqlControllerTest extends MavenRestAssuredBaseTest
 {
+
+    private static final String ARTIFACT_TRHEE = "org/carlspring/strongbox/searches/test-project/1.0.11.3.2/test-project-1.0.11.3.2.jar";
+
+    private static final String ARTIFACT_TWO = "org/carlspring/strongbox/searches/test-project/1.0.11.3.1/test-project-1.0.11.3.1.jar";
+
+    private static final String ARTIFACT_ONE = "org/carlspring/strongbox/searches/test-project/1.0.11.3/test-project-1.0.11.3.jar";
 
     private static final String STORAGE_SC_TEST = "storage-sc-test";
 
@@ -45,9 +55,9 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
     @Test
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
     public void testSearchExcludeVersion(@TestRepository(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, layout = MavenArtifactCoordinates.LAYOUT_NAME) Repository repository,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3/test-project-1.0.11.3.jar", generator = MavenArtifactGenerator.class) Path artifact1,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3.1/test-project-1.0.11.3.1.jar", generator = MavenArtifactGenerator.class) Path artifact2,
-                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3.2/test-project-1.0.11.3.2.jar", generator = MavenArtifactGenerator.class) Path artifact3)
+                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_ONE, generator = MavenArtifactGenerator.class) Path artifact1,
+                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TWO, generator = MavenArtifactGenerator.class) Path artifact2,
+                                         @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TRHEE, generator = MavenArtifactGenerator.class) Path artifact3)
         throws Exception
     {
         given().accept(MediaType.APPLICATION_JSON_VALUE)
@@ -81,9 +91,9 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
     @Test
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
     public void testSearchValidMavenCoordinates(@TestRepository(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, layout = MavenArtifactCoordinates.LAYOUT_NAME) Repository repository,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3/test-project-1.0.11.3.jar", generator = MavenArtifactGenerator.class) Path artifact1,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3.1/test-project-1.0.11.3.1.jar", generator = MavenArtifactGenerator.class) Path artifact2,
-                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = "org/carlspring/strongbox/searches/test-project/1.0.11.3.2/test-project-1.0.11.3.2.jar", generator = MavenArtifactGenerator.class) Path artifact3)
+                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_ONE, generator = MavenArtifactGenerator.class) Path artifact1,
+                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TWO, generator = MavenArtifactGenerator.class) Path artifact2,
+                                                @TestArtifact(storage = STORAGE_SC_TEST, repository = REPOSITORY_RELEASES, resource = ARTIFACT_TRHEE, generator = MavenArtifactGenerator.class) Path artifact3)
             throws Exception {
         given().accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("query", "layout:maven+groupId:org.carlspring.strongbox.*")

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
@@ -2,7 +2,7 @@ package org.carlspring.strongbox.controllers.aql;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates.LAYOUT_NAME;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.nio.file.Path;
 
@@ -25,7 +25,7 @@ import org.springframework.http.MediaType;
  *
  */
 @IntegrationTest
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD)
 public class AqlControllerTest extends MavenRestAssuredBaseTest
 {
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/aql/AqlControllerTest.java
@@ -1,6 +1,8 @@
 package org.carlspring.strongbox.controllers.aql;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates.LAYOUT_NAME;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 import java.nio.file.Path;
 
@@ -13,21 +15,17 @@ import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
-import static org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates.LAYOUT_NAME;
 /**
  * @author sbespalov
  *
  */
 @IntegrationTest
-@Execution(SAME_THREAD)
+@Execution(CONCURRENT)
 public class AqlControllerTest extends MavenRestAssuredBaseTest
 {
 
@@ -41,16 +39,6 @@ public class AqlControllerTest extends MavenRestAssuredBaseTest
 
     private static final String R1 = "sc-releases-search";
     
-    @Override
-    @BeforeEach
-    public void init()
-        throws Exception
-    {
-        super.init();
-
-        createStorage(S1);
-    }
-
     @Test
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
     public void testSearchExcludeVersion(@TestRepository(storage = S1, repository = R1, layout = LAYOUT_NAME) Repository repository,


### PR DESCRIPTION
Partial fix for #1145 
- `MavenArtifactGenerator` implements `ArtifactGenerator` interface
- `AqlControllerTest` reworked to use `TestArtifact` annotations
- `TestArtifact` annotation logic fixed