### PR TITLE
Issue 1141: ParallelDownloadRemoteArtifactTest is not idempotent

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/RetryDownloadArtifactTestBase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/RetryDownloadArtifactTestBase.java
@@ -79,7 +79,7 @@ public abstract class RetryDownloadArtifactTestBase
 
     protected String getVaultDirectoryVersionPath()
     {
-        return "storages/storage-common-proxies/maven-central/" + getGroupId().replaceAll(".", "/") + "/" +
+        return "storages/storage-common-proxies/maven-central/" + getGroupId().replaceAll("\\.", "/") + "/" +
                getArtifactId() + "/" + getArtifactVersion();
     }
 


### PR DESCRIPTION
- The cleanup method is calling getVaultDirectoryVersionPath, which intends to replace "."
  in the artifact name with "/" to be able to find the location on disk. However replaceAll
  takes a regular expression and "." is interpreted as any character, so all characters in
  groupId were being replaced by "/" yielding a wrong path. The solution is to escape "\\.".