### PR TITLE
Issues/1219: TestRepository.Group annotation implemented

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/ConfigurationManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/ConfigurationManager.java
@@ -34,21 +34,6 @@ public class ConfigurationManager
         return getConfiguration().getStorage(storageId).getRepository(repositoryId);
     }
 
-    public String getStorageId(Storage storage,
-                               String storageAndRepositoryId)
-    {
-        String[] storageAndRepositoryIdTokens = storageAndRepositoryId.split(":");
-
-        return storageAndRepositoryIdTokens.length == 2 ? storageAndRepositoryIdTokens[0] : storage.getId();
-    }
-
-    public String getRepositoryId(String storageAndRepositoryId)
-    {
-        String[] storageAndRepositoryIdTokens = storageAndRepositoryId.split(":");
-
-        return storageAndRepositoryIdTokens[storageAndRepositoryIdTokens.length < 2 ? 0 : 1];
-    }
-
     public Configuration getConfiguration()
     {
         return configurationService.getConfiguration();

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
@@ -19,6 +19,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
 import org.carlspring.strongbox.data.criteria.OQueryTemplate;
 import org.carlspring.strongbox.data.criteria.Paginator;
 import org.carlspring.strongbox.data.criteria.Predicate;
@@ -34,7 +35,6 @@ import org.carlspring.strongbox.providers.repository.group.GroupRepositorySetCol
 import org.carlspring.strongbox.services.support.ArtifactRoutingRulesChecker;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -99,8 +99,8 @@ public class GroupRepositoryProvider extends AbstractRepositoryProvider
         
         for (String storageAndRepositoryId : groupRepository.getGroupRepositories())
         {
-            String sId = configurationManager.getStorageId(storage, storageAndRepositoryId);
-            String rId = configurationManager.getRepositoryId(storageAndRepositoryId);
+            String sId = ConfigurationUtils.getStorageId(storage.getId(), storageAndRepositoryId);
+            String rId = ConfigurationUtils.getRepositoryId(storageAndRepositoryId);
 
             Repository subRepository = getConfiguration().getStorage(sId).getRepository(rId);
             if (!subRepository.isInService())

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
@@ -101,7 +101,7 @@ public class GroupRepositoryArtifactExistenceChecker
                                 final String maybeStorageAndRepositoryId)
     {
         return ConfigurationUtils.getStorageId(groupRepository.getStorage().getId(),
-                                                 maybeStorageAndRepositoryId);
+                                               maybeStorageAndRepositoryId);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositoryArtifactExistenceChecker.java
@@ -1,19 +1,20 @@
 package org.carlspring.strongbox.providers.repository.group;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.providers.layout.LayoutProvider;
 import org.carlspring.strongbox.providers.layout.LayoutProviderRegistry;
 import org.carlspring.strongbox.storage.repository.Repository;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.springframework.stereotype.Component;
 
 /**
@@ -93,13 +94,13 @@ public class GroupRepositoryArtifactExistenceChecker
 
     private String getRepositoryId(final String maybeStorageAndRepositoryId)
     {
-        return configurationManager.getRepositoryId(maybeStorageAndRepositoryId);
+        return ConfigurationUtils.getRepositoryId(maybeStorageAndRepositoryId);
     }
 
     private String getStorageId(final Repository groupRepository,
                                 final String maybeStorageAndRepositoryId)
     {
-        return configurationManager.getStorageId(groupRepository.getStorage(),
+        return ConfigurationUtils.getStorageId(groupRepository.getStorage().getId(),
                                                  maybeStorageAndRepositoryId);
     }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositorySetCollector.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/group/GroupRepositorySetCollector.java
@@ -1,6 +1,7 @@
 package org.carlspring.strongbox.providers.repository.group;
 
 import org.carlspring.strongbox.configuration.ConfigurationManager;
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
 
@@ -62,8 +63,8 @@ public class GroupRepositorySetCollector
     private Repository getRepository(Storage storage,
                                      String id)
     {
-        String sId = configurationManager.getStorageId(storage, id);
-        String rId = configurationManager.getRepositoryId(id);
+        String sId = ConfigurationUtils.getStorageId(storage.getId(), id);
+        String rId = ConfigurationUtils.getRepositoryId(id);
 
         return configurationManager.getConfiguration().getStorage(sId).getRepository(rId);
     }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -281,12 +281,13 @@ public class TestArtifactContext implements AutoCloseable
 
     public static String id(TestArtifact testArtifact)
     {
+        String format = "%s/%s/%s";
         if (!testArtifact.resource().trim().isEmpty())
         {
-            return testArtifact.resource();
+            return String.format(format, testArtifact.storage(), testArtifact.repository(), testArtifact.resource());
         }
         
-        return testArtifact.id();
+        return String.format(format, testArtifact.storage(), testArtifact.repository(), testArtifact.id());
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 
 import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -34,10 +35,11 @@ public class RepositoryManagementTestExecutionListener extends TestRepositoryMan
     {
         Parameter parameter = parameterContext.getParameter();
         TestRepository testRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, TestRepository.class);
-        RemoteRepository remoteRepository = parameter.getAnnotation(RemoteRepository.class);
+        RemoteRepository remoteRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, RemoteRepository.class);
+        GroupRepository groupRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, GroupRepository.class);
         
         TestRepositoryManagementContext testApplicationContext = getTestRepositoryManagementContext();
-        testApplicationContext.register(testRepository, remoteRepository);
+        testApplicationContext.register(testRepository, remoteRepository, groupRepository);
         testApplicationContext.refresh();
 
         return Proxy.newProxyInstance(RepositoryManagementTestExecutionListener.class.getClassLoader(),

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
@@ -9,8 +9,8 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Proxy;
 
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -35,8 +35,8 @@ public class RepositoryManagementTestExecutionListener extends TestRepositoryMan
     {
         Parameter parameter = parameterContext.getParameter();
         TestRepository testRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, TestRepository.class);
-        RemoteRepository remoteRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, RemoteRepository.class);
-        GroupRepository groupRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, GroupRepository.class);
+        Remote remoteRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, Remote.class);
+        Group groupRepository = AnnotatedElementUtils.findMergedAnnotation(parameter, Group.class);
         
         TestRepositoryManagementContext testApplicationContext = getTestRepositoryManagementContext();
         testApplicationContext.register(testRepository, remoteRepository, groupRepository);

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
@@ -10,6 +10,8 @@ import java.net.URL;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.storage.routing.RoutingRuleTypeEnum;
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * This annotation provide ability to inject {@link Repository} instance as test
@@ -75,7 +77,7 @@ public @interface TestRepository
     @Target(ElementType.PARAMETER)
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
-    public static @interface RemoteRepository
+    public static @interface Remote
     {
 
         /**
@@ -94,14 +96,40 @@ public @interface TestRepository
     @Target(ElementType.PARAMETER)
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
-    public static @interface GroupRepository
+    public static @interface Group
     {
 
+
+        /**
+         * Alias for `repositories`.
+         */
+        @AliasFor(attribute = "repositories")
+        String[] value();
+        
         /**
          * Group member repositories list.
+         */        
+        String[] repositories();
+
+        /**
+         * Routing rules.
          */
-        String[] value();
+        Rule[] rules() default {};
+        
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        public static @interface Rule
+        {
+
+            String[] repositories();
+            
+            String pattern() default "*";
+            
+            RoutingRuleTypeEnum type() default RoutingRuleTypeEnum.ACCEPT;
+
+        }
 
     }
-    
+
+
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
@@ -104,12 +104,13 @@ public @interface TestRepository
          * Alias for `repositories`.
          */
         @AliasFor(attribute = "repositories")
-        String[] value();
+        String[] value() default {};
         
         /**
          * Group member repositories list.
-         */        
-        String[] repositories();
+         */
+        @AliasFor(attribute = "value")
+        String[] repositories() default {};
 
         /**
          * Routing rules.

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
@@ -42,7 +42,7 @@ public @interface TestRepository
     /**
      * {@link Repository} ID.
      */
-    String repository();
+    String repository() default "releases";
 
     /**
      * {@link RepositoryPolicyEnum}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepository.java
@@ -85,4 +85,23 @@ public @interface TestRepository
 
     }
 
+    /**
+     * Group Repository configuration support.
+     * 
+     * @author sbespalov
+     *
+     */
+    @Target(ElementType.PARAMETER)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    public static @interface GroupRepository
+    {
+
+        /**
+         * Group member repositories list.
+         */
+        String[] value();
+
+    }
+    
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -142,7 +142,7 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         });
         Optional.ofNullable(groupRepository).ifPresent(g -> {
             repository.setType(RepositoryTypeEnum.GROUP.getType());
-            repository.getGroupRepositories().addAll(Arrays.asList(groupRepository.value()));
+            repository.getGroupRepositories().addAll(Arrays.asList(groupRepository.repositories()));
             
             Arrays.stream(groupRepository.rules()).forEach((rule) -> {
                 MutableRoutingRule routingRule = MutableRoutingRule.create(testRepository.storage(),

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -21,8 +21,8 @@ import java.util.stream.Collectors;
 
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -305,7 +305,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
     }
 
     @Override
-    public void register(TestRepository testRepository, RemoteRepository remoteRepository, GroupRepository groupRepository)
+    public void register(TestRepository testRepository, Remote remoteRepository, Group groupRepository)
     {
         idSync.putIfAbsent(id(testRepository), new ReentrantLock());
         registerBean(id(testRepository), TestRepositoryContext.class, testRepository, remoteRepository, groupRepository);

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -304,10 +305,10 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
     }
 
     @Override
-    public void register(TestRepository testRepository, RemoteRepository remoteRepository)
+    public void register(TestRepository testRepository, RemoteRepository remoteRepository, GroupRepository groupRepository)
     {
         idSync.putIfAbsent(id(testRepository), new ReentrantLock());
-        registerBean(id(testRepository), TestRepositoryContext.class, testRepository, remoteRepository);
+        registerBean(id(testRepository), TestRepositoryContext.class, testRepository, remoteRepository, groupRepository);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
@@ -305,10 +306,22 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
     }
 
     @Override
-    public void register(TestRepository testRepository, Remote remoteRepository, Group groupRepository)
+    public void register(TestRepository testRepository,
+                         Remote remoteRepository,
+                         Group groupRepository)
     {
         idSync.putIfAbsent(id(testRepository), new ReentrantLock());
         registerBean(id(testRepository), TestRepositoryContext.class, testRepository, remoteRepository, groupRepository);
+        
+        if (groupRepository == null)
+        {
+            return;
+        }
+        
+        Arrays.stream(groupRepository.repositories()).forEach(r -> {
+            BeanDefinition beanDefinition = getBeanDefinition(id(ConfigurationUtils.getStorageId(testRepository.storage(), r), ConfigurationUtils.getRepositoryId(r)));
+            beanDefinition.setDependsOn(id(testRepository));
+        });
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
@@ -23,7 +23,9 @@ public interface TestRepositoryManagementContext
 
     public void refresh();
 
-    public void register(TestRepository testRepository, Remote remoteRepository, Group groupRepository);
+    public void register(TestRepository testRepository,
+                         Remote remoteRepository,
+                         Group groupRepository);
 
     public void register(TestArtifact testArtifact,
                          Map<String, Object> attributesMap,

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
@@ -6,8 +6,8 @@ import java.util.Map;
 
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ParameterContext;
 
@@ -23,7 +23,7 @@ public interface TestRepositoryManagementContext
 
     public void refresh();
 
-    public void register(TestRepository testRepository, RemoteRepository remoteRepository, GroupRepository groupRepository);
+    public void register(TestRepository testRepository, Remote remoteRepository, Group groupRepository);
 
     public void register(TestArtifact testArtifact,
                          Map<String, Object> attributesMap,

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementContext.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.GroupRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -22,7 +23,7 @@ public interface TestRepositoryManagementContext
 
     public void refresh();
 
-    public void register(TestRepository testRepository, RemoteRepository remoteRepository);
+    public void register(TestRepository testRepository, RemoteRepository remoteRepository, GroupRepository groupRepository);
 
     public void register(TestArtifact testArtifact,
                          Map<String, Object> attributesMap,

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/configuration/ConfigurationUtils.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/configuration/ConfigurationUtils.java
@@ -1,0 +1,22 @@
+package org.carlspring.strongbox.configuration;
+
+public class ConfigurationUtils
+{
+
+    public static String getStorageId(String storageId,
+                                      String storageAndRepositoryId)
+    {
+        String[] storageAndRepositoryIdTokens = storageAndRepositoryId.split(":");
+
+        return storageAndRepositoryIdTokens.length == 2 ? storageAndRepositoryIdTokens[0] : storageId;
+    }
+
+    public static String getRepositoryId(String storageAndRepositoryId)
+    {
+        String[] storageAndRepositoryIdTokens = storageAndRepositoryId.split(":");
+
+        return storageAndRepositoryIdTokens[storageAndRepositoryIdTokens.length < 2 ? 0 : 1];
+    }
+
+    
+}

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/routing/MutableRoutingRuleRepository.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/routing/MutableRoutingRuleRepository.java
@@ -2,6 +2,8 @@ package org.carlspring.strongbox.storage.routing;
 
 import java.io.Serializable;
 
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -21,6 +23,12 @@ public class MutableRoutingRuleRepository
     {
     }
 
+    public MutableRoutingRuleRepository(String storageAndRepositoryId) {
+        this(ConfigurationUtils.getStorageId(null, storageAndRepositoryId),
+                ConfigurationUtils.getRepositoryId(storageAndRepositoryId));
+    }
+
+    
     @JsonCreator
     public MutableRoutingRuleRepository(@JsonProperty("storageId") String storageId,
                                         @JsonProperty("repositoryId") String repositoryId)

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/routing/MutableRoutingRuleRepository.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/routing/MutableRoutingRuleRepository.java
@@ -23,9 +23,10 @@ public class MutableRoutingRuleRepository
     {
     }
 
-    public MutableRoutingRuleRepository(String storageAndRepositoryId) {
+    public MutableRoutingRuleRepository(String storageAndRepositoryId)
+    {
         this(ConfigurationUtils.getStorageId(null, storageAndRepositoryId),
-                ConfigurationUtils.getRepositoryId(storageAndRepositoryId));
+             ConfigurationUtils.getRepositoryId(storageAndRepositoryId));
     }
 
     
@@ -56,4 +57,5 @@ public class MutableRoutingRuleRepository
     {
         this.repositoryId = repositoryId;
     }
+    
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenGroupRepositoryPathFetchEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenGroupRepositoryPathFetchEventListener.java
@@ -1,6 +1,7 @@
 package org.carlspring.strongbox.providers.io;
 
 import org.carlspring.strongbox.configuration.ConfigurationManager;
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
 import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.repository.GroupRepositoryProvider;
 import org.carlspring.strongbox.providers.repository.RepositoryProvider;
@@ -76,8 +77,8 @@ public class MavenGroupRepositoryPathFetchEventListener
 
         for (String storageAndRepositoryId : groupRepository.getGroupRepositories())
         {
-            String sId = configurationManager.getStorageId(storage, storageAndRepositoryId);
-            String rId = configurationManager.getRepositoryId(storageAndRepositoryId);
+            String sId = ConfigurationUtils.getStorageId(storage.getId(), storageAndRepositoryId);
+            String rId = ConfigurationUtils.getRepositoryId(storageAndRepositoryId);
             Repository subRepository = configurationManager.getRepository(sId, rId);
 
             if (!subRepository.isInService())

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -83,24 +83,6 @@ public class MavenGroupRepositoryProviderTest
     {
         Set<MutableRepository> repositories = new LinkedHashSet<>();
         repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-tgi-1", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-tgi-2", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-tgi-group", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-mmfsbffgpr-1", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-mmfsbffgpr-2", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("grpt-releases-mmfsbffgpr-group", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
                                               getRepositoryName("grpt-releases-tgiwoosr-1", testInfo),
                                               Maven2LayoutProvider.ALIAS));
         repositories.add(createRepositoryMock(STORAGE0,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/Maven2ProxyRepositoryTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/Maven2ProxyRepositoryTest.java
@@ -21,7 +21,7 @@ import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecution
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.RemoteRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -58,7 +58,7 @@ public class Maven2ProxyRepositoryTest
     @EnabledIf(expression = "#{containsObject('repositoryIndexManager')}", loadContext = true)
     @ExtendWith({RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class})
     public void testRepositoryIndexFetching(@TestRepository(layout = LAYOUT_NAME, storage = STORAGE0, repository = REPOSITORY_RELEASES, setup = MavenIndexedRepositorySetup.class) Repository repository,
-                                            @TestRepository(layout = LAYOUT_NAME, storage = STORAGE0, repository = REPOSITORY_PROXY, setup = MavenIndexedRepositorySetup.class) @RemoteRepository(url = PROXY_REPOSITORY_URL ) Repository proxyRepository,
+                                            @TestRepository(layout = LAYOUT_NAME, storage = STORAGE0, repository = REPOSITORY_PROXY, setup = MavenIndexedRepositorySetup.class) @Remote(url = PROXY_REPOSITORY_URL ) Repository proxyRepository,
                                             @TestArtifact(storage = STORAGE0, repository = REPOSITORY_RELEASES, resource = A1, generator = MavenArtifactGenerator.class) Path a1,
                                             @TestArtifact(storage = STORAGE0, repository = REPOSITORY_RELEASES, resource = A2, generator = MavenArtifactGenerator.class) Path a2,
                                             @TestArtifact(storage = STORAGE0, repository = REPOSITORY_RELEASES, resource = A3, generator = MavenArtifactGenerator.class) Path a3)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepository.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepository.java
@@ -1,0 +1,43 @@
+package org.carlspring.strongbox.testing.repository;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.testing.storage.repository.RepositorySetup;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * @author sbespalov
+ *
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({PARAMETER, ANNOTATION_TYPE})
+@TestRepository(layout = MavenArtifactCoordinates.LAYOUT_NAME)
+public @interface MavenRepository
+{
+
+    @AliasFor(annotation = TestRepository.class)
+    String storage() default "storage0";
+
+    @AliasFor(annotation = TestRepository.class)
+    String repository() default "releases";
+
+    @AliasFor(annotation = TestRepository.class)
+    RepositoryPolicyEnum policy() default RepositoryPolicyEnum.RELEASE;
+
+    @AliasFor(annotation = TestRepository.class)
+    Class<? extends RepositorySetup>[] setup() default {};
+
+    @AliasFor(annotation = TestRepository.class)
+    boolean cleanup() default true;
+
+}


### PR DESCRIPTION
Fixes #1219 

- `@TestRepository.Group` implemented with Routing Rules support
- `MavenGroupRepositoryProviderTest` partially reworked to use `@TestRepository` and `@TestArtifact`