### PR TITLE
SB-1387: fixed URI for Maven artifact with underscore in group name

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryPathLock.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryPathLock.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.providers.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -63,7 +64,7 @@ public class RepositoryPathLock
             // We should lock all the RepositoryArtifactIdGroup because there can be
             // `ArtifactEntryServiceImpl.updateLastVersionTag()` operations
             // which affetcs on other artifacts from group.
-            return URI.create(c.getId());
+            return URI.create(URLEncoder.encode(c.getId(), "UTF-8"));
         }
 
         final URI lock = repositoryPath.toUri();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/artifact/coordinates/MavenArtifactCoordinates.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/artifact/coordinates/MavenArtifactCoordinates.java
@@ -155,7 +155,7 @@ public class MavenArtifactCoordinates
     @Override
     public String getId()
     {
-        return String.format("%s/%s", getGroupId(), getArtifactId());
+        return String.format("%s:%s", getGroupId(), getArtifactId());
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenArtifactTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenArtifactTest.java
@@ -2,9 +2,11 @@ package org.carlspring.strongbox.providers.io;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
@@ -41,7 +43,9 @@ public class MavenArtifactTest
                                                  @MavenTestArtifact(repository = REPOSITORY_RELEASES, id = "org.bitbucket.b_c:jose4j", versions = "0.6.3") Path path)
         throws IOException
     {
-        assertThat(path.normalize(), instanceOf(RepositoryPath.class));
+        Path repositoryPath = path.normalize();
+        assertThat(repositoryPath, instanceOf(RepositoryPath.class));
+        assertEquals(URI.create("strongbox:/storage0/mrpl-releases/org/bitbucket/b_c/jose4j/0.6.3/jose4j-0.6.3.jar"), repositoryPath.toUri());
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenArtifactTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenArtifactTest.java
@@ -1,25 +1,25 @@
 package org.carlspring.strongbox.providers.io;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.nio.file.Path;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
@@ -28,25 +28,20 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
-public class MavenRepositoryPathLockTest
+public class MavenArtifactTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
     private static final String REPOSITORY_RELEASES = "mrpl-releases";
 
-    @Inject
-    private RepositoryPathLock repositoryPathLock;
-
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void repositoryPathLockShouldNotThrowAnyException(
-            @TestRepository(repository = REPOSITORY_RELEASES, layout = Maven2LayoutProvider.ALIAS) Repository repository,
-            @MavenTestArtifact(id = "org.bitbucket.b_c:jose4j", repository = REPOSITORY_RELEASES, versions = { "0.6.3" }) Path path)
-            throws IOException
+    public void artifactWithUnderscoreShouldWork(@MavenRepository(repository = REPOSITORY_RELEASES) Repository repository,
+                                                 @MavenTestArtifact(repository = REPOSITORY_RELEASES, id = "org.bitbucket.b_c:jose4j", versions = "0.6.3") Path path)
+        throws IOException
     {
-        RepositoryPath artifactPath = (RepositoryPath) path.normalize();
-
-        repositoryPathLock.lock(artifactPath);
+        assertThat(path.normalize(), instanceOf(RepositoryPath.class));
     }
+
 }


### PR DESCRIPTION
The SB-1387 issue was not in `MavenArtifactCoordinates.getId` method, conversely it should be `{groupId}:{artifactId}` according to Maven style.
The problem was that we should encode `URI` for it to escape special symbols in any `ArtifactCoordinates.getId` regardless maven or any other layout specific implementation

Changes:

- `MavenArtifactCoordinates.getId` reverted to be in the from of **{groupId}:{artifactId}**
- `RepositoryPathLock.getLock` fixed to correctly resolve encoded Artifact ID
-  `MavenRepositoryPathLockTest` improved to be `MavenArtifactTest` because it actually check cases with specific Artifact names to be resolved correctly
- No need to call `RepositoryPathLock.lock()` expectedly because it invoked within Test Artifact deployment