### PR TITLE
Issue 1165: Migrate the MavenRepositoryManagementServiceImplTest and ArtifactMetadataServiceReleasesTest tests to use the new annotations

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -69,31 +69,7 @@ public class ArtifactMetadataServiceReleasesTest
     @Inject
     private RepositoryPathResolver repositoryPathResolver;
 
-
-    @BeforeAll
-    public static void cleanUp()
-            throws Exception
-    {
-        //cleanUp(getRepositoriesToClean());
-    }
-
-    @BeforeEach
-    public void initialize()
-            throws Exception
-    {
-        //createRepository(STORAGE0, REPOSITORY_RELEASES, RepositoryPolicyEnum.RELEASE.getPolicy(), false);
-    }
-
-    public static Set<MutableRepository> getRepositoriesToClean()
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_RELEASES, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-                  ArtifactManagementTestExecutionListener.class })
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,ArtifactManagementTestExecutionListener.class })
     @Test
     public void testReleaseMetadataRebuild(@TestRepository(storage = STORAGE0,
                                                            repository = "amsr-releases",
@@ -112,9 +88,6 @@ public class ArtifactMetadataServiceReleasesTest
                                            List<Path> repositoryArtifact2)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        //createRelease("org.carlspring.strongbox.metadata.nested:foo:2.1:jar");
-        //createRelease("org.carlspring.strongbox.metadata.nested:bar:3.1:jar");
-
         File strongboxMetadataDir = new File(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES),
                                              "org/carlspring/strongbox/metadata/strongbox-metadata");
 
@@ -166,8 +139,7 @@ public class ArtifactMetadataServiceReleasesTest
         assertNotNull(nestedMetadata2);
     }
 
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-                  ArtifactManagementTestExecutionListener.class })
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testAddVersionToMetadata(@TestRepository(storage = STORAGE0,
                                                          repository = "amsr-releases1",
@@ -181,11 +153,6 @@ public class ArtifactMetadataServiceReleasesTest
                                                  List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        //createRelease("org.carlspring.strongbox:added:1.0:jar");
-        //createRelease("org.carlspring.strongbox:added:1.1:jar");
-        //createRelease("org.carlspring.strongbox:added:1.2:jar");
-        //createRelease("org.carlspring.strongbox:added:1.3:jar");
-
         String artifactPath = "org/carlspring/strongbox/added";
 
         artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases1", artifactPath);
@@ -208,8 +175,7 @@ public class ArtifactMetadataServiceReleasesTest
         assertEquals("1.4", metadataAfter.getVersioning().getRelease(), "Unexpected set of versions!");
     }
 
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-                  ArtifactManagementTestExecutionListener.class })
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeleteVersionFromMetadata(@TestRepository(storage = STORAGE0,
                                                               repository = "amsr-releases2",
@@ -223,11 +189,6 @@ public class ArtifactMetadataServiceReleasesTest
                                               List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        //createRelease("org.carlspring.strongbox:deleted:1.0:jar");
-        //createRelease("org.carlspring.strongbox:deleted:1.1:jar");
-        //createRelease("org.carlspring.strongbox:deleted:1.2:jar");
-        //createRelease("org.carlspring.strongbox:deleted:1.3:jar");
-
         String artifactPath = "org/carlspring/strongbox/deleted";
 
         artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases2", artifactPath);
@@ -249,8 +210,7 @@ public class ArtifactMetadataServiceReleasesTest
         assertFalse(MetadataHelper.containsVersion(metadataAfter, "1.3"), "Unexpected set of versions!");
     }
 
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-                  ArtifactManagementTestExecutionListener.class  })
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class  })
     @Test
     public void testReleasePluginMetadataRebuild(@TestRepository(storage = STORAGE0,
                                                                  repository = "amsr-releases3",
@@ -259,16 +219,11 @@ public class ArtifactMetadataServiceReleasesTest
                                                  Repository repository,
                                                  @MavenTestArtifact(repository = "amsr-releases3",
                                                                     id = "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
-                                                         versions = { "1.0" },
-                                                         packaging = "maven-plugin")
+                                                                    versions = { "1.0" },
+                                                                    packaging = "maven-plugin")
                                                          List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        // Create plugin artifact
-        //generatePluginArtifact(getRepositoryBasedir(STORAGE0, "amsr-releases3").getAbsolutePath(),
-          //                     "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
-            //                   "1.0");
-
         Artifact pluginArtifact = ArtifactUtils.getArtifactFromGAVTC(
                 "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin:1.0");
 
@@ -299,13 +254,12 @@ public class ArtifactMetadataServiceReleasesTest
                                                             policy = RepositoryPolicyEnum.RELEASE)
                                   Repository repository,
                                   @TestArtifact(repository = "amsr-releases4",
-                                          id = "org.carlspring.strongbox.metadata:strongbox-metadata-merge",
-                                          versions = { "1.0" },
-                                          generator = MavenArtifactGenerator.class)
+                                                id = "org.carlspring.strongbox.metadata:strongbox-metadata-merge",
+                                                versions = { "1.0" },
+                                                generator = MavenArtifactGenerator.class)
                                           List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException, ProviderImplementationException
     {
-
         RepositoryPath repositoryPath = (RepositoryPath)artifactGroupPath.get(0);
         MavenArtifact mergeArtifact = MavenArtifactUtils.convertPathToArtifact(repositoryPath);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -4,20 +4,16 @@ import org.carlspring.maven.commons.util.ArtifactUtils;
 import org.carlspring.strongbox.artifact.MavenArtifact;
 import org.carlspring.strongbox.artifact.MavenArtifactUtils;
 import org.carlspring.strongbox.artifact.MavenRepositoryArtifact;
-import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
 import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.metadata.MetadataHelper;
 import org.carlspring.strongbox.storage.metadata.MetadataType;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
@@ -30,16 +26,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -61,7 +53,12 @@ public class ArtifactMetadataServiceReleasesTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
-    private static final String REPOSITORY_RELEASES = "amsr-releases";
+    private static final String R1 = "amsr-releases1";
+    private static final String R2 = "amsr-releases2";
+    private static final String R3 = "amsr-releases3";
+    private static final String R4 = "amsr-releases4";
+    private static final String R5 = "amsr-releases5";
+
 
     @Inject
     private ArtifactMetadataService artifactMetadataService;
@@ -72,23 +69,23 @@ public class ArtifactMetadataServiceReleasesTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,ArtifactManagementTestExecutionListener.class })
     @Test
     public void testReleaseMetadataRebuild(@TestRepository(storage = STORAGE0,
-                                                           repository = "amsr-releases",
+                                                           repository = R1,
                                                            layout = MavenArtifactCoordinates.LAYOUT_NAME,
                                                            policy = RepositoryPolicyEnum.RELEASE)
                                            Repository repository,
-                                           @TestArtifact(repository = "amsr-releases",
+                                           @TestArtifact(repository = R1,
                                                          id = "org.carlspring.strongbox.metadata.nested:foo",
                                                          versions = { "2.1" },
                                                          generator = MavenArtifactGenerator.class)
                                            List<Path> repositoryArtifact1,
-                                           @TestArtifact(repository = REPOSITORY_RELEASES,
+                                           @TestArtifact(repository = R1,
                                                          id = "org.carlspring.strongbox.metadata.nested:bar",
                                                          versions = { "3.1" },
                                                          generator = MavenArtifactGenerator.class)
                                            List<Path> repositoryArtifact2)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        File strongboxMetadataDir = new File(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES),
+        File strongboxMetadataDir = new File(getRepositoryBasedir(STORAGE0, R1),
                                              "org/carlspring/strongbox/metadata/strongbox-metadata");
 
         String ga = "org.carlspring.strongbox.metadata:strongbox-metadata";
@@ -109,10 +106,10 @@ public class ArtifactMetadataServiceReleasesTest
 
         changeCreationDate(artifact);
 
-        artifactMetadataService.rebuildMetadata(STORAGE0, REPOSITORY_RELEASES, "org/carlspring/strongbox/metadata");
+        artifactMetadataService.rebuildMetadata(STORAGE0, R1, "org/carlspring/strongbox/metadata");
 
         Metadata metadata = artifactMetadataService.getMetadata(STORAGE0,
-                                                                REPOSITORY_RELEASES,
+                                                                R1,
                                                                 "org/carlspring/strongbox/metadata/strongbox-metadata");
 
         assertNotNull(metadata);
@@ -127,13 +124,13 @@ public class ArtifactMetadataServiceReleasesTest
         assertEquals(6, versioning.getVersions().size(), "Incorrect number of versions stored in metadata!");
 
         Metadata nestedMetadata1 = artifactMetadataService.getMetadata(STORAGE0,
-                                                                       REPOSITORY_RELEASES,
+                                                                       R1,
                                                                        "org/carlspring/strongbox/metadata/nested/foo");
 
         assertNotNull(nestedMetadata1);
 
         Metadata nestedMetadata2 = artifactMetadataService.getMetadata(STORAGE0,
-                                                                       REPOSITORY_RELEASES,
+                                                                       R1,
                                                                        "org/carlspring/strongbox/metadata/nested/bar");
 
         assertNotNull(nestedMetadata2);
@@ -142,11 +139,11 @@ public class ArtifactMetadataServiceReleasesTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testAddVersionToMetadata(@TestRepository(storage = STORAGE0,
-                                                         repository = "amsr-releases1",
+                                                         repository = R2,
                                                          layout = MavenArtifactCoordinates.LAYOUT_NAME,
                                                          policy = RepositoryPolicyEnum.RELEASE)
                                          Repository repository,
-                                         @TestArtifact(repository = "amsr-releases1",
+                                         @TestArtifact(repository = R2,
                                                  id = "org.carlspring.strongbox:added",
                                                  versions = { "1.0","1.1", "1.2", "1.3" },
                                                  generator = MavenArtifactGenerator.class)
@@ -155,19 +152,19 @@ public class ArtifactMetadataServiceReleasesTest
     {
         String artifactPath = "org/carlspring/strongbox/added";
 
-        artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases1", artifactPath);
+        artifactMetadataService.rebuildMetadata(STORAGE0, R2, artifactPath);
 
-        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases1", artifactPath);
+        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, R2, artifactPath);
 
         assertNotNull(metadataBefore);
         assertTrue(MetadataHelper.containsVersion(metadataBefore, "1.3"), "Unexpected set of versions!");
 
         artifactMetadataService.addVersion(STORAGE0,
-                                           "amsr-releases1", artifactPath,
+                                           R2, artifactPath,
                                            "1.4",
                                            MetadataType.ARTIFACT_ROOT_LEVEL);
 
-        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases1", artifactPath);
+        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, R2, artifactPath);
 
         assertNotNull(metadataAfter);
         assertTrue(MetadataHelper.containsVersion(metadataAfter, "1.4"), "Unexpected set of versions!");
@@ -178,11 +175,11 @@ public class ArtifactMetadataServiceReleasesTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeleteVersionFromMetadata(@TestRepository(storage = STORAGE0,
-                                                              repository = "amsr-releases2",
+                                                              repository = R3,
                                                               layout = MavenArtifactCoordinates.LAYOUT_NAME,
                                                               policy = RepositoryPolicyEnum.RELEASE)
                                               Repository repository,
-                                              @TestArtifact(repository = "amsr-releases2",
+                                              @TestArtifact(repository = R3,
                                                             id = "org.carlspring.strongbox:deleted",
                                                             versions = { "1.0","1.1", "1.2", "1.3" },
                                                             generator = MavenArtifactGenerator.class)
@@ -191,20 +188,20 @@ public class ArtifactMetadataServiceReleasesTest
     {
         String artifactPath = "org/carlspring/strongbox/deleted";
 
-        artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases2", artifactPath);
+        artifactMetadataService.rebuildMetadata(STORAGE0, R3, artifactPath);
 
-        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases2", artifactPath);
+        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, R3, artifactPath);
 
         assertNotNull(metadataBefore);
         assertTrue(MetadataHelper.containsVersion(metadataBefore, "1.3"), "Unexpected set of versions!");
 
         artifactMetadataService.removeVersion(STORAGE0,
-                                              "amsr-releases2",
+                                              R3,
                                               artifactPath,
                                               "1.3",
                                               MetadataType.ARTIFACT_ROOT_LEVEL);
 
-        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases2", artifactPath);
+        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, R3, artifactPath);
 
         assertNotNull(metadataAfter);
         assertFalse(MetadataHelper.containsVersion(metadataAfter, "1.3"), "Unexpected set of versions!");
@@ -213,11 +210,11 @@ public class ArtifactMetadataServiceReleasesTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class  })
     @Test
     public void testReleasePluginMetadataRebuild(@TestRepository(storage = STORAGE0,
-                                                                 repository = "amsr-releases3",
+                                                                 repository = R4,
                                                                  layout = MavenArtifactCoordinates.LAYOUT_NAME,
                                                                  policy = RepositoryPolicyEnum.RELEASE)
                                                  Repository repository,
-                                                 @MavenTestArtifact(repository = "amsr-releases3",
+                                                 @MavenTestArtifact(repository = R4,
                                                                     id = "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
                                                                     versions = { "1.0" },
                                                                     packaging = "maven-plugin")
@@ -228,11 +225,11 @@ public class ArtifactMetadataServiceReleasesTest
                 "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin:1.0");
 
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                "amsr-releases3",
+                                                R4,
                                                 "org/carlspring/strongbox/metadata/maven/strongbox-metadata-plugin");
 
         Metadata metadata = artifactMetadataService.getMetadata(STORAGE0,
-                                                                "amsr-releases3",
+                                                                R4,
                                                                 "org/carlspring/strongbox/metadata/maven/strongbox-metadata-plugin");
 
         assertNotNull(metadata);
@@ -249,11 +246,11 @@ public class ArtifactMetadataServiceReleasesTest
     @ExtendWith({RepositoryManagementTestExecutionListener.class,ArtifactManagementTestExecutionListener.class})
     @Test
     public void testMetadataMerge(@TestRepository(storage = STORAGE0,
-                                                            repository = "amsr-releases4",
+                                                            repository = R5,
                                                             layout = MavenArtifactCoordinates.LAYOUT_NAME,
                                                             policy = RepositoryPolicyEnum.RELEASE)
                                   Repository repository,
-                                  @TestArtifact(repository = "amsr-releases4",
+                                  @TestArtifact(repository = R5,
                                                 id = "org.carlspring.strongbox.metadata:strongbox-metadata-merge",
                                                 versions = { "1.0" },
                                                 generator = MavenArtifactGenerator.class)
@@ -265,7 +262,7 @@ public class ArtifactMetadataServiceReleasesTest
 
         // Generate a proper maven-metadata.xml
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                "amsr-releases4",
+                                                R5,
                                                 "org/carlspring/strongbox/metadata/strongbox-metadata-merge");
 
         // Generate metadata to merge
@@ -283,7 +280,7 @@ public class ArtifactMetadataServiceReleasesTest
         artifactMetadataService.mergeMetadata(mergeArtifact, mergeMetadata);
 
         Metadata metadata = artifactMetadataService.getMetadata(STORAGE0,
-                                                                "amsr-releases4",
+                                                                R5,
                                                                 "org/carlspring/strongbox/metadata/strongbox-metadata-merge");
 
         assertNotNull(metadata);
@@ -307,11 +304,11 @@ public class ArtifactMetadataServiceReleasesTest
     private MavenArtifact createRelease(String gavtc)
             throws NoSuchAlgorithmException, XmlPullParserException, IOException
     {
-        File repositoryBasedir = getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES);
+        File repositoryBasedir = getRepositoryBasedir(STORAGE0, R1);
         MavenArtifact result = new MavenRepositoryArtifact(generateArtifact(repositoryBasedir.getAbsolutePath(), gavtc));
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES,
+                                                                       R1,
                                                                        ArtifactUtils.convertArtifactToPath(result));
 
         result.setPath(repositoryPath);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -66,7 +66,7 @@ public class ArtifactMetadataServiceReleasesTest
     @Inject
     private RepositoryPathResolver repositoryPathResolver;
 
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,ArtifactManagementTestExecutionListener.class })
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testReleaseMetadataRebuild(@TestRepository(storage = STORAGE0,
                                                            repository = R1,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -144,10 +144,10 @@ public class ArtifactMetadataServiceReleasesTest
                                                          policy = RepositoryPolicyEnum.RELEASE)
                                          Repository repository,
                                          @TestArtifact(repository = R2,
-                                                 id = "org.carlspring.strongbox:added",
-                                                 versions = { "1.0","1.1", "1.2", "1.3" },
-                                                 generator = MavenArtifactGenerator.class)
-                                                 List<Path> artifactGroupPath)
+                                                       id = "org.carlspring.strongbox:added",
+                                                       versions = { "1.0","1.1", "1.2", "1.3" },
+                                                       generator = MavenArtifactGenerator.class)
+                                                       List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
         String artifactPath = "org/carlspring/strongbox/added";
@@ -218,7 +218,7 @@ public class ArtifactMetadataServiceReleasesTest
                                                                     id = "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
                                                                     versions = { "1.0" },
                                                                     packaging = "maven-plugin")
-                                                         List<Path> artifactGroupPath)
+                                                 List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
         Artifact pluginArtifact = ArtifactUtils.getArtifactFromGAVTC(
@@ -254,7 +254,7 @@ public class ArtifactMetadataServiceReleasesTest
                                                 id = "org.carlspring.strongbox.metadata:strongbox-metadata-merge",
                                                 versions = { "1.0" },
                                                 generator = MavenArtifactGenerator.class)
-                                          List<Path> artifactGroupPath)
+                                  List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException, ProviderImplementationException
     {
         RepositoryPath repositoryPath = (RepositoryPath)artifactGroupPath.get(0);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -2,7 +2,11 @@ package org.carlspring.strongbox.services;
 
 import org.carlspring.maven.commons.util.ArtifactUtils;
 import org.carlspring.strongbox.artifact.MavenArtifact;
+import org.carlspring.strongbox.artifact.MavenArtifactUtils;
 import org.carlspring.strongbox.artifact.MavenRepositoryArtifact;
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
@@ -11,14 +15,23 @@ import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.metadata.MetadataHelper;
 import org.carlspring.strongbox.storage.metadata.MetadataType;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -28,6 +41,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -60,14 +74,14 @@ public class ArtifactMetadataServiceReleasesTest
     public static void cleanUp()
             throws Exception
     {
-        cleanUp(getRepositoriesToClean());
+        //cleanUp(getRepositoriesToClean());
     }
 
     @BeforeEach
     public void initialize()
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES, RepositoryPolicyEnum.RELEASE.getPolicy(), false);
+        //createRepository(STORAGE0, REPOSITORY_RELEASES, RepositoryPolicyEnum.RELEASE.getPolicy(), false);
     }
 
     public static Set<MutableRepository> getRepositoriesToClean()
@@ -78,12 +92,28 @@ public class ArtifactMetadataServiceReleasesTest
         return repositories;
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testReleaseMetadataRebuild()
+    public void testReleaseMetadataRebuild(@TestRepository(storage = STORAGE0,
+                                                           repository = "amsr-releases",
+                                                           layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                                           policy = RepositoryPolicyEnum.RELEASE)
+                                           Repository repository,
+                                           @TestArtifact(repository = "amsr-releases",
+                                                         id = "org.carlspring.strongbox.metadata.nested:foo",
+                                                         versions = { "2.1" },
+                                                         generator = MavenArtifactGenerator.class)
+                                           List<Path> repositoryArtifact1,
+                                           @TestArtifact(repository = REPOSITORY_RELEASES,
+                                                         id = "org.carlspring.strongbox.metadata.nested:bar",
+                                                         versions = { "3.1" },
+                                                         generator = MavenArtifactGenerator.class)
+                                           List<Path> repositoryArtifact2)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        createRelease("org.carlspring.strongbox.metadata.nested:foo:2.1:jar");
-        createRelease("org.carlspring.strongbox.metadata.nested:bar:3.1:jar");
+        //createRelease("org.carlspring.strongbox.metadata.nested:foo:2.1:jar");
+        //createRelease("org.carlspring.strongbox.metadata.nested:bar:3.1:jar");
 
         File strongboxMetadataDir = new File(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES),
                                              "org/carlspring/strongbox/metadata/strongbox-metadata");
@@ -136,30 +166,41 @@ public class ArtifactMetadataServiceReleasesTest
         assertNotNull(nestedMetadata2);
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testAddVersionToMetadata()
+    public void testAddVersionToMetadata(@TestRepository(storage = STORAGE0,
+                                                         repository = "amsr-releases1",
+                                                         layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                                         policy = RepositoryPolicyEnum.RELEASE)
+                                         Repository repository,
+                                         @TestArtifact(repository = "amsr-releases1",
+                                                 id = "org.carlspring.strongbox:added",
+                                                 versions = { "1.0","1.1", "1.2", "1.3" },
+                                                 generator = MavenArtifactGenerator.class)
+                                                 List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        createRelease("org.carlspring.strongbox:added:1.0:jar");
-        createRelease("org.carlspring.strongbox:added:1.1:jar");
-        createRelease("org.carlspring.strongbox:added:1.2:jar");
-        createRelease("org.carlspring.strongbox:added:1.3:jar");
+        //createRelease("org.carlspring.strongbox:added:1.0:jar");
+        //createRelease("org.carlspring.strongbox:added:1.1:jar");
+        //createRelease("org.carlspring.strongbox:added:1.2:jar");
+        //createRelease("org.carlspring.strongbox:added:1.3:jar");
 
         String artifactPath = "org/carlspring/strongbox/added";
 
-        artifactMetadataService.rebuildMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases1", artifactPath);
 
-        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases1", artifactPath);
 
         assertNotNull(metadataBefore);
         assertTrue(MetadataHelper.containsVersion(metadataBefore, "1.3"), "Unexpected set of versions!");
 
         artifactMetadataService.addVersion(STORAGE0,
-                                           REPOSITORY_RELEASES, artifactPath,
+                                           "amsr-releases1", artifactPath,
                                            "1.4",
                                            MetadataType.ARTIFACT_ROOT_LEVEL);
 
-        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases1", artifactPath);
 
         assertNotNull(metadataAfter);
         assertTrue(MetadataHelper.containsVersion(metadataAfter, "1.4"), "Unexpected set of versions!");
@@ -167,54 +208,76 @@ public class ArtifactMetadataServiceReleasesTest
         assertEquals("1.4", metadataAfter.getVersioning().getRelease(), "Unexpected set of versions!");
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testDeleteVersionFromMetadata()
+    public void testDeleteVersionFromMetadata(@TestRepository(storage = STORAGE0,
+                                                              repository = "amsr-releases2",
+                                                              layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                                              policy = RepositoryPolicyEnum.RELEASE)
+                                              Repository repository,
+                                              @TestArtifact(repository = "amsr-releases2",
+                                                            id = "org.carlspring.strongbox:deleted",
+                                                            versions = { "1.0","1.1", "1.2", "1.3" },
+                                                            generator = MavenArtifactGenerator.class)
+                                              List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
-        createRelease("org.carlspring.strongbox:deleted:1.0:jar");
-        createRelease("org.carlspring.strongbox:deleted:1.1:jar");
-        createRelease("org.carlspring.strongbox:deleted:1.2:jar");
-        createRelease("org.carlspring.strongbox:deleted:1.3:jar");
+        //createRelease("org.carlspring.strongbox:deleted:1.0:jar");
+        //createRelease("org.carlspring.strongbox:deleted:1.1:jar");
+        //createRelease("org.carlspring.strongbox:deleted:1.2:jar");
+        //createRelease("org.carlspring.strongbox:deleted:1.3:jar");
 
         String artifactPath = "org/carlspring/strongbox/deleted";
 
-        artifactMetadataService.rebuildMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        artifactMetadataService.rebuildMetadata(STORAGE0, "amsr-releases2", artifactPath);
 
-        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        Metadata metadataBefore = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases2", artifactPath);
 
         assertNotNull(metadataBefore);
         assertTrue(MetadataHelper.containsVersion(metadataBefore, "1.3"), "Unexpected set of versions!");
 
         artifactMetadataService.removeVersion(STORAGE0,
-                                              REPOSITORY_RELEASES,
+                                              "amsr-releases2",
                                               artifactPath,
                                               "1.3",
                                               MetadataType.ARTIFACT_ROOT_LEVEL);
 
-        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, REPOSITORY_RELEASES, artifactPath);
+        Metadata metadataAfter = artifactMetadataService.getMetadata(STORAGE0, "amsr-releases2", artifactPath);
 
         assertNotNull(metadataAfter);
         assertFalse(MetadataHelper.containsVersion(metadataAfter, "1.3"), "Unexpected set of versions!");
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class  })
     @Test
-    public void testReleasePluginMetadataRebuild()
+    public void testReleasePluginMetadataRebuild(@TestRepository(storage = STORAGE0,
+                                                                 repository = "amsr-releases3",
+                                                                 layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                                                 policy = RepositoryPolicyEnum.RELEASE)
+                                                 Repository repository,
+                                                 @MavenTestArtifact(repository = "amsr-releases3",
+                                                                    id = "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
+                                                         versions = { "1.0" },
+                                                         packaging = "maven-plugin")
+                                                         List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException
     {
         // Create plugin artifact
-        generatePluginArtifact(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES).getAbsolutePath(),
-                               "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
-                               "1.0");
+        //generatePluginArtifact(getRepositoryBasedir(STORAGE0, "amsr-releases3").getAbsolutePath(),
+          //                     "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin",
+            //                   "1.0");
 
         Artifact pluginArtifact = ArtifactUtils.getArtifactFromGAVTC(
                 "org.carlspring.strongbox.metadata.maven:strongbox-metadata-plugin:1.0");
 
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                REPOSITORY_RELEASES,
+                                                "amsr-releases3",
                                                 "org/carlspring/strongbox/metadata/maven/strongbox-metadata-plugin");
 
         Metadata metadata = artifactMetadataService.getMetadata(STORAGE0,
-                                                                REPOSITORY_RELEASES,
+                                                                "amsr-releases3",
                                                                 "org/carlspring/strongbox/metadata/maven/strongbox-metadata-plugin");
 
         assertNotNull(metadata);
@@ -228,16 +291,27 @@ public class ArtifactMetadataServiceReleasesTest
         assertEquals(1, versioning.getVersions().size(), "Incorrect number of versions stored in metadata!");
     }
 
+    @ExtendWith({RepositoryManagementTestExecutionListener.class,ArtifactManagementTestExecutionListener.class})
     @Test
-    public void testMetadataMerge()
+    public void testMetadataMerge(@TestRepository(storage = STORAGE0,
+                                                            repository = "amsr-releases4",
+                                                            layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                                            policy = RepositoryPolicyEnum.RELEASE)
+                                  Repository repository,
+                                  @TestArtifact(repository = "amsr-releases4",
+                                          id = "org.carlspring.strongbox.metadata:strongbox-metadata-merge",
+                                          versions = { "1.0" },
+                                          generator = MavenArtifactGenerator.class)
+                                          List<Path> artifactGroupPath)
             throws IOException, XmlPullParserException, NoSuchAlgorithmException, ProviderImplementationException
     {
-        // Create an artifact for metadata merging tests
-        MavenArtifact mergeArtifact = createRelease("org.carlspring.strongbox.metadata:strongbox-metadata-merge:1.0:jar");
+
+        RepositoryPath repositoryPath = (RepositoryPath)artifactGroupPath.get(0);
+        MavenArtifact mergeArtifact = MavenArtifactUtils.convertPathToArtifact(repositoryPath);
 
         // Generate a proper maven-metadata.xml
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                REPOSITORY_RELEASES,
+                                                "amsr-releases4",
                                                 "org/carlspring/strongbox/metadata/strongbox-metadata-merge");
 
         // Generate metadata to merge
@@ -255,7 +329,7 @@ public class ArtifactMetadataServiceReleasesTest
         artifactMetadataService.mergeMetadata(mergeArtifact, mergeMetadata);
 
         Metadata metadata = artifactMetadataService.getMetadata(STORAGE0,
-                                                                REPOSITORY_RELEASES,
+                                                                "amsr-releases4",
                                                                 "org/carlspring/strongbox/metadata/strongbox-metadata-merge");
 
         assertNotNull(metadata);
@@ -285,6 +359,7 @@ public class ArtifactMetadataServiceReleasesTest
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
                                                                        REPOSITORY_RELEASES,
                                                                        ArtifactUtils.convertArtifactToPath(result));
+
         result.setPath(repositoryPath);
         
         return result;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenRepositoryManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenRepositoryManagementServiceImplTest.java
@@ -3,31 +3,23 @@ package org.carlspring.strongbox.services;
 import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
-import org.carlspring.strongbox.providers.io.RepositoryFiles;
-import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
 import org.carlspring.strongbox.repository.IndexedMavenRepositoryFeatures;
 import org.carlspring.strongbox.storage.indexing.IndexTypeEnum;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
 import org.carlspring.strongbox.storage.search.SearchRequest;
 import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -74,20 +66,25 @@ public class MavenRepositoryManagementServiceImplTest
         assertTrue(repositoryBaseDir.exists(), "Failed to create repository '" + REPOSITORY_RELEASES_1 + "'!");
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void testCreateAndDelete()
+    public void testCreateAndDelete(@TestRepository(storage = STORAGE0,
+                                    repository = REPOSITORY_RELEASES_1,
+                                    layout = MavenArtifactCoordinates.LAYOUT_NAME,
+                                    policy = RepositoryPolicyEnum.RELEASE,
+                                    setup = MavenIndexedRepositorySetup.class,
+                                    cleanup = false)
+                                    Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_2, true);
-
-        File repositoryDir = getRepositoryBasedir(STORAGE0,  REPOSITORY_RELEASES_2).getAbsoluteFile();
+        File repositoryDir = getRepositoryBasedir(STORAGE0,  REPOSITORY_RELEASES_1).getAbsoluteFile();
 
         assertTrue(repositoryDir.exists(),
                    "Failed to create the repository \"" + repositoryDir.getAbsolutePath() + "\"!");
 
-        closeIndexer(STORAGE0 + ":" + REPOSITORY_RELEASES_2 + ":" + IndexTypeEnum.LOCAL.getType());
+        closeIndexer(STORAGE0 + ":" + REPOSITORY_RELEASES_1 + ":" + IndexTypeEnum.LOCAL.getType());
 
-        getRepositoryManagementService().removeRepository(STORAGE0, REPOSITORY_RELEASES_2);
+        getRepositoryManagementService().removeRepository(STORAGE0, REPOSITORY_RELEASES_1);
 
         assertFalse(repositoryDir.exists(), "Failed to remove the repository!");
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenRepositoryManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenRepositoryManagementServiceImplTest.java
@@ -114,8 +114,7 @@ public class MavenRepositoryManagementServiceImplTest
                                         id = "org.carlspring.strongbox:strongbox-utils",
                                         versions = { "6.2.3" },
                                         generator = MavenArtifactGenerator.class)
-                          List<Path> repositoryArtifact2
-                                  )
+                          List<Path> repositoryArtifact2)
             throws Exception
     {
         // dumpIndex(STORAGE0, REPOSITORY_RELEASES_MERGE_1, IndexTypeEnum.LOCAL.getType());


### PR DESCRIPTION
Added `@TestRepository` and `@TestArtifact` annotations in test classes `MavenRepositoryManagementServiceImplTest.java` and `ArtifactMetadataServiceReleasesTest.java`

Fixes for #1165.
