### PR TITLE
Allow swagger API to be rendered when running from JAR file

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -201,7 +201,7 @@ public class WebConfig
         registry.setOrder(-1);
 
         registry.addResourceHandler("/docs/**")
-                .addResourceLocations("/docs/")
+                .addResourceLocations("classpath:/META-INF/resources/docs/")
                 .setCachePeriod(3600);
 
         registry.addResourceHandler("*.html")
@@ -214,10 +214,6 @@ public class WebConfig
                 .resourceChain(true)
                 .addResolver(new GzipResourceResolver())
                 .addResolver(new PathResourceResolver());
-
-        // Swagger-UI mapping needs to be after the *.html mapping in order to override it.
-        registry.addResourceHandler("swagger-ui.html")
-                .addResourceLocations("classpath:/META-INF/resources/");
 
         registry.addResourceHandler("/webjars/**")
                 .addResourceLocations("classpath:/META-INF/resources/webjars/");


### PR DESCRIPTION
This fixes #1230.  The resource handler I added in the original implementation used a mapping that would only work when run from a source tree.  I've changed the mapping to refer to the classpath-based location that works either from a source tree or from the JAR file.