### PR TITLE
Add a JRE dependency to our RPM

### DIFF
--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -449,6 +449,7 @@
                             <defineStatements>
                                 <defineStatement>_binaries_in_noarch_packages_terminate_build 0</defineStatement>
                             </defineStatements>
+                            <requires>jre &gt;= 1.8.0</requires>
                             <mappings>
                                 <mapping>
                                     <filemode>0755</filemode>


### PR DESCRIPTION
This adds a dependency on the virtual RPM package `jre` so that it won't install without a JRE present on the system.  Identified this as part of #1151 testing.