### PR TITLE
Issue 1237 -- correct base URL and API path in swagger docs

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/SwaggerConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/SwaggerConfig.java
@@ -38,7 +38,6 @@ public class SwaggerConfig
                                       Collections.EMPTY_LIST);
         
         return new Docket(DocumentationType.SWAGGER_2).protocols(Sets.newHashSet("http", "https"))
-                                                      .host("localhost:48080")
                                                       .pathMapping("/")
                                                       .apiInfo(apiInfo);
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/SwaggerConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/SwaggerConfig.java
@@ -38,8 +38,8 @@ public class SwaggerConfig
                                       Collections.EMPTY_LIST);
         
         return new Docket(DocumentationType.SWAGGER_2).protocols(Sets.newHashSet("http", "https"))
-                                                      .host("carlspring.org")
-                                                      .pathMapping("/strongbox")
+                                                      .host("localhost:48080")
+                                                      .pathMapping("/")
                                                       .apiInfo(apiInfo);
     }
 


### PR DESCRIPTION
This fixes #1237 by removing the configured hostname for the API base URL (the system will infer it based on the request), and setting the API base path to `/api`.