### PR TITLE
Issue 1165 - Migrate the Maven layout provider tests to use the new annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,7 @@ To accept, please:
 | Akhilesh Bedre               |                                          | Hyderabad, India                        | 2019-04-07 |
 | Theodore Ravindranathh       |                                          | Chennai, India                          | 2019-04-13 |
 | Solomon Yakubov              |                                          | New York, New York, USA                 | 2019-04-15 |
+| Yugander Krishan Singh       |                                          | Himachal Pradesh, India                 | 2019-04-21 |
 
 [chat]: https://chat.carlspring.org/
 [issue tracker]: https://github.com/strongbox/strongbox/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+label%3A%22good+first+issue%22

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -183,11 +183,11 @@ public class ArtifactManagementServiceImplTest
         return repositories;
     }
 
-    @AfterEach
+    //@AfterEach
     public void removeRepositories(TestInfo testInfo)
             throws IOException, JAXBException
     {
-        removeRepositories(getRepositories(testInfo));
+        //removeRepositories(getRepositories(testInfo));
     }
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
@@ -204,6 +204,8 @@ public class ArtifactManagementServiceImplTest
                                                                                  List<Path> repositoryArtifact2)
             throws Exception
     {
+        String repositoryWithoutDeploymentId = repositoryWithoutDeployment.getId();
+
         InputStream is = null;
 
         //noinspection EmptyCatchBlock
@@ -211,15 +213,15 @@ public class ArtifactManagementServiceImplTest
         {
             String gavtc = "org.carlspring.strongbox:strongbox-utils:8.0:jar";
 
-            File repositoryDir = getRepositoryBasedir(STORAGE0, REPO_PREFIX+"testDeploymentToRepositoryWithForbiddenDeployments");
+            File repositoryDir = getRepositoryBasedir(STORAGE0, repositoryWithoutDeploymentId);
             is = generateArtifactInputStream(repositoryDir.toPath().getParent().toAbsolutePath().toString(),
-                                             REPO_PREFIX+"-testDeploymentToRepositoryWithForbiddenDeployments",
+                                             repositoryWithoutDeploymentId,
                                              gavtc,
                                              true);
 
             Artifact artifact = ArtifactUtils.getArtifactFromGAVTC(gavtc);
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           REPO_PREFIX+"-testDeploymentToRepositoryWithForbiddenDeployments",
+                                                                           repositoryWithoutDeploymentId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -249,6 +251,8 @@ public class ArtifactManagementServiceImplTest
                                                                        List<Path> repositoryArtifact2)
             throws Exception
     {
+        String repositoryWithoutDeploymentId = repositoryWithoutDeployment.getId();
+
         InputStream is = null;
 
         //noinspection EmptyCatchBlock
@@ -256,17 +260,17 @@ public class ArtifactManagementServiceImplTest
         {
             String gavtc = "org.carlspring.strongbox:strongbox-utils:8.1:jar";
 
-            File repositoryBasedir = getRepositoryBasedir(STORAGE0, REPO_PREFIX2+"-testRedeploymentToRepositoryWithForbiddenRedeployments");
+            File repositoryBasedir = getRepositoryBasedir(STORAGE0, repositoryWithoutDeploymentId);
             //generateArtifact(repositoryBasedir.getAbsolutePath(), gavtc);
 
             is = generateArtifactInputStream(repositoryBasedir.toPath().getParent().toAbsolutePath().toString(),
-                                             REPO_PREFIX2+"-testRedeploymentToRepositoryWithForbiddenRedeployments",
+                                             repositoryWithoutDeploymentId,
                                              gavtc,
                                              true);
 
             Artifact artifact = ArtifactUtils.getArtifactFromGAVTC(gavtc);
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           REPO_PREFIX2+"-testRedeploymentToRepositoryWithForbiddenRedeployments",
+                                                                           repositoryWithoutDeploymentId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -296,6 +300,7 @@ public class ArtifactManagementServiceImplTest
                                                                List<Path> repositoryArtifact)
             throws Exception
     {
+        String repositoryWithoutDeploymentId = repositoryWithoutDeployment.getId();
         //noinspection EmptyCatchBlock
         try
         {
@@ -303,7 +308,7 @@ public class ArtifactManagementServiceImplTest
 
             Artifact artifact = ArtifactUtils.getArtifactFromGAVTC(gavtc);
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
+                                                                           repositoryWithoutDeploymentId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.delete(repositoryPath, false);
 
@@ -335,6 +340,8 @@ public class ArtifactManagementServiceImplTest
                                                                             List<Path> repositoryArtifact)
             throws Exception
     {
+        String repositoryGroupId = repositoryGroup.getId();
+
         InputStream is = null;
 
         String gavtc = "org.carlspring.strongbox:strongbox-utils:8.3:jar";
@@ -344,14 +351,14 @@ public class ArtifactManagementServiceImplTest
         //noinspection EmptyCatchBlock
         try
         {
-            File repositoryDir = getRepositoryBasedir(STORAGE0, REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository");
+            File repositoryDir = getRepositoryBasedir(STORAGE0, repositoryGroupId);
             is = generateArtifactInputStream(repositoryDir.toPath().getParent().toAbsolutePath().toString(),
-                                             REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                             repositoryGroupId,
                                              gavtc,
                                              true);
 
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                           repositoryGroupId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -374,7 +381,7 @@ public class ArtifactManagementServiceImplTest
             // generateArtifact(getRepositoryBasedir(STORAGE0, REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository").getAbsolutePath(), gavtc);
             
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                           repositoryGroupId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -390,7 +397,7 @@ public class ArtifactManagementServiceImplTest
         }
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                       repositoryGroupId,
                                                                        ArtifactUtils.convertArtifactToPath(artifact));
 
         // Delete: Case 1: No forcing
@@ -488,6 +495,9 @@ public class ArtifactManagementServiceImplTest
 
         //createRepositoryWithArtifacts(STORAGE0, repositoryId, false, "org.carlspring.strongbox:strongbox-utils", "7.0");
 
+        String repositoryid = repository1.getId();
+        String repositoryWithTrashId = repository2.getId();
+
         final String artifactPath = "org/carlspring/strongbox/strongbox-utils/7.0/strongbox-utils-7.0.jar";
 
         //RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0, repositoryId, artifactPath);
@@ -496,7 +506,7 @@ public class ArtifactManagementServiceImplTest
 
         mavenArtifactManagementService.delete(repositoryPath, true);
 
-        assertFalse(new File(getRepositoryBasedir(STORAGE0, REPO_PREFIX8+"-testForceDelete"), artifactPath).exists(),
+        assertFalse(new File(getRepositoryBasedir(STORAGE0, repositoryid), artifactPath).exists(),
                     "Failed to delete artifact during a force delete operation!");
 
         //MutableRepository repositoryWithTrash = mavenRepositoryFactory.createRepository(repositoryWithTrashId);
@@ -516,7 +526,7 @@ public class ArtifactManagementServiceImplTest
 
         mavenArtifactManagementService.delete(repositoryPath, true);
 
-        final File repositoryDir = new File(getStorageBasedir(STORAGE0), repository2.getId() + "/.trash");
+        final File repositoryDir = new File(getStorageBasedir(STORAGE0), repositoryWithTrashId + "/.trash");
 
         assertTrue(new File(repositoryDir, artifactPath2).exists(),
                    "Should have moved the artifact to the trash during a force delete operation, " +
@@ -529,11 +539,11 @@ public class ArtifactManagementServiceImplTest
                                                                repository = REPO_PREFIX10+"-testRemoveTimestampedSnapshots",
                                                                layout = Maven2LayoutProvider.ALIAS,
                                                                policy = RepositoryPolicyEnum.SNAPSHOT)
-                                               Repository repository1,
+                                               Repository repository,
                                                TestInfo testInfo)
             throws Exception
     {
-        String repositoryid = repository1.getId();
+        String repositoryid = repository.getId();
         String repositoryBasedir = getRepositoryBasedir(STORAGE0, repositoryid).getAbsolutePath();
 
         String artifactPath = repositoryBasedir + "/org/carlspring/strongbox/timestamped";
@@ -611,15 +621,7 @@ public class ArtifactManagementServiceImplTest
                                         TestInfo testInfo)
             throws Exception
     {
-        //String repositoryId = getRepositoryName("tcrw-releases-with-lock", testInfo);
-
-        //MutableRepository repositoryWithLock = mavenRepositoryFactory.createRepository(repositoryId);
-
-        //createRepository(STORAGE0, repositoryWithLock);
-
         String repositoryId = repository.getId();
-
-        //Repository repository = getConfiguration().getStorage(STORAGE0).getRepository(repositoryId);
 
         int concurrency = 64;
 
@@ -681,14 +683,6 @@ public class ArtifactManagementServiceImplTest
                                           TestInfo testInfo)
             throws Exception
     {
-        //String repositoryId = getRepositoryName("last-version-releases", testInfo);
-
-        //MutableRepository repository = mavenRepositoryFactory.createRepository(repositoryId);
-        //repository.setLayout(Maven2LayoutProvider.ALIAS);
-        //repository.setType(RepositoryTypeEnum.HOSTED.getType());
-
-        //createRepository(STORAGE0, repository);
-
         String repositoryId = repository.getId();
 
         // store the file without classifier

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -138,58 +138,6 @@ public class ArtifactManagementServiceImplTest
     @Inject
     private RepositoryPathResolver repositoryPathResolver;
 
-    private Set<MutableRepository> getRepositories(TestInfo testInfo)
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("amsi-releases-without-deployment", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("amsi-releases-without-redeployment", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("amsi-releases-without-deletes", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tdradagr-releases", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tdradagr-group", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tarfg-releases", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tarfg-group", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tfd-release-with-trash", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tfd-release-without-delete", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("trts-snapshots", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("tcrw-releases-with-lock", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("last-version-releases", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName("checksums-storage", testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        return repositories;
-    }
-
-    //@AfterEach
-    public void removeRepositories(TestInfo testInfo)
-            throws IOException, JAXBException
-    {
-        //removeRepositories(getRepositories(testInfo));
-    }
-
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeploymentToRepositoryWithForbiddenDeployments(@TestRepository(storage = STORAGE0,
@@ -301,6 +249,7 @@ public class ArtifactManagementServiceImplTest
             throws Exception
     {
         String repositoryWithoutDeploymentId = repositoryWithoutDeployment.getId();
+
         //noinspection EmptyCatchBlock
         try
         {
@@ -450,12 +399,13 @@ public class ArtifactManagementServiceImplTest
                                                 Repository repositoryGroup,
                                                 @TestArtifact(repository = REPO_PREFIX6+"-testArtifactResolutionFromGroup",
                                                               id = "org.carlspring.strongbox:strongbox-utils",
-                                                        versions = { "8.0.5" },
-                                                        generator = MavenArtifactGenerator.class)
-                                                        List<Path> repositoryArtifact)
+                                                              versions = { "8.0.5" },
+                                                              generator = MavenArtifactGenerator.class)
+                                                List<Path> repositoryArtifact)
             throws Exception
     {
         RepositoryPath path = (RepositoryPath)repositoryArtifact.get(0);
+
         try (InputStream is = artifactResolutionService.getInputStream(path))
         {
             assertNotNull(is, "Failed to resolve artifact from group repository!");
@@ -485,22 +435,16 @@ public class ArtifactManagementServiceImplTest
                                 @TestArtifact(repository = REPO_PREFIX9+"-testForceDelete",
                                               id = "org.carlspring.strongbox:strongbox-utils",
                                               versions = { "7.2" },
-
                                               generator = MavenArtifactGenerator.class)
                                 List<Path> repositoryArtifact2)
             throws Exception
     {
-        //String repositoryId = getRepositoryName("tfd-release-without-delete", testInfo);
-        //String repositoryWithTrashId = getRepositoryName("tfd-release-with-trash", testInfo);
-
-        //createRepositoryWithArtifacts(STORAGE0, repositoryId, false, "org.carlspring.strongbox:strongbox-utils", "7.0");
 
         String repositoryid = repository1.getId();
+
         String repositoryWithTrashId = repository2.getId();
 
         final String artifactPath = "org/carlspring/strongbox/strongbox-utils/7.0/strongbox-utils-7.0.jar";
-
-        //RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0, repositoryId, artifactPath);
 
         RepositoryPath repositoryPath = (RepositoryPath)repositoryArtifact1.get(0);
 
@@ -508,16 +452,6 @@ public class ArtifactManagementServiceImplTest
 
         assertFalse(new File(getRepositoryBasedir(STORAGE0, repositoryid), artifactPath).exists(),
                     "Failed to delete artifact during a force delete operation!");
-
-        //MutableRepository repositoryWithTrash = mavenRepositoryFactory.createRepository(repositoryWithTrashId);
-        //repositoryWithTrash.setTrashEnabled(true);
-        //repositoryWithTrash.setLayout(Maven2LayoutProvider.ALIAS);
-
-        //createRepository(STORAGE0, repositoryWithTrash);
-
-        //generateArtifact(getRepositoryBasedir(STORAGE0, repositoryWithTrashId).getAbsolutePath(),
-          //               "org.carlspring.strongbox:strongbox-utils",
-            //             new String[]{ "7.2" });
 
         final String artifactPath2 = "org/carlspring/strongbox/strongbox-utils/7.2/strongbox-utils-7.2.jar";
         //repositoryPath = repositoryPathResolver.resolve(STORAGE0, repositoryWithTrashId, artifactPath2);
@@ -544,6 +478,7 @@ public class ArtifactManagementServiceImplTest
             throws Exception
     {
         String repositoryid = repository.getId();
+
         String repositoryBasedir = getRepositoryBasedir(STORAGE0, repositoryid).getAbsolutePath();
 
         String artifactPath = repositoryBasedir + "/org/carlspring/strongbox/timestamped";

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -545,8 +545,6 @@ public class ArtifactManagementServiceImplTest
                                         TestInfo testInfo)
             throws Exception
     {
-        String repositoryId = repository.getId();
-
         int concurrency = 64;
 
         Random random = new Random();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -99,6 +99,10 @@ public class ArtifactManagementServiceImplTest
 
     private static final String REPO_PREFIX3 = "amsi-releases-without-deletes";
 
+    private static final String REPO_PREFIX4 = "tdradagr-releases";
+
+    private static final String REPO_PREFIX5 = "tdradagr-group";
+
     @Inject
     private ArtifactManagementService mavenArtifactManagementService;
 
@@ -267,15 +271,15 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeletionFromRepositoryWithForbiddenDeletes(@TestRepository(storage = STORAGE0,
-            repository = REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
-            layout = Maven2LayoutProvider.ALIAS,
-            setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
-                                                                       Repository repositoryWithoutDeployment,
+                                                                               repository = REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
+                                                                               layout = Maven2LayoutProvider.ALIAS,
+                                                                               setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
+                                                               Repository repositoryWithoutDeployment,
                                                                @TestArtifact(repository = REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
-                                                                       id = "org.carlspring.strongbox:strongbox-utils",
-                                                                       versions = { "8.2", "8.6" },
-                                                                       generator = MavenArtifactGenerator.class)
-                                                                       List<Path> repositoryArtifact)
+                                                                             id = "org.carlspring.strongbox:strongbox-utils",
+                                                                             versions = { "8.2", "8.6" },
+                                                                             generator = MavenArtifactGenerator.class)
+                                                               List<Path> repositoryArtifact)
             throws Exception
     {
         //noinspection EmptyCatchBlock

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -301,33 +301,26 @@ public class ArtifactManagementServiceImplTest
         }
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testDeploymentRedeploymentAndDeletionAgainstGroupRepository(TestInfo testInfo)
+    public void testDeploymentRedeploymentAndDeletionAgainstGroupRepository(@TestRepository(storage = STORAGE0,
+                                                                                            repository = REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                                            layout = Maven2LayoutProvider.ALIAS,
+                                                                                            setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
+                                                                            Repository repository,
+                                                                            @TestRepository.Group({REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository"})
+                                                                            @TestRepository(storage = STORAGE0,
+                                                                                            repository = REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                                            layout = Maven2LayoutProvider.ALIAS,
+                                                                                            setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
+                                                                            Repository repositoryGroup,
+                                                                            @TestArtifact(repository = REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                                          id = "org.carlspring.strongbox:strongbox-utils",
+                                                                                          versions = { "8.3" },
+                                                                                          generator = MavenArtifactGenerator.class)
+                                                                            List<Path> repositoryArtifact)
             throws Exception
     {
-        // Test resource initialization start:
-        String repositoryId = getRepositoryName("tdradagr-releases", testInfo);
-        String repositoryGroupId = getRepositoryName("tdradagr-group", testInfo);
-
-        MutableRepository repository = mavenRepositoryFactory.createRepository(repositoryId);
-        repository.setAllowsDelete(false);
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-
-        MutableRepository repositoryGroup = mavenRepositoryFactory.createRepository(repositoryGroupId);
-        repositoryGroup.setType(RepositoryTypeEnum.GROUP.getType());
-        repositoryGroup.setAllowsRedeployment(false);
-        repositoryGroup.setAllowsDelete(false);
-        repositoryGroup.setAllowsForceDeletion(false);
-        repositoryGroup.addRepositoryToGroup(repositoryId);
-
-        createRepositoryWithArtifacts(STORAGE0,
-                                      repository,
-                                      "org.carlspring.strongbox:strongbox-utils",
-                                      "8.3");
-
-        createRepository(STORAGE0, repositoryGroup);
-        // Test resource initialization end.
-
         InputStream is = null;
 
         String gavtc = "org.carlspring.strongbox:strongbox-utils:8.3:jar";
@@ -337,14 +330,14 @@ public class ArtifactManagementServiceImplTest
         //noinspection EmptyCatchBlock
         try
         {
-            File repositoryDir = getRepositoryBasedir(STORAGE0, repositoryGroupId);
+            File repositoryDir = getRepositoryBasedir(STORAGE0, REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository");
             is = generateArtifactInputStream(repositoryDir.toPath().getParent().toAbsolutePath().toString(),
-                                             repositoryGroupId,
+                                             REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
                                              gavtc,
                                              true);
 
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           repositoryGroupId,
+                                                                           REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -364,10 +357,10 @@ public class ArtifactManagementServiceImplTest
         {
             // Generate the artifact on the file-system anyway so that we could achieve
             // the state of having it there before attempting a re-deployment
-            generateArtifact(getRepositoryBasedir(STORAGE0, repositoryId).getAbsolutePath(), gavtc);
+            // generateArtifact(getRepositoryBasedir(STORAGE0, REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository").getAbsolutePath(), gavtc);
             
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                           repositoryGroupId,
+                                                                           REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
             mavenArtifactManagementService.validateAndStore(repositoryPath, is);
 
@@ -383,7 +376,7 @@ public class ArtifactManagementServiceImplTest
         }
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       repositoryGroupId,
+                                                                       REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
                                                                        ArtifactUtils.convertArtifactToPath(artifact));
 
         // Delete: Case 1: No forcing

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -19,18 +19,15 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
 
 import org.apache.maven.artifact.Artifact;
 
@@ -52,10 +49,8 @@ import org.carlspring.strongbox.resource.ResourceCloser;
 import org.carlspring.strongbox.storage.ArtifactResolutionException;
 import org.carlspring.strongbox.storage.ArtifactStorageException;
 import org.carlspring.strongbox.storage.repository.MavenRepositoryFactory;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.testing.MavenRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
@@ -65,7 +60,6 @@ import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,29 +87,27 @@ public class ArtifactManagementServiceImplTest
 
     private DateFormat formatter = new SimpleDateFormat("yyyyMMdd.HHmmss");
 
-    private static final String REPO_PREFIX = "amsi-releases-without-deployment";
+    private static final String AMSI_RELEASES_WITHOUT_DEPLOYMENT = "amsi-releases-without-deployment";
 
-    private static final String REPO_PREFIX2 = "amsi-releases-without-redeployment";
+    private static final String AMSI_RELEASES_WITHOUT_DELETES = "amsi-releases-without-deletes";
 
-    private static final String REPO_PREFIX3 = "amsi-releases-without-deletes";
+    private static final String TDRADAGR_RELEASES = "tdradagr-releases";
 
-    private static final String REPO_PREFIX4 = "tdradagr-releases";
+    private static final String TDRADAGR_GROUP = "tdradagr-group";
 
-    private static final String REPO_PREFIX5 = "tdradagr-group";
+    private static final String TARFG_RELEASES = "tarfg-releases";
 
-    private static final String REPO_PREFIX6 = "tarfg-releases";
+    private static final String TARFG_GROUP = "tarfg-group";
 
-    private static final String REPO_PREFIX7 = "tarfg-group";
+    private static final String TFD_RELEASE_WITHOUT_DELETE = "tfd-release-without-delete";
 
-    private static final String REPO_PREFIX8 = "tfd-release-without-delete";
+    private static final String TFD_RELEASE_WITH_TRASH = "tfd-release-with-trash";
 
-    private static final String REPO_PREFIX9 = "tfd-release-with-trash";
+    private static final String TRTS_SNAPSHOTS = "trts-snapshots";
 
-    private static final String REPO_PREFIX10 = "trts-snapshots";
+    private static final String TCRW_RELEASES_WITH_LOCK = "tcrw-releases-with-lock";
 
-    private static final String REPO_PREFIX11 = "tcrw-releases-with-lock";
-
-    private static final String REPO_PREFIX12 = "last-version-releases";
+    private static final String LAST_VERSION_RELEASES = "last-version-releases";
 
     @Inject
     private ArtifactManagementService mavenArtifactManagementService;
@@ -141,11 +133,11 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeploymentToRepositoryWithForbiddenDeployments(@TestRepository(storage = STORAGE0,
-                                                                                   repository = REPO_PREFIX+"-testDeploymentToRepositoryWithForbiddenDeployments",
+                                                                                   repository = AMSI_RELEASES_WITHOUT_DEPLOYMENT,
                                                                                    layout = Maven2LayoutProvider.ALIAS,
                                                                                    setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeleteAndDeloyment.class)
                                                                                    Repository repositoryWithoutDeployment,
-                                                                   @TestArtifact(repository = REPO_PREFIX+"-testDeploymentToRepositoryWithForbiddenDeployments",
+                                                                   @TestArtifact(repository = AMSI_RELEASES_WITHOUT_DEPLOYMENT,
                                                                                  id = "org.carlspring.strongbox:strongbox-utils",
                                                                                  versions = { "8.0" },
                                                                                  generator = MavenArtifactGenerator.class)
@@ -188,11 +180,11 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testRedeploymentToRepositoryWithForbiddenRedeployments(@TestRepository(storage = STORAGE0,
-                                                                                       repository = REPO_PREFIX2+"-testRedeploymentToRepositoryWithForbiddenRedeployments",
+                                                                                       repository = AMSI_RELEASES_WITHOUT_DEPLOYMENT,
                                                                                        layout = Maven2LayoutProvider.ALIAS,
                                                                                        setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenRedeloyment.class)
                                                                        Repository repositoryWithoutDeployment,
-                                                                       @TestArtifact(repository = REPO_PREFIX2+"-testRedeploymentToRepositoryWithForbiddenRedeployments",
+                                                                       @TestArtifact(repository = AMSI_RELEASES_WITHOUT_DEPLOYMENT,
                                                                                      id = "org.carlspring.strongbox:strongbox-utils",
                                                                                      versions = { "8.1" },
                                                                                      generator = MavenArtifactGenerator.class)
@@ -237,11 +229,11 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeletionFromRepositoryWithForbiddenDeletes(@TestRepository(storage = STORAGE0,
-                                                                               repository = REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
+                                                                               repository = AMSI_RELEASES_WITHOUT_DELETES,
                                                                                layout = Maven2LayoutProvider.ALIAS,
                                                                                setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
                                                                Repository repositoryWithoutDeployment,
-                                                               @TestArtifact(repository = REPO_PREFIX3+"-testDeletionFromRepositoryWithForbiddenDeletes",
+                                                               @TestArtifact(repository = AMSI_RELEASES_WITHOUT_DELETES,
                                                                              id = "org.carlspring.strongbox:strongbox-utils",
                                                                              versions = { "8.2", "8.6" },
                                                                              generator = MavenArtifactGenerator.class)
@@ -272,17 +264,17 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testDeploymentRedeploymentAndDeletionAgainstGroupRepository(@TestRepository(storage = STORAGE0,
-                                                                                            repository = REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                                            repository = TDRADAGR_RELEASES,
                                                                                             layout = Maven2LayoutProvider.ALIAS,
                                                                                             setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
                                                                             Repository repository,
-                                                                            @TestRepository.Group({REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository"})
+                                                                            @TestRepository.Group({ TDRADAGR_RELEASES })
                                                                             @TestRepository(storage = STORAGE0,
-                                                                                            repository = REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                                            repository = TDRADAGR_GROUP,
                                                                                             layout = Maven2LayoutProvider.ALIAS,
                                                                                             setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeleteDeploymentForceDelete.class)
                                                                             Repository repositoryGroup,
-                                                                            @TestArtifact(repository = REPO_PREFIX4+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository",
+                                                                            @TestArtifact(repository = TDRADAGR_RELEASES,
                                                                                           id = "org.carlspring.strongbox:strongbox-utils",
                                                                                           versions = { "8.3" },
                                                                                           generator = MavenArtifactGenerator.class)
@@ -325,10 +317,6 @@ public class ArtifactManagementServiceImplTest
         //noinspection EmptyCatchBlock
         try
         {
-            // Generate the artifact on the file-system anyway so that we could achieve
-            // the state of having it there before attempting a re-deployment
-            // generateArtifact(getRepositoryBasedir(STORAGE0, REPO_PREFIX5+"-testDeploymentRedeploymentAndDeletionAgainstGroupRepository").getAbsolutePath(), gavtc);
-            
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
                                                                            repositoryGroupId,
                                                                            ArtifactUtils.convertArtifactToPath(artifact));
@@ -387,17 +375,18 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testArtifactResolutionFromGroup(@TestRepository(storage = STORAGE0,
-                                                                repository = REPO_PREFIX6+"-testArtifactResolutionFromGroup",
+                                                                repository = TARFG_RELEASES,
                                                                 layout = Maven2LayoutProvider.ALIAS,
                                                                 setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeletes.class)
                                                 Repository repository,
-                                                @TestRepository.Group({REPO_PREFIX6+"-testArtifactResolutionFromGroup"})
+                                                @TestRepository.Group({
+                                                        TARFG_RELEASES})
                                                 @TestRepository(storage = STORAGE0,
-                                                                repository = REPO_PREFIX7+"-testArtifactResolutionFromGroup",
+                                                                repository = TARFG_GROUP,
                                                                 layout = Maven2LayoutProvider.ALIAS,
                                                                 setup = MavenRepositorySetup.MavenRepositorySetupWithForbiddenDeleteDeploymentForceDelete.class)
                                                 Repository repositoryGroup,
-                                                @TestArtifact(repository = REPO_PREFIX6+"-testArtifactResolutionFromGroup",
+                                                @TestArtifact(repository = TARFG_RELEASES,
                                                               id = "org.carlspring.strongbox:strongbox-utils",
                                                               versions = { "8.0.5" },
                                                               generator = MavenArtifactGenerator.class)
@@ -416,23 +405,23 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
     public void testForceDelete(@TestRepository(storage = STORAGE0,
-                                                repository = REPO_PREFIX8+"-testForceDelete",
+                                                repository = TFD_RELEASE_WITHOUT_DELETE,
                                                 layout = Maven2LayoutProvider.ALIAS,
                                                 policy = RepositoryPolicyEnum.RELEASE)
                                 Repository repository1,
-                                @TestArtifact(repository = REPO_PREFIX8+"-testForceDelete",
+                                @TestArtifact(repository = TFD_RELEASE_WITHOUT_DELETE,
                                                 id = "org.carlspring.strongbox:strongbox-utils",
                                                 versions = { "7.0" },
                                                 generator = MavenArtifactGenerator.class)
                                 List<Path> repositoryArtifact1,
                                 @TestRepository(storage = STORAGE0,
-                                        repository = REPO_PREFIX9+"-testForceDelete",
+                                        repository = TFD_RELEASE_WITH_TRASH,
                                         layout = Maven2LayoutProvider.ALIAS,
                                         policy = RepositoryPolicyEnum.RELEASE,
                                         cleanup = false,
                                         setup = MavenRepositorySetup.MavenRepositorySetupWithTrashEnabled.class)
                                 Repository repository2,
-                                @TestArtifact(repository = REPO_PREFIX9+"-testForceDelete",
+                                @TestArtifact(repository = TFD_RELEASE_WITH_TRASH,
                                               id = "org.carlspring.strongbox:strongbox-utils",
                                               versions = { "7.2" },
                                               generator = MavenArtifactGenerator.class)
@@ -470,7 +459,7 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
     public void testRemoveTimestampedSnapshots(@TestRepository(storage = STORAGE0,
-                                                               repository = REPO_PREFIX10+"-testRemoveTimestampedSnapshots",
+                                                               repository = TRTS_SNAPSHOTS,
                                                                layout = Maven2LayoutProvider.ALIAS,
                                                                policy = RepositoryPolicyEnum.SNAPSHOT)
                                                Repository repository,
@@ -550,7 +539,7 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
     public void testConcurrentReadWrite(@TestRepository(storage = STORAGE0,
-                                                        repository = REPO_PREFIX11+"-testConcurrentReadWrite",
+                                                        repository = TCRW_RELEASES_WITH_LOCK,
                                                         layout = Maven2LayoutProvider.ALIAS)
                                         Repository repository,
                                         TestInfo testInfo)
@@ -611,7 +600,7 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
     public void testLastVersionManagement(@TestRepository(storage = STORAGE0,
-                                                          repository = REPO_PREFIX12+"-testLastVersionManagement",
+                                                          repository = LAST_VERSION_RELEASES,
                                                           layout = Maven2LayoutProvider.ALIAS,
                                                           setup = MavenRepositorySetup.MavenHostedRepositorySetup.class)
                                                           Repository repository,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -113,6 +113,10 @@ public class ArtifactManagementServiceImplTest
 
     private static final String REPO_PREFIX10 = "trts-snapshots";
 
+    private static final String REPO_PREFIX11 = "tcrw-releases-with-lock";
+
+    private static final String REPO_PREFIX12 = "last-version-releases";
+
     @Inject
     private ArtifactManagementService mavenArtifactManagementService;
 
@@ -598,17 +602,24 @@ public class ArtifactManagementServiceImplTest
         assertTrue(files[0].toString().endsWith("-3.jar"));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testConcurrentReadWrite(TestInfo testInfo)
+    public void testConcurrentReadWrite(@TestRepository(storage = STORAGE0,
+                                                        repository = REPO_PREFIX11+"-testConcurrentReadWrite",
+                                                        layout = Maven2LayoutProvider.ALIAS)
+                                        Repository repository,
+                                        TestInfo testInfo)
             throws Exception
     {
-        String repositoryId = getRepositoryName("tcrw-releases-with-lock", testInfo);
+        //String repositoryId = getRepositoryName("tcrw-releases-with-lock", testInfo);
 
-        MutableRepository repositoryWithLock = mavenRepositoryFactory.createRepository(repositoryId);
+        //MutableRepository repositoryWithLock = mavenRepositoryFactory.createRepository(repositoryId);
 
-        createRepository(STORAGE0, repositoryWithLock);
+        //createRepository(STORAGE0, repositoryWithLock);
 
-        Repository repository = getConfiguration().getStorage(STORAGE0).getRepository(repositoryId);
+        String repositoryId = repository.getId();
+
+        //Repository repository = getConfiguration().getStorage(STORAGE0).getRepository(repositoryId);
 
         int concurrency = 64;
 
@@ -660,17 +671,25 @@ public class ArtifactManagementServiceImplTest
 
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testLastVersionManagement(TestInfo testInfo)
+    public void testLastVersionManagement(@TestRepository(storage = STORAGE0,
+                                                          repository = REPO_PREFIX12+"-testLastVersionManagement",
+                                                          layout = Maven2LayoutProvider.ALIAS,
+                                                          setup = MavenRepositorySetup.MavenHostedRepositorySetup.class)
+                                                          Repository repository,
+                                          TestInfo testInfo)
             throws Exception
     {
-        String repositoryId = getRepositoryName("last-version-releases", testInfo);
+        //String repositoryId = getRepositoryName("last-version-releases", testInfo);
 
-        MutableRepository repository = mavenRepositoryFactory.createRepository(repositoryId);
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setType(RepositoryTypeEnum.HOSTED.getType());
+        //MutableRepository repository = mavenRepositoryFactory.createRepository(repositoryId);
+        //repository.setLayout(Maven2LayoutProvider.ALIAS);
+        //repository.setType(RepositoryTypeEnum.HOSTED.getType());
 
-        createRepository(STORAGE0, repository);
+        //createRepository(STORAGE0, repository);
+
+        String repositoryId = repository.getId();
 
         // store the file without classifier
         String gavtc = "org.carlspring.strongbox:strongbox-lv-artifact:1.0:jar";

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -1,0 +1,47 @@
+package org.carlspring.strongbox.testing;
+
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositorySetup;
+
+public abstract class MavenRepositorySetup implements RepositorySetup
+{
+
+    public static class MavenRepositorySetupWithForbiddenDeleteAndDeloyment extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            //MavenRepositoryFeatures mavenRepositoryFeatures = new MavenRepositoryFeatures();
+            repository.setAllowsDelete(false);
+            repository.setAllowsDeployment(false);
+            //repository.setArtifactCoordinateValidators(new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
+            //repository.setArtsetAsetArtifactCoordinateValidators(
+            //new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
+        }
+    }
+
+    public static class MavenRepositorySetupWithForbiddenDeletes extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            //MavenRepositoryFeatures mavenRepositoryFeatures = new MavenRepositoryFeatures();
+            repository.setAllowsDelete(false);
+            repository.setLayout(Maven2LayoutProvider.ALIAS);
+            //repository.setAllowsDeployment(false);
+            //repository.setArtifactCoordinateValidators(new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
+            //repository.setArtsetAsetArtifactCoordinateValidators(
+            //new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
+        }
+    }
+
+    public static class MavenRepositorySetupWithForbiddenRedeloyment extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            repository.setAllowsRedeployment(false);
+        }
+    }
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -67,4 +67,14 @@ public abstract class MavenRepositorySetup implements RepositorySetup
             repository.setTrashEnabled(true);
         }
     }
+
+    public static class MavenHostedRepositorySetup extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            repository.setLayout(Maven2LayoutProvider.ALIAS);
+            repository.setType(RepositoryTypeEnum.HOSTED.getType());
+        }
+    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -4,9 +4,31 @@ import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.testing.storage.repository.RepositorySetup;
+import org.carlspring.strongbox.yaml.configuration.repository.MutableMavenRepositoryConfiguration;
 
 public abstract class MavenRepositorySetup implements RepositorySetup
 {
+    public static class MavenRepositorySetupWithProxyType extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            MutableMavenRepositoryConfiguration repositoryConfiguration = new MutableMavenRepositoryConfiguration();
+            repositoryConfiguration.setIndexingEnabled(true);
+
+            repository.setRepositoryConfiguration(repositoryConfiguration);
+            repository.setType(RepositoryTypeEnum.PROXY.getType());
+        }
+    }
+
+    public static class MavenRepositorySetupWithGroupType extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            repository.setType(RepositoryTypeEnum.GROUP.getType());
+        }
+    }
 
     public static class MavenRepositorySetupWithForbiddenDeleteAndDeloyment extends MavenRepositorySetup
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -2,6 +2,7 @@ package org.carlspring.strongbox.testing;
 
 import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.testing.storage.repository.RepositorySetup;
 
 public abstract class MavenRepositorySetup implements RepositorySetup
@@ -42,6 +43,18 @@ public abstract class MavenRepositorySetup implements RepositorySetup
         public void setup(MutableRepository repository)
         {
             repository.setAllowsRedeployment(false);
+        }
+    }
+
+    public static class MavenRepositorySetupWithForbiddenDeleteDeploymentForceDelete extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            repository.setType(RepositoryTypeEnum.GROUP.getType());
+            repository.setAllowsRedeployment(false);
+            repository.setAllowsDelete(false);
+            repository.setAllowsForceDeletion(false);
         }
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -13,10 +13,8 @@ public abstract class MavenRepositorySetup implements RepositorySetup
         @Override
         public void setup(MutableRepository repository)
         {
-            //MavenRepositoryFeatures mavenRepositoryFeatures = new MavenRepositoryFeatures();
             repository.setAllowsDelete(false);
             repository.setAllowsDeployment(false);
-            //repository.setArtifactCoordinateValidators(new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
             //repository.setArtsetAsetArtifactCoordinateValidators(
             //new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
         }
@@ -27,11 +25,8 @@ public abstract class MavenRepositorySetup implements RepositorySetup
         @Override
         public void setup(MutableRepository repository)
         {
-            //MavenRepositoryFeatures mavenRepositoryFeatures = new MavenRepositoryFeatures();
             repository.setAllowsDelete(false);
             repository.setLayout(Maven2LayoutProvider.ALIAS);
-            //repository.setAllowsDeployment(false);
-            //repository.setArtifactCoordinateValidators(new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
             //repository.setArtsetAsetArtifactCoordinateValidators(
             //new LinkedHashSet<>(mavenRepositoryFeatures.getDefaultArtifactCoordinateValidators()));
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenRepositorySetup.java
@@ -57,4 +57,14 @@ public abstract class MavenRepositorySetup implements RepositorySetup
             repository.setAllowsForceDeletion(false);
         }
     }
+
+    public static class MavenRepositorySetupWithTrashEnabled extends MavenRepositorySetup
+    {
+        @Override
+        public void setup(MutableRepository repository)
+        {
+            repository.setLayout(Maven2LayoutProvider.ALIAS);
+            repository.setTrashEnabled(true);
+        }
+    }
 }


### PR DESCRIPTION
Fixes for [#1165](https://github.com/strongbox/strongbox/issues/1165):

- [x] ArtifactManagementServiceImplTest
- [x] MavenMetadataExpirationSingleGroupCaseTest