### PR TITLE
Added validation for OPTIONS request on entryPoint

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/Http401AuthenticationEntryPoint.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/Http401AuthenticationEntryPoint.java
@@ -23,6 +23,8 @@ public class Http401AuthenticationEntryPoint implements AuthenticationEntryPoint
 
     private static final String STRONGBOX_REALM = "Strongbox Repository Manager";
 
+    private static final String IS_REQUEST_OPTIONS = "options";
+
     @Inject
     private ObjectMapper objectMapper;
     
@@ -35,7 +37,7 @@ public class Http401AuthenticationEntryPoint implements AuthenticationEntryPoint
     {
         String message = Optional.ofNullable(authException).map(e -> e.getMessage()).orElse("unauthorized");
         
-        if (!IS_AJAX_REQUEST_HEADER_VALUE.equals(request.getHeader(IS_AJAX_REQUEST_HEADER_NAME)))
+        if (!IS_AJAX_REQUEST_HEADER_VALUE.equals(request.getHeader(IS_AJAX_REQUEST_HEADER_NAME))  &&  !request.getMethod().equalsIgnoreCase(IS_REQUEST_OPTIONS))
         {
             response.setHeader("WWW-Authenticate", "Basic realm=\"" + STRONGBOX_REALM + "\"");
         }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/Http401AuthenticationEntryPoint.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/Http401AuthenticationEntryPoint.java
@@ -37,7 +37,8 @@ public class Http401AuthenticationEntryPoint implements AuthenticationEntryPoint
     {
         String message = Optional.ofNullable(authException).map(e -> e.getMessage()).orElse("unauthorized");
         
-        if (!IS_AJAX_REQUEST_HEADER_VALUE.equals(request.getHeader(IS_AJAX_REQUEST_HEADER_NAME))  &&  !request.getMethod().equalsIgnoreCase(IS_REQUEST_OPTIONS))
+        if (!IS_AJAX_REQUEST_HEADER_VALUE.equals(request.getHeader(IS_AJAX_REQUEST_HEADER_NAME)) &&
+            !request.getMethod().equalsIgnoreCase(IS_REQUEST_OPTIONS))
         {
             response.setHeader("WWW-Authenticate", "Basic realm=\"" + STRONGBOX_REALM + "\"");
         }


### PR DESCRIPTION
Fixes #1235.

I just added a validation inside the Http401AuthenticationEntryPoint.java along the one that it had before.

With this is checks if a request has the desired Authentication header and that its not an OPTIONS request.
