### PR TITLE
Issue 1271: Apache Buildr dependency formatter for Maven artifacts

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BuildrDependencyFormatter.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BuildrDependencyFormatter.java
@@ -1,0 +1,63 @@
+package org.carlspring.strongbox.dependency.snippet;
+
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.providers.layout.AbstractLayoutProvider;
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Oleksandr Gryniuk
+ */
+@Component
+public class BuildrDependencyFormatter
+        implements DependencySynonymFormatter
+{
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractLayoutProvider.class);
+
+    public static final String ALIAS = "Buildr";
+
+    @Inject
+    private CompatibleDependencyFormatRegistry compatibleDependencyFormatRegistry;
+
+    @PostConstruct
+    @Override
+    public void register()
+    {
+        compatibleDependencyFormatRegistry.addProviderImplementation(getLayout(), getFormatAlias(), this);
+
+        logger.debug("Initialized the Buildr dependency formatter.");
+    }
+
+    @Override
+    public String getLayout()
+    {
+        return Maven2LayoutProvider.ALIAS;
+    }
+
+    @Override
+    public String getFormatAlias()
+    {
+        return ALIAS;
+    }
+
+    @Override
+    public String getDependencySnippet(ArtifactCoordinates artifactCoordinates)
+    {
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) artifactCoordinates;
+
+        return coordinates.getGroupId() + ":" +
+               coordinates.getArtifactId() + ":" +
+               coordinates.getExtension() + ":" +
+               (coordinates.getClassifier() != null ? coordinates.getClassifier() + ":": "") +
+               coordinates.getVersion();
+    }
+}
+

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/BuildrDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/BuildrDependencyFormatterTest.java
@@ -1,0 +1,102 @@
+package org.carlspring.strongbox.dependency.snippet;
+
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.ProviderImplementationException;
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+/**
+ * @author Oleksandr Gryniuk
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
+@Execution(CONCURRENT)
+public class BuildrDependencyFormatterTest
+{
+
+    @Inject
+    private CompatibleDependencyFormatRegistry compatibleDependencyFormatRegistry;
+
+    MavenArtifactCoordinates coordinates;
+
+    @BeforeEach
+    public void setUp()
+    {
+        coordinates = new MavenArtifactCoordinates();
+        coordinates.setGroupId("org.carlspring.strongbox");
+        coordinates.setArtifactId("maven-snippet");
+        coordinates.setVersion("1.0");
+    }
+
+    @Test
+    public void testBuildrDependencyGeneration()
+            throws ProviderImplementationException
+    {
+        DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,
+                                                                                                            BuildrDependencyFormatter.ALIAS);
+        assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
+
+        coordinates.setExtension("jar");
+
+        String snippet = formatter.getDependencySnippet(coordinates);
+
+        System.out.print(snippet);
+
+        assertEquals("org.carlspring.strongbox:maven-snippet:jar:1.0",
+                     snippet,
+                     "Failed to generate dependency!");
+    }
+
+    @Test
+    public void testBuildrDependencyGenerationWithClassifier()
+            throws ProviderImplementationException
+    {
+        DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,
+                                                                                                            BuildrDependencyFormatter.ALIAS);
+        assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
+
+        coordinates.setExtension("jar");
+        coordinates.setClassifier("jdk12");
+
+        String snippet = formatter.getDependencySnippet(coordinates);
+
+        System.out.print(snippet);
+
+        assertEquals("org.carlspring.strongbox:maven-snippet:jar:jdk12:1.0",
+                     snippet,
+                     "Failed to generate dependency!");
+    }
+
+    @Test
+    public void testBuildrDependencyGenerationWithNonStandardType()
+            throws ProviderImplementationException
+    {
+        DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,
+                                                                                                            BuildrDependencyFormatter.ALIAS);
+        assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
+
+        coordinates.setExtension("zip");
+
+        String snippet = formatter.getDependencySnippet(coordinates);
+
+        System.out.print(snippet);
+
+        assertEquals("org.carlspring.strongbox:maven-snippet:zip:1.0",
+                     snippet,
+                     "Failed to generate dependency!");
+    }
+}
+

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
@@ -223,9 +223,9 @@ public class MavenDependencyFormatterTest
 
         assertNotNull(codeSnippets, "Failed to look up dependency synonym formatter!");
         assertFalse(codeSnippets.isEmpty(), "No synonyms found!");
-        assertEquals(5, codeSnippets.size(), "Incorrect number of dependency synonyms!");
+        assertEquals(6, codeSnippets.size(), "Incorrect number of dependency synonyms!");
 
-        String[] synonyms = new String[]{ "Maven 2", "Gradle", "Ivy", "Leiningen", "SBT" };
+        String[] synonyms = new String[]{ "Maven 2", "Buildr", "Gradle", "Ivy", "Leiningen", "SBT", };
 
         int i = 0;
         for (CodeSnippet snippet : codeSnippets)


### PR DESCRIPTION
Fixes #1271

1. Introduced a formatter for Apache Buildr together with a test class
2. Adapted `MavenDependencyFormatterTest.testRegisteredSynonyms` to the addition of the formatter: Increased by one the number of registered synonyms and added ApacheBuildr to the tested array 