### PR TITLE
Issue 1270: Add Bazel dependency formatter for Maven artifacts

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatter.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatter.java
@@ -1,6 +1,64 @@
 package org.carlspring.strongbox.dependency.snippet;
 
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.providers.layout.AbstractLayoutProvider;
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * 
+ * @author Declan-Y
+ *
+ */
+@Component
 public class BazelDependencyFormatter
+        implements DependencySynonymFormatter
 {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractLayoutProvider.class);
+    
+    public static final String ALIAS = "Bazel";
+    
+    @Inject
+    private CompatibleDependencyFormatRegistry compatibleDependencyFormatRegistry;
+    
+    
+    @PostConstruct
+    @Override
+    public void register()
+    {
+        compatibleDependencyFormatRegistry.addProviderImplementation(getLayout(), getFormatAlias(), this);
+        
+        logger.debug("Initialized the Bazel dependency formatter.");
+    }
+    @Override
+    public String getLayout()
+    {
+        return Maven2LayoutProvider.ALIAS;
+    }
+    
+    
+    public String getFormatAlias()
+    {
+        return ALIAS;
+    }
+    
+    @Override
+    public String getDependencySnippet(ArtifactCoordinates artifactCoordinates)
+    {
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) artifactCoordinates;
+        
+        return "maven_jar(" +"\n"+"    name ="+" "
+        +"\""+coordinates.getArtifactId()+"\""+","+
+        (coordinates.getArtifactId() != null && coordinates.getGroupId() != null && coordinates.getVersion() != null ? 
+        "\n    artifact = " + "\""+
+        coordinates.getGroupId()+":"+coordinates.getArtifactId()+":"+coordinates.getVersion()+"\""+",\n)\n": 
+        "\n)\n");
+    }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatter.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatter.java
@@ -1,0 +1,6 @@
+package org.carlspring.strongbox.dependency.snippet;
+
+public class BazelDependencyFormatter
+{
+
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/BazelDependencyFormatterTest.java
@@ -1,0 +1,79 @@
+package org.carlspring.strongbox.dependency.snippet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+import javax.inject.Inject;
+
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.ProviderImplementationException;
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * 
+ * @author Declan-Y
+ *
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
+@Execution(CONCURRENT)
+
+public class BazelDependencyFormatterTest
+{
+    @Inject
+    private CompatibleDependencyFormatRegistry compatibleDependencyFormatRegistry;
+    
+    @Test
+    public void testBazelDependencyGeneration()
+            throws ProviderImplementationException
+    {
+        DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,BazelDependencyFormatter.ALIAS);
+        
+        assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
+        
+        MavenArtifactCoordinates coordinates = new MavenArtifactCoordinates();
+        coordinates.setGroupId("org.carlspring.strongbox");
+        coordinates.setArtifactId("maven-snippet");
+        coordinates.setVersion("1.0");
+        coordinates.setExtension("jar");
+        
+        String snippet = formatter.getDependencySnippet(coordinates);
+        
+        System.out.print(snippet);
+        
+        assertEquals("maven_jar(\n    name = \"maven-snippet\","
+                + "\n    artifact = \"org.carlspring.strongbox:maven-snippet:1.0\",\n)\n", 
+                snippet, "Failed to generate dependency!");
+        
+    }
+    @Test
+    public void testBazelDependencyGenerationWithoutArtifactField()
+            throws ProviderImplementationException
+    {
+        DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,BazelDependencyFormatter.ALIAS);
+        
+        assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
+        
+        MavenArtifactCoordinates coordinates = new MavenArtifactCoordinates();
+        coordinates.setArtifactId("maven-snippet");
+        
+        
+        String snippet = formatter.getDependencySnippet(coordinates);
+        
+        System.out.print(snippet);
+        
+        assertEquals("maven_jar(\n    name = \"maven-snippet\",\n)\n", snippet, "Failed to generate dependency!");
+        
+        
+    }
+    
+
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
@@ -223,9 +223,10 @@ public class MavenDependencyFormatterTest
 
         assertNotNull(codeSnippets, "Failed to look up dependency synonym formatter!");
         assertFalse(codeSnippets.isEmpty(), "No synonyms found!");
-        assertEquals(6, codeSnippets.size(), "Incorrect number of dependency synonyms!");
+        assertEquals(7, codeSnippets.size(), "Incorrect number of dependency synonyms!");
 
-        String[] synonyms = new String[]{ "Maven 2", "Buildr", "Gradle", "Ivy", "Leiningen", "SBT", };
+
+        String[] synonyms = new String[]{ "Maven 2", "Bazel", "Buildr", "Gradle", "Ivy", "Leiningen", "SBT", };
 
         int i = 0;
         for (CodeSnippet snippet : codeSnippets)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
@@ -226,6 +226,7 @@ public class MavenDependencyFormatterTest
         assertEquals(7, codeSnippets.size(), "Incorrect number of dependency synonyms!");
 
 
+
         String[] synonyms = new String[]{ "Maven 2", "Bazel", "Buildr", "Gradle", "Ivy", "Leiningen", "SBT", };
 
         int i = 0;


### PR DESCRIPTION
Fixes #1270.

- Implemented BazelDependencyFormatter class
- Implemented BazelDependencyFormatterTest class
- Updated array in testRegisteredSynonyms. 