### PR TITLE
Issue 1263: Upgrade com.mchange:c3p0 to version 0.9.5.4 or higher

### DIFF
--- a/strongbox-cron/strongbox-cron-api/pom.xml
+++ b/strongbox-cron/strongbox-cron-api/pom.xml
@@ -136,6 +136,10 @@
         </dependency>
 
         <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
         </dependency>

--- a/strongbox-cron/strongbox-cron-tasks/pom.xml
+++ b/strongbox-cron/strongbox-cron-tasks/pom.xml
@@ -240,6 +240,10 @@
         </dependency>
 
         <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
         </dependency>


### PR DESCRIPTION
Upgraded to `org.quartz-scheduler:quartz:2.3.1` and `com.mchange:c3p0:jar:0.9.5.4`.

Fixes #1263.
