### PR TITLE
Issue-1300: CronTaskConfigurationDto should base on java.util.UUID not on java.lang.String

### DIFF
--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -128,6 +128,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/domain/CronTaskConfiguration.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/domain/CronTaskConfiguration.java
@@ -4,17 +4,19 @@ import javax.annotation.concurrent.Immutable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @Immutable
 public class CronTaskConfiguration
 {
 
-    private final String uuid;
+    private final UUID uuid;
 
     private final String name;
 
@@ -44,7 +46,7 @@ public class CronTaskConfiguration
         return source != null ? ImmutableMap.copyOf(source) : Collections.emptyMap();
     }
 
-    public String getUuid()
+    public UUID getUuid()
     {
         return uuid;
     }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/domain/CronTaskConfigurationDto.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/domain/CronTaskConfigurationDto.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.cron.domain;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -18,7 +19,7 @@ public class CronTaskConfigurationDto
         implements Serializable
 {
 
-    private String uuid;
+    private UUID uuid;
 
     private String name;
 
@@ -37,19 +38,19 @@ public class CronTaskConfigurationDto
     }
 
     @JsonCreator
-    public CronTaskConfigurationDto(@JsonProperty(value = "uuid", required = true) String uuid,
+    public CronTaskConfigurationDto(@JsonProperty(value = "uuid", required = true) UUID uuid,
                                     @JsonProperty(value = "name", required = true) String name)
     {
         this.uuid = uuid;
         this.name = name;
     }
 
-    public String getUuid()
+    public UUID getUuid()
     {
         return uuid;
     }
 
-    public void setUuid(String uuid)
+    public void setUuid(UUID uuid)
     {
         this.uuid = uuid;
     }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronJobSchedulerService.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronJobSchedulerService.java
@@ -7,13 +7,14 @@ import java.util.UUID;
 
 /**
  * @author carlspring
+ * @author Pablo Tirado
  */
 public interface CronJobSchedulerService
 {
 
     void scheduleJob(CronTaskConfigurationDto cronTaskConfiguration);
 
-    void deleteJob(String cronTaskConfigurationUuid);
+    void deleteJob(UUID cronTaskConfigurationUuid);
 
     GroovyScriptNamesDto getGroovyScriptsName();
 }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronTaskConfigurationService.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronTaskConfigurationService.java
@@ -8,6 +8,9 @@ import java.util.UUID;
 
 import org.quartz.SchedulerException;
 
+/**
+ * @author Pablo Tirado
+ */
 public interface CronTaskConfigurationService
 {
 
@@ -15,12 +18,12 @@ public interface CronTaskConfigurationService
     UUID saveConfiguration(CronTaskConfigurationDto cronTaskConfiguration)
             throws Exception;
 
-    void deleteConfiguration(String cronTaskConfigurationUuid)
+    void deleteConfiguration(UUID cronTaskConfigurationUuid)
             throws SchedulerException,
                    CronTaskNotFoundException,
                    ClassNotFoundException;
 
-    CronTaskConfigurationDto getTaskConfigurationDto(String cronTaskConfigurationUuid);
+    CronTaskConfigurationDto getTaskConfigurationDto(UUID cronTaskConfigurationUuid);
 
     CronTasksConfigurationDto getTasksConfigurationDto();
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronTaskDataService.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/CronTaskDataService.java
@@ -10,11 +10,12 @@ import java.util.UUID;
 
 /**
  * @author Yougeshwar
+ * @author Pablo Tirado
  */
 public interface CronTaskDataService
 {
 
-    CronTaskConfigurationDto getTaskConfigurationDto(String cronTaskConfigurationUuid);
+    CronTaskConfigurationDto getTaskConfigurationDto(UUID cronTaskConfigurationUuid);
 
     CronTasksConfigurationDto getTasksConfigurationDto();
 
@@ -22,7 +23,7 @@ public interface CronTaskDataService
 
     UUID save(CronTaskConfigurationDto configuration);
 
-    void delete(String uuid);
+    void delete(UUID cronTaskConfigurationUuid);
 
 
 }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
@@ -7,6 +7,7 @@ import org.carlspring.strongbox.cron.services.CronJobSchedulerService;
 
 import javax.inject.Inject;
 import java.util.Set;
+import java.util.UUID;
 
 import org.quartz.*;
 import org.quartz.impl.matchers.GroupMatcher;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 /**
  * @author Yougeshwar
+ * @author Pablo Tirado
  */
 @Service
 public class CronJobSchedulerServiceImpl
@@ -49,7 +51,7 @@ public class CronJobSchedulerServiceImpl
         JobDataMap jobDataMap = new JobDataMap();
         jobDataMap.put("config", cronTaskConfiguration);
 
-        JobKey jobKey = JobKey.jobKey(cronTaskConfiguration.getUuid());
+        JobKey jobKey = JobKey.jobKey(cronTaskConfiguration.getUuid().toString());
         JobDetail jobDetail = JobBuilder.newJob(jobClass)
                                         .withIdentity(jobKey)
                                         .setJobData(jobDataMap)
@@ -92,7 +94,7 @@ public class CronJobSchedulerServiceImpl
             return;
         }
 
-        TriggerKey triggerKey = TriggerKey.triggerKey(cronTaskConfiguration.getUuid());
+        TriggerKey triggerKey = TriggerKey.triggerKey(cronTaskConfiguration.getUuid().toString());
         TriggerBuilder<Trigger> triggerBuilder = TriggerBuilder.newTrigger()
                                                                .withIdentity(triggerKey)
                                                                .forJob(jobDetail);
@@ -115,9 +117,9 @@ public class CronJobSchedulerServiceImpl
     }
 
     @Override
-    public void deleteJob(String cronTaskConfigurationUuid)
+    public void deleteJob(UUID cronTaskConfigurationUuid)
     {
-        JobKey jobKey = JobKey.jobKey(cronTaskConfigurationUuid);
+        JobKey jobKey = JobKey.jobKey(cronTaskConfigurationUuid.toString());
 
         try
         {

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskConfigurationServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskConfigurationServiceImpl.java
@@ -8,7 +8,6 @@ import org.carlspring.strongbox.cron.services.CronTaskDataService;
 import org.carlspring.strongbox.event.cron.CronTaskEventListenerRegistry;
 
 import javax.inject.Inject;
-
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -17,6 +16,9 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextStartedEvent;
 import org.springframework.stereotype.Service;
 
+/**
+ * @author Pablo Tirado
+ */
 @Service
 class CronTaskConfigurationServiceImpl
         implements CronTaskConfigurationService, ApplicationListener<ContextStartedEvent>
@@ -61,7 +63,7 @@ class CronTaskConfigurationServiceImpl
         return configurationId;
     }
 
-    public void deleteConfiguration(String cronTaskConfigurationUuid)
+    public void deleteConfiguration(UUID cronTaskConfigurationUuid)
     {
         logger.debug("Deleting cron task configuration {}", cronTaskConfigurationUuid);
 
@@ -72,7 +74,7 @@ class CronTaskConfigurationServiceImpl
     }
 
     @Override
-    public CronTaskConfigurationDto getTaskConfigurationDto(String uuid)
+    public CronTaskConfigurationDto getTaskConfigurationDto(UUID uuid)
     {
         return cronTaskDataService.getTaskConfigurationDto(uuid);
     }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/event/cron/CronTaskEventListenerRegistry.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/event/cron/CronTaskEventListenerRegistry.java
@@ -2,12 +2,15 @@ package org.carlspring.strongbox.event.cron;
 
 import org.carlspring.strongbox.event.AbstractEventListenerRegistry;
 
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
  * @author carlspring
+ * @author Pablo Tirado
  */
 @Component
 public class CronTaskEventListenerRegistry
@@ -17,36 +20,39 @@ public class CronTaskEventListenerRegistry
     private static final Logger logger = LoggerFactory.getLogger(CronTaskEventListenerRegistry.class);
 
 
-    public void dispatchCronTaskCreatedEvent(String uuid)
+    public void dispatchCronTaskCreatedEvent(final UUID uuid)
     {
-        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_SAVED.getType(), uuid);
+        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_SAVED.getType(), uuid.toString());
 
         logger.debug("Dispatching CronTaskEventTypeEnum.EVENT_CRON_TASK_SAVED event for '{}'...", uuid);
 
         dispatchEvent(event);
     }
 
-    public void dispatchCronTaskDeletedEvent(String uuid)
+    public void dispatchCronTaskDeletedEvent(final UUID uuid)
     {
-        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_DELETED.getType(), uuid);
+        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_DELETED.getType(),
+                                                uuid.toString());
 
         logger.debug("Dispatching CronTaskEventTypeEnum.EVENT_CRON_TASK_DELETED event for '{}'...", uuid);
 
         dispatchEvent(event);
     }
 
-    public void dispatchCronTaskExecutingEvent(String uuid)
+    public void dispatchCronTaskExecutingEvent(final UUID uuid)
     {
-        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTING.getType(), uuid);
+        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTING.getType(),
+                                                uuid.toString());
 
         logger.debug("Dispatching CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTING event for '{}'...", uuid);
 
         dispatchEvent(event);
     }
 
-    public void dispatchCronTaskExecutedEvent(String uuid)
+    public void dispatchCronTaskExecutedEvent(final UUID uuid)
     {
-        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTION_COMPLETE.getType(), uuid);
+        CronTaskEvent event = new CronTaskEvent(CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTION_COMPLETE.getType(),
+                                                uuid.toString());
 
         logger.debug("Dispatching CronTaskEventTypeEnum.EVENT_CRON_TASK_EXECUTION_COMPLETE event for '{}'...", uuid);
 

--- a/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronTestCase.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronTestCase.java
@@ -3,13 +3,14 @@ package org.carlspring.strongbox.cron.jobs;
 import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 import org.carlspring.strongbox.cron.services.CronTaskConfigurationService;
 import org.carlspring.strongbox.event.cron.CronTaskEvent;
-import org.carlspring.strongbox.event.cron.CronTaskEventListenerRegistry;
 import org.carlspring.strongbox.event.cron.CronTaskEventTypeEnum;
 
 import javax.inject.Inject;
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.UUID;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,10 +31,9 @@ abstract class BaseCronTestCase implements ApplicationListener<CronTaskEvent>, A
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
-    protected CronTaskEventListenerRegistry cronTaskEventListenerRegistry;
-
-    @Inject
     protected CronTaskConfigurationService cronTaskConfigurationService;
+
+    protected UUID expectedCronTaskUuid;
 
     protected String expectedCronTaskName;
 
@@ -46,6 +46,8 @@ abstract class BaseCronTestCase implements ApplicationListener<CronTaskEvent>, A
     public void init(TestInfo testInfo)
             throws Exception
     {
+        expectedCronTaskUuid = UUID.randomUUID();
+
         Optional<Method> method = testInfo.getTestMethod();
         expectedCronTaskName = method.map(Method::getName).orElse(null);
     }
@@ -76,7 +78,8 @@ abstract class BaseCronTestCase implements ApplicationListener<CronTaskEvent>, A
         logger.debug("Received event type {} for {}. Expected event type {}, Expected event name {}", event.getType(),
                      event.getName(), expectedEventType, expectedCronTaskName);
 
-        if (event.getType() == expectedEventType && expectedCronTaskName.equals(event.getName()))
+        if (event.getType() == expectedEventType &&
+            StringUtils.equals(expectedCronTaskUuid.toString(), event.getName()))
         {
             receivedExpectedEvent = true;
             receivedEvent = event;

--- a/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/ImmediateExecutionCronJobTestIT.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/ImmediateExecutionCronJobTestIT.java
@@ -5,12 +5,14 @@ import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 import org.carlspring.strongbox.cron.services.JobManager;
 
 import javax.inject.Inject;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -34,10 +36,11 @@ public class ImmediateExecutionCronJobTestIT
         super.init(testInfo);
     }
 
-    public void addImmediateExecutionCronJobConfig(String name)
+    public void addImmediateExecutionCronJobConfig(final UUID uuid, final String name)
             throws Exception
     {
         CronTaskConfigurationDto configuration = new CronTaskConfigurationDto();
+        configuration.setUuid(uuid);
         configuration.setName(name);
         configuration.setJobClass(ImmediateExecutionCronJob.class.getName());
         configuration.setCronExpression("0 11 11 11 11 ? 2100");
@@ -51,15 +54,17 @@ public class ImmediateExecutionCronJobTestIT
     public void testImmediateExecutionCronJob()
             throws Exception
     {
-        String jobName = expectedCronTaskName;
+        final UUID jobKey = expectedCronTaskUuid;
+        final String jobName = expectedCronTaskName;
 
         // Checking if job was executed
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            assertTrue(jobName1.equals(jobName) && statusExecuted);
+            assertEquals(jobKey1, jobKey.toString());
+            assertTrue(statusExecuted);
         });
 
-        addImmediateExecutionCronJobConfig(jobName);
+        addImmediateExecutionCronJobConfig(jobKey, jobName);
 
         assertTrue(expectEvent(), "Failed to execute task within a reasonable time!");
     }

--- a/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/OneTimeExecutionCronJobTestIT.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/OneTimeExecutionCronJobTestIT.java
@@ -3,6 +3,8 @@ package org.carlspring.strongbox.cron.jobs;
 import org.carlspring.strongbox.cron.context.CronTaskTest;
 import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -27,10 +29,11 @@ public class OneTimeExecutionCronJobTestIT
         super.init(testInfo);
     }
 
-    public void addOneTimeExecutionCronJobConfig(String name)
+    public void addOneTimeExecutionCronJobConfig(final UUID uuid, final String name)
             throws Exception
     {
         CronTaskConfigurationDto configuration = new CronTaskConfigurationDto();
+        configuration.setUuid(uuid);
         configuration.setName(name);
         configuration.setCronExpression("0 11 11 11 11 ? 2100");
         configuration.setJobClass(OneTimeExecutionCronJob.class.getName());
@@ -44,7 +47,7 @@ public class OneTimeExecutionCronJobTestIT
     public void testOneTimeExecutionCronJob()
             throws Exception
     {
-        addOneTimeExecutionCronJobConfig(expectedCronTaskName);
+        addOneTimeExecutionCronJobConfig(expectedCronTaskUuid, expectedCronTaskName);
 
         assertTrue(expectEvent(60000, 500), "Failed to execute task within a reasonable time!");
     }

--- a/strongbox-security/strongbox-authentication-registry/pom.xml
+++ b/strongbox-security/strongbox-authentication-registry/pom.xml
@@ -163,11 +163,6 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/strongbox-security/strongbox-user-management/pom.xml
+++ b/strongbox-security/strongbox-user-management/pom.xml
@@ -192,11 +192,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>

--- a/strongbox-storage/strongbox-storage-api/pom.xml
+++ b/strongbox-storage/strongbox-storage-api/pom.xml
@@ -208,11 +208,6 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
@@ -258,11 +258,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven.indexer</groupId>
             <artifactId>indexer-core</artifactId>
         </dependency>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithMavenIndexingTestCase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithMavenIndexingTestCase.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
@@ -41,6 +42,8 @@ public class BaseCronJobWithMavenIndexingTestCase
 
     private CronJobApplicationListener cronJobApplicationListener;
 
+    protected UUID expectedJobKey;
+
     protected String expectedJobName;
 
     /**
@@ -48,16 +51,18 @@ public class BaseCronJobWithMavenIndexingTestCase
      */
     protected Map<String, CronTaskConfigurationDto> cronTaskConfigurations = new LinkedHashMap<>();
 
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName,
+    protected CronTaskConfigurationDto addCronJobConfig(UUID jobKey,
+                                                        String jobName,
                                                         Class<? extends JavaCronJob> className,
                                                         String storageId,
                                                         String repositoryId)
             throws Exception
     {
-        return addCronJobConfig(jobName, className, storageId, repositoryId, null);
+        return addCronJobConfig(jobKey, jobName, className, storageId, repositoryId, null);
     }
 
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName,
+    protected CronTaskConfigurationDto addCronJobConfig(UUID jobKey,
+                                                        String jobName,
                                                         Class<? extends JavaCronJob> className,
                                                         String storageId,
                                                         String repositoryId,
@@ -71,10 +76,11 @@ public class BaseCronJobWithMavenIndexingTestCase
         {
             additionalProperties.accept(properties);
         }
-        return addCronJobConfig(jobName, className , properties );
+        return addCronJobConfig(jobKey, jobName, className , properties );
     }
 
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName,
+    protected CronTaskConfigurationDto addCronJobConfig(UUID jobKey,
+                                                        String jobName,
                                                         Class<? extends JavaCronJob> className,
                                                         Map<String, String> properties)
             throws Exception
@@ -83,7 +89,7 @@ public class BaseCronJobWithMavenIndexingTestCase
         cronTaskConfiguration.setCronExpression("0 11 11 11 11 ? 2100");
         cronTaskConfiguration.setOneTimeExecution(true);
         cronTaskConfiguration.setImmediateExecution(true);
-        cronTaskConfiguration.setUuid(UUID.randomUUID().toString());
+        cronTaskConfiguration.setUuid(jobKey);
         cronTaskConfiguration.setName(jobName);
         cronTaskConfiguration.setJobClass(className.getCanonicalName());
 
@@ -108,10 +114,12 @@ public class BaseCronJobWithMavenIndexingTestCase
     public void init(final TestInfo testInfo)
             throws Exception
     {
+        expectedJobKey = UUID.randomUUID();
+
         Optional<Method> method = testInfo.getTestMethod();
         expectedJobName = method.map(Method::getName).orElseThrow(() -> new IllegalStateException("No method name ?"));
 
-        cronJobApplicationListener = new CronJobApplicationListener(expectedJobName);
+        cronJobApplicationListener = new CronJobApplicationListener(expectedJobKey);
 
         ((ConfigurableApplicationContext) applicationContext).addApplicationListener(cronJobApplicationListener);
     }
@@ -124,11 +132,11 @@ public class BaseCronJobWithMavenIndexingTestCase
 
         private AtomicBoolean receivedExpectedEvent = new AtomicBoolean(false);
 
-        private final String expectedJobName;
+        private final UUID expectedJobKey;
 
-        public CronJobApplicationListener(final String expectedJobName)
+        public CronJobApplicationListener(final UUID expectedJobKey)
         {
-            this.expectedJobName = expectedJobName;
+            this.expectedJobKey = expectedJobKey;
         }
 
         @Override
@@ -139,7 +147,7 @@ public class BaseCronJobWithMavenIndexingTestCase
 
         public void handle(CronTaskEvent event)
         {
-            if (event.getType() == expectedEventType && expectedJobName.equals(event.getName()))
+            if (event.getType() == expectedEventType && StringUtils.equals(expectedJobKey.toString(), event.getName()))
             {
                 receivedExpectedEvent.set(true);
             }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -1,29 +1,22 @@
 package org.carlspring.strongbox.cron.jobs;
 
-import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
-
-import javax.inject.Inject;
-
 import org.carlspring.strongbox.config.Maven2LayoutProviderCronTasksTestConfig;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryAttributes;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import javax.inject.Inject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -33,6 +26,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
@@ -105,7 +101,8 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
         assertFalse(Files.exists(artifact1.normalize()), "The repository path exists!");
         assertTrue(Files.exists(RepositoryFiles.trash((RepositoryPath) artifact1.normalize())), "The repository trash is empty!");
 
-        addCronJobConfig(expectedJobName, ClearRepositoryTrashCronJob.class, STORAGE0, REPOSITORY_RELEASES_1);
+        addCronJobConfig(expectedJobKey, expectedJobName, ClearRepositoryTrashCronJob.class, STORAGE0,
+                         REPOSITORY_RELEASES_1);
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
         

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
@@ -13,8 +13,10 @@ import javax.inject.Inject;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,12 +127,13 @@ public class DownloadRemoteMavenIndexCronJobTestIT
     public void testDownloadRemoteIndexAndExecuteSearch()
             throws Exception
     {
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         // Checking if job was executed
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 // Requests against the remote index on the proxied repository:
                 // org.carlspring.strongbox.indexes.download:strongbox-test-one:1.0:jar
@@ -173,7 +176,7 @@ public class DownloadRemoteMavenIndexCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName, DownloadRemoteMavenIndexCronJob.class, STORAGE0,
+        addCronJobConfig(jobKey, jobName, DownloadRemoteMavenIndexCronJob.class, STORAGE0,
                          REPOSITORY_PROXIED_RELEASES);
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
@@ -14,8 +14,10 @@ import java.io.File;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,12 +98,13 @@ public class RebuildMavenIndexesCronJobTestIT
     public void testRebuildArtifactsIndexes(TestInfo testInfo)
             throws Exception
     {
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         // Checking if job was executed
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 SearchRequest request = new SearchRequest(STORAGE0,
                                                           getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
@@ -122,7 +125,8 @@ public class RebuildMavenIndexesCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RebuildMavenIndexesCronJob.class,
                          STORAGE0,
                          getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
@@ -135,10 +139,12 @@ public class RebuildMavenIndexesCronJobTestIT
     public void testRebuildIndexesInRepository(TestInfo testInfo)
             throws Exception
     {
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 try
                 {
@@ -169,7 +175,8 @@ public class RebuildMavenIndexesCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RebuildMavenIndexesCronJob.class,
                          STORAGE0,
                          getRepositoryName(REPOSITORY_RELEASES_1, testInfo));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenMetadataCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenMetadataCronJobTestIT.java
@@ -14,8 +14,10 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -95,10 +97,11 @@ public class RebuildMavenMetadataCronJobTestIT
 
         MavenArtifact artifact1 = createTestArtifact1(repositoryId);
 
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 try
                 {
@@ -125,7 +128,8 @@ public class RebuildMavenMetadataCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RebuildMavenMetadataCronJob.class,
                          STORAGE0,
                          repositoryId,
@@ -153,10 +157,11 @@ public class RebuildMavenMetadataCronJobTestIT
                          RepositoryPolicyEnum.SNAPSHOT.getPolicy(),
                          false);
 
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 try
                 {
@@ -196,7 +201,8 @@ public class RebuildMavenMetadataCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RebuildMavenMetadataCronJob.class,
                          STORAGE0,
                          repositoryId);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateMavenChecksumCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateMavenChecksumCronJobTestIT.java
@@ -14,8 +14,10 @@ import javax.inject.Inject;
 import java.io.File;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.file.Path;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -78,6 +80,7 @@ public class RegenerateMavenChecksumCronJobTestIT
                                                      "strongbox-checksum-one",
                                                      "2.0-20190512.202601-5");
 
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         String artifactPath = getRepositoryBasedir(STORAGE0, repository.getId()).getAbsolutePath() +
@@ -98,9 +101,9 @@ public class RegenerateMavenChecksumCronJobTestIT
         deleteIfExists(new File(artifactPath, "/maven-metadata.xml.md5"));
         deleteIfExists(new File(artifactPath, "/maven-metadata.xml.sha1"));
 
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
 
                 try
@@ -132,7 +135,7 @@ public class RegenerateMavenChecksumCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName, RegenerateChecksumCronJob.class, STORAGE0,
+        addCronJobConfig(jobKey, jobName, RegenerateChecksumCronJob.class, STORAGE0,
                          repository.getId(),
                          properties ->
                          {
@@ -164,6 +167,7 @@ public class RegenerateMavenChecksumCronJobTestIT
                                                      "strongbox-checksum-two",
                                                      "2.0-20190512.202601-5");
 
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         String artifactPath = getRepositoryBasedir(STORAGE0, repository.getId()).getAbsolutePath() +
@@ -184,9 +188,9 @@ public class RegenerateMavenChecksumCronJobTestIT
         deleteIfExists(new File(artifactPath, "/maven-metadata.xml.md5"));
         deleteIfExists(new File(artifactPath, "/maven-metadata.xml.sha1"));
 
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
-            if (jobName1.equals(jobName) && statusExecuted)
+            if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
                 try
                 {
@@ -219,7 +223,8 @@ public class RegenerateMavenChecksumCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RegenerateChecksumCronJob.class,
                          STORAGE0,
                          repository.getId(),

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -14,8 +14,10 @@ import java.io.File;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,6 +119,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     public void testRemoveTimestampedSnapshot(TestInfo testInfo)
             throws Exception
     {
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         String artifactPath = getRepositoryBasedir(STORAGE0, getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo)) +
@@ -124,11 +127,11 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
 
         File file = new File(artifactPath, "2.0-SNAPSHOT");
 
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
             try
             {
-                if (jobName.equals(jobName1) && statusExecuted)
+                if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
                 {
                     assertEquals(1, file.listFiles(new JarFilenameFilter()).length,
                                  "Amount of timestamped snapshots doesn't equal 1.");
@@ -141,7 +144,8 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RemoveTimestampedMavenSnapshotCronJob.class,
                          STORAGE0,
                          getRepositoryName(REPOSITORY_SNAPSHOTS,
@@ -160,6 +164,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     public void testRemoveTimestampedSnapshotInRepository(TestInfo testInfo)
             throws Exception
     {
+        final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
         String artifactPath = getRepositoryBasedir(STORAGE0, getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo)) +
@@ -167,11 +172,11 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
 
         File file = new File(artifactPath, "2.0-SNAPSHOT");
 
-        jobManager.registerExecutionListener(jobName, (jobName1, statusExecuted) ->
+        jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
             try
             {
-                if (jobName.equals(jobName1) && statusExecuted)
+                if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
                 {
                     assertEquals(1, file.listFiles(new JarFilenameFilter()).length,
                                  "Amount of timestamped snapshots doesn't equal 1.");
@@ -184,7 +189,8 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobName,
+        addCronJobConfig(jobKey,
+                         jobName,
                          RemoveTimestampedMavenSnapshotCronJob.class,
                          STORAGE0,
                          getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo),

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithNugetIndexingTestCase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithNugetIndexingTestCase.java
@@ -3,7 +3,6 @@ package org.carlspring.strongbox.cron.jobs;
 import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 import org.carlspring.strongbox.cron.services.CronTaskConfigurationService;
 import org.carlspring.strongbox.event.cron.CronTaskEvent;
-import org.carlspring.strongbox.event.cron.CronTaskEventListenerRegistry;
 import org.carlspring.strongbox.event.cron.CronTaskEventTypeEnum;
 import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
 
@@ -15,6 +14,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -26,12 +26,11 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @author carlspring
  */
 public class BaseCronJobWithNugetIndexingTestCase
-        extends TestCaseWithNugetPackageGeneration implements ApplicationListener<CronTaskEvent>, ApplicationContextAware
+        extends TestCaseWithNugetPackageGeneration
+        implements ApplicationListener<CronTaskEvent>, ApplicationContextAware
 {
-    public static final long CRON_TASK_CHECK_INTERVAL = 500L;
 
-    @Inject
-    protected CronTaskEventListenerRegistry cronTaskEventListenerRegistry;
+    public static final long CRON_TASK_CHECK_INTERVAL = 500L;
 
     @Inject
     protected CronTaskConfigurationService cronTaskConfigurationService;
@@ -47,20 +46,24 @@ public class BaseCronJobWithNugetIndexingTestCase
 
     protected boolean receivedExpectedEvent = false;
 
+    protected UUID expectedJobKey;
+
     protected String expectedJobName;
 
     public void init(TestInfo testInfo)
             throws Exception
     {
+        expectedJobKey = UUID.randomUUID();
+
         Optional<Method> method = testInfo.getTestMethod();
         expectedJobName = method.map(Method::getName).orElse(null);
     }
-    
+
     @Override
     public void setApplicationContext(ApplicationContext applicationContext)
-        throws BeansException
+            throws BeansException
     {
-        ((ConfigurableApplicationContext) applicationContext).addApplicationListener(this);        
+        ((ConfigurableApplicationContext) applicationContext).addApplicationListener(this);
     }
 
     @Override
@@ -69,16 +72,8 @@ public class BaseCronJobWithNugetIndexingTestCase
         handle(event);
     }
 
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName,
-                                                        Class<? extends JavaCronJob> className,
-                                                        String storageId,
-                                                        String repositoryId)
-            throws Exception
-    {
-        return addCronJobConfig(jobName,className,storageId, repositoryId,null);
-    }
-
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName,
+    protected CronTaskConfigurationDto addCronJobConfig(UUID jobKey,
+                                                        String jobName,
                                                         Class<? extends JavaCronJob> className,
                                                         String storageId,
                                                         String repositoryId,
@@ -92,17 +87,20 @@ public class BaseCronJobWithNugetIndexingTestCase
         {
             additionalProperties.accept(properties);
         }
-        return addCronJobConfig(jobName, className, properties);
+        return addCronJobConfig(jobKey, jobName, className, properties);
     }
 
-    protected CronTaskConfigurationDto addCronJobConfig(String jobName, Class<? extends JavaCronJob> className, Map<String, String> properties)
+    protected CronTaskConfigurationDto addCronJobConfig(UUID jobKey,
+                                                        String jobName,
+                                                        Class<? extends JavaCronJob> className,
+                                                        Map<String, String> properties)
             throws Exception
     {
         CronTaskConfigurationDto cronTaskConfiguration = new CronTaskConfigurationDto();
         cronTaskConfiguration.setCronExpression("0 11 11 11 11 ? 2100");
         cronTaskConfiguration.setOneTimeExecution(true);
         cronTaskConfiguration.setImmediateExecution(true);
-        cronTaskConfiguration.setUuid(UUID.randomUUID().toString());
+        cronTaskConfiguration.setUuid(jobKey);
         cronTaskConfiguration.setName(jobName);
         cronTaskConfiguration.setJobClass(className.getCanonicalName());
 
@@ -113,14 +111,14 @@ public class BaseCronJobWithNugetIndexingTestCase
 
         cronTaskConfigurationService.saveConfiguration(cronTaskConfiguration);
 
-        addCronTaskConfiguration(jobName, cronTaskConfiguration);
+        addCronTaskConfiguration(jobKey.toString(), cronTaskConfiguration);
 
         return cronTaskConfiguration;
     }
 
     public void handle(CronTaskEvent event)
     {
-        if (event.getType() == expectedEventType && expectedJobName.equals(event.getName()))
+        if (event.getType() == expectedEventType && StringUtils.equals(expectedJobKey.toString(), event.getName()))
         {
             receivedExpectedEvent = true;
             receivedEvent = event;
@@ -136,15 +134,17 @@ public class BaseCronJobWithNugetIndexingTestCase
     /**
      * Waits for an event to occur.
      *
-     * @param maxWaitTime           The maximum wait time (in milliseconds)
-     * @param checkInterval         The interval (in milliseconds) at which to check for the occurrence of the event
+     * @param maxWaitTime   The maximum wait time (in milliseconds)
+     * @param checkInterval The interval (in milliseconds) at which to check for the occurrence of the event
      */
-    public boolean expectEvent(long maxWaitTime, long checkInterval) throws InterruptedException
+    public boolean expectEvent(long maxWaitTime,
+                               long checkInterval)
+            throws InterruptedException
     {
         int totalWait = 0;
         while (!receivedExpectedEvent &&
                (maxWaitTime > 0 && totalWait <= maxWaitTime || // If a maxWaitTime has been defined,
-                maxWaitTime == 0 ))                            // otherwise, default to forever
+                maxWaitTime == 0))                            // otherwise, default to forever
         {
             Thread.sleep(checkInterval);
             totalWait += checkInterval;

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -506,11 +506,6 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
         

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/cron/CronTaskController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/cron/CronTaskController.java
@@ -135,7 +135,7 @@ public class CronTaskController
                 consumes = MediaType.APPLICATION_JSON_VALUE,
                 produces = { MediaType.TEXT_PLAIN_VALUE,
                              MediaType.APPLICATION_JSON_VALUE })
-    public ResponseEntity updateConfiguration(@PathVariable("UUID") String uuid,
+    public ResponseEntity updateConfiguration(@PathVariable("UUID") UUID uuid,
                                               @RequestBody @Validated CronTaskConfigurationForm cronTaskConfigurationForm,
                                               BindingResult bindingResult,
                                               @RequestHeader(HttpHeaders.ACCEPT) String acceptHeader)
@@ -175,7 +175,7 @@ public class CronTaskController
     @DeleteMapping(value = "{UUID}",
             produces = { MediaType.TEXT_PLAIN_VALUE,
                          MediaType.APPLICATION_JSON_VALUE })
-    public ResponseEntity deleteConfiguration(@PathVariable("UUID") String uuid,
+    public ResponseEntity deleteConfiguration(@PathVariable("UUID") UUID uuid,
                                               @RequestHeader(HttpHeaders.ACCEPT) String acceptHeader)
     {
         final CronTaskConfigurationDto config = cronTaskConfigurationService.getTaskConfigurationDto(uuid);
@@ -225,7 +225,7 @@ public class CronTaskController
     @GetMapping(value = "/{UUID}",
                 produces = { MediaType.APPLICATION_JSON_VALUE,
                              APPLICATION_YAML_VALUE })
-    public ResponseEntity getConfiguration(@PathVariable("UUID") String uuid,
+    public ResponseEntity getConfiguration(@PathVariable("UUID") UUID uuid,
                                            @RequestHeader(HttpHeaders.ACCEPT) String acceptHeader)
     {
         CronTaskConfigurationDto config = cronTaskConfigurationService.getTaskConfigurationDto(uuid);
@@ -259,7 +259,7 @@ public class CronTaskController
     @PutMapping(value = "/cron/groovy/{UUID}",
                 produces = { MediaType.TEXT_PLAIN_VALUE,
                              MediaType.APPLICATION_JSON_VALUE })
-    public ResponseEntity uploadGroovyScript(@PathVariable("UUID") String uuid,
+    public ResponseEntity uploadGroovyScript(@PathVariable("UUID") UUID uuid,
                                              HttpServletRequest request,
                                              @RequestHeader(HttpHeaders.ACCEPT) String acceptHeader)
     {

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/cron/CronTaskControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/cron/CronTaskControllerTest.java
@@ -11,6 +11,7 @@ import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.UUID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.emory.mathcs.backport.java.util.Arrays;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -340,8 +340,8 @@ public class CronTaskControllerTest
                                  .extract()
                                  .headers();
 
-        String cronUuid = headers.getValue(HEADER_NAME_CRON_TASK_ID);
-        assertThat(cronUuid).isNotEmpty();
+        UUID cronUuid = UUID.fromString(headers.getValue(HEADER_NAME_CRON_TASK_ID));
+        assertThat(cronUuid).isNotNull();
 
         deleteConfig(cronUuid);
     }
@@ -368,8 +368,8 @@ public class CronTaskControllerTest
                                  .extract()
                                  .headers();
 
-        String cronUuid = headers.getValue(HEADER_NAME_CRON_TASK_ID);
-        assertThat(cronUuid).isNotEmpty();
+        UUID cronUuid = UUID.fromString(headers.getValue(HEADER_NAME_CRON_TASK_ID));
+        assertThat(cronUuid).isNotNull();
 
         CronTaskConfigurationDto config = given().contentType(MediaType.APPLICATION_JSON_VALUE)
                                                  .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -440,8 +440,8 @@ public class CronTaskControllerTest
                                  .extract()
                                  .headers();
 
-        String cronUuid = headers.getValue(HEADER_NAME_CRON_TASK_ID);
-        assertThat(cronUuid).isNotEmpty();
+        UUID cronUuid = UUID.fromString(headers.getValue(HEADER_NAME_CRON_TASK_ID));
+        assertThat(cronUuid).isNotNull();
 
         uploadGroovyScript(cronUuid);
 
@@ -460,7 +460,7 @@ public class CronTaskControllerTest
                .statusCode(OK);
     }
 
-    private void uploadGroovyScript(String uuid)
+    private void uploadGroovyScript(UUID uuid)
             throws Exception
     {
         String url = getContextBaseUrl() + "/cron/groovy/" + uuid;
@@ -485,7 +485,7 @@ public class CronTaskControllerTest
                .statusCode(OK);
     }
 
-    private void deleteConfig(String cronUuid)
+    private void deleteConfig(UUID cronUuid)
     {
         MockMvcResponse response = deleteCronConfig(cronUuid);
 
@@ -497,7 +497,7 @@ public class CronTaskControllerTest
         assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatusCode(), "Cron task config exists!");
     }
 
-    private MockMvcResponse deleteCronConfig(String uuid)
+    private MockMvcResponse deleteCronConfig(UUID uuid)
     {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                       .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -514,7 +514,7 @@ public class CronTaskControllerTest
                       .peek();
     }
 
-    private MockMvcResponse getCronConfig(String uuid)
+    private MockMvcResponse getCronConfig(UUID uuid)
     {
         return given().contentType(MediaType.APPLICATION_JSON_VALUE)
                       .accept(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
Fixes #1300.

# Tasks
* [x] Change the `CronTaskConfigurationDto#uuid` type from 'String' to 'UUID', and all affected classes.
* [x] Dispatching of cron events use the cron task UUID instead of its name.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.