### PR TITLE
Issue-1295: Make the NugetArtifactGenerator implement the ArtifactGenerator interface

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/coordinates/NugetArtifactConverterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/coordinates/NugetArtifactConverterTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @Execution(CONCURRENT)
-public class NugetPackageConverterTest
+public class NugetArtifactConverterTest
 {
 
     @Test

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
@@ -60,12 +60,12 @@ public class NugetArtifactGenerator
 
     public NugetArtifactGenerator(String basedir)
     {
-        this.basedir = Paths.get(basedir);
+        this.basedir = Paths.get(basedir).normalize().toAbsolutePath();
     }
 
     public NugetArtifactGenerator(Path basedir)
     {
-        this.basedir = basedir;
+        this.basedir = basedir.normalize().toAbsolutePath();
     }
 
     @Override
@@ -89,8 +89,8 @@ public class NugetArtifactGenerator
         return generateArtifact(nac.getId(), nac.getVersion());
     }
 
-    private Path generateArtifact(String id,
-                                  String version)
+    public Path generateArtifact(String id,
+                                 String version)
             throws IOException
     {
         try
@@ -109,8 +109,7 @@ public class NugetArtifactGenerator
             throws IOException, NoSuchAlgorithmException, JAXBException, NugetFormatException
     {
         NugetArtifactCoordinates nac = new NugetArtifactCoordinates(id, version, "nupkg");
-        Path basePath = Paths.get(getBasedir()).normalize().toAbsolutePath();
-        Path nupkgPath = basePath.resolve(nac.toPath()).normalize().toAbsolutePath();
+        Path nupkgPath = basedir.resolve(nac.toPath()).normalize().toAbsolutePath();
         Files.createDirectories(nupkgPath.getParent());
 
         SemanticVersion semanticVersion = SemanticVersion.parse(version);
@@ -346,7 +345,7 @@ public class NugetArtifactGenerator
 
     public String getBasedir()
     {
-        return basedir.toAbsolutePath().toString();
+        return basedir.normalize().toAbsolutePath().toString();
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithNugetIndexingTestCase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronJobWithNugetIndexingTestCase.java
@@ -4,7 +4,7 @@ import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 import org.carlspring.strongbox.cron.services.CronTaskConfigurationService;
 import org.carlspring.strongbox.event.cron.CronTaskEvent;
 import org.carlspring.strongbox.event.cron.CronTaskEventTypeEnum;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
 
 import javax.inject.Inject;
 import java.lang.reflect.Method;
@@ -26,7 +26,7 @@ import org.springframework.context.ConfigurableApplicationContext;
  * @author carlspring
  */
 public class BaseCronJobWithNugetIndexingTestCase
-        extends TestCaseWithNugetPackageGeneration
+        extends TestCaseWithNugetArtifactGeneration
         implements ApplicationListener<CronTaskEvent>, ApplicationContextAware
 {
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateNugetChecksumCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RegenerateNugetChecksumCronJobTestIT.java
@@ -124,24 +124,24 @@ public class RegenerateNugetChecksumCronJobTestIT
         createRepository(STORAGE1, REPOSITORY_RELEASES, RepositoryPolicyEnum.RELEASE.getPolicy());
 
         //Create released nuget package in the repository rnccj-releases (storage1)
-        generateNugetPackage(getRepositoryBasedir(STORAGE1, REPOSITORY_RELEASES),
-                             "org.carlspring.strongbox.checksum-second", "1.0.0");
+        generateNugetArtifact(getRepositoryBasedir(STORAGE1, REPOSITORY_RELEASES),
+                              "org.carlspring.strongbox.checksum-second", "1.0.0");
 
         createRepository(STORAGE1, REPOSITORY_ALPHA, RepositoryPolicyEnum.SNAPSHOT.getPolicy());
 
         //Create pre-released nuget package in the repository rnccj-alpha
-        generateAlphaNugetPackage(getRepositoryBasedir(STORAGE1, REPOSITORY_ALPHA),
-                                  "org.carlspring.strongbox.checksum-one",
-                                  "1.0.1");
+        generateAlphaNugetArtifact(getRepositoryBasedir(STORAGE1, REPOSITORY_ALPHA),
+                                   "org.carlspring.strongbox.checksum-one",
+                                   "1.0.1");
 
         createStorage(STORAGE2);
 
         createRepository(STORAGE2, REPOSITORY_RELEASES, RepositoryPolicyEnum.RELEASE.getPolicy());
 
         //Create released nuget package in the repository rnccj-releases (storage2)
-        generateNugetPackage(getRepositoryBasedir(STORAGE2, REPOSITORY_RELEASES),
-                             "org.carlspring.strongbox.checksum-one",
-                             "1.0.0");
+        generateNugetArtifact(getRepositoryBasedir(STORAGE2, REPOSITORY_RELEASES),
+                              "org.carlspring.strongbox.checksum-one",
+                              "1.0.0");
     }
 
     @AfterEach
@@ -158,7 +158,7 @@ public class RegenerateNugetChecksumCronJobTestIT
     }
 
     @Test
-    public void testRegenerateNugetPackageChecksum()
+    public void testRegenerateNugetArtifactChecksum()
             throws Exception
     {
         final UUID jobKey = expectedJobKey;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/nuget/filter/NugetFilterODataParserTestCase.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/nuget/filter/NugetFilterODataParserTestCase.java
@@ -10,7 +10,7 @@ import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.providers.layout.NugetLayoutProvider;
 import org.carlspring.strongbox.services.RepositoryManagementService;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = NugetLayoutProviderTestConfig.class)
-public class NugetFilterODataParserTestCase extends TestCaseWithNugetPackageGeneration
+public class NugetFilterODataParserTestCase extends TestCaseWithNugetArtifactGeneration
 {
 
     private static final String REPOSITORY_RELEASES_1 = "nfpt-releases-1";
@@ -57,7 +57,7 @@ public class NugetFilterODataParserTestCase extends TestCaseWithNugetPackageGene
     {
         createRepository(createRepositoryMock(STORAGE0, REPOSITORY_RELEASES_1, NugetLayoutProvider.ALIAS),
                          NugetLayoutProvider.ALIAS);
-        generateRepositoryPackages(STORAGE0, REPOSITORY_RELEASES_1, "Org.Carlspring.Strongbox.Nuget.Test.Nfpt", 9);
+        generateRepositoryArtifacts(STORAGE0, REPOSITORY_RELEASES_1, "Org.Carlspring.Strongbox.Nuget.Test.Nfpt", 9);
 
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/NugetGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/NugetGroupRepositoryProviderTest.java
@@ -11,7 +11,7 @@ import org.carlspring.strongbox.storage.repository.MutableRepository;
 import org.carlspring.strongbox.storage.repository.NugetRepositoryFactory;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
 import org.carlspring.strongbox.yaml.configuration.repository.MutableNugetRepositoryConfiguration;
 
 import javax.inject.Inject;
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ContextConfiguration(classes = NugetLayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
 public class NugetGroupRepositoryProviderTest
-        extends TestCaseWithNugetPackageGeneration
+        extends TestCaseWithNugetArtifactGeneration
 {
 
     private static final String REPOSITORY_RELEASES_1 = "grpt-releases-1";
@@ -88,17 +88,17 @@ public class NugetGroupRepositoryProviderTest
 
         //REPOSITORY_RELEASES_1
         createRepository(STORAGE0, createRepositoryMock(STORAGE0, REPOSITORY_RELEASES_1, NugetLayoutProvider.ALIAS), NugetLayoutProvider.ALIAS);
-        generateRepositoryPackages(STORAGE0, REPOSITORY_RELEASES_1, "grpt.search.package", 9);
+        generateRepositoryArtifacts(STORAGE0, REPOSITORY_RELEASES_1, "grpt.search.package", 9);
 
         //REPOSITORY_RELEASES_2
         createRepository(STORAGE0, createRepositoryMock(STORAGE0, REPOSITORY_RELEASES_2, NugetLayoutProvider.ALIAS),
                          NugetLayoutProvider.ALIAS);
-        generateRepositoryPackages(STORAGE0, REPOSITORY_RELEASES_2, "grpt.search.package", 12);
+        generateRepositoryArtifacts(STORAGE0, REPOSITORY_RELEASES_2, "grpt.search.package", 12);
         
         //REPOSITORY_RELEASES_3
         createRepository(STORAGE0, createRepositoryMock(STORAGE0, REPOSITORY_RELEASES_3, NugetLayoutProvider.ALIAS),
                          NugetLayoutProvider.ALIAS);
-        generateRepositoryPackages(STORAGE0, REPOSITORY_RELEASES_3, "grpt.search.package", 8);
+        generateRepositoryArtifacts(STORAGE0, REPOSITORY_RELEASES_3, "grpt.search.package", 8);
 
         MutableRepository repositoryGroup = nugetRepositoryFactory.createRepository(REPOSITORY_GROUP);
         repositoryGroup.setType(RepositoryTypeEnum.GROUP.getType());

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/storage/metadata/nuget/TempNupkgFileTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/storage/metadata/nuget/TempNupkgFileTest.java
@@ -20,7 +20,7 @@ package org.carlspring.strongbox.storage.metadata.nuget;
 import org.carlspring.strongbox.artifact.coordinates.versioning.SemanticVersion;
 import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.config.NugetBootersTestConfig;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
 import org.carlspring.strongbox.util.MessageDigestUtils;
 
 import javax.inject.Inject;
@@ -94,11 +94,9 @@ public class TempNupkgFileTest
         // GIVEN
         String packageId = "NUnit";
         String packageVersion = "2.5.9.10348";
-        Path packageFilePath = TestCaseWithNugetPackageGeneration.generatePackageFile(baseDirectoryPath, packageId,
-                                                                                      packageVersion,
-                                                                                      (String[]) null/*
-                                                                                                      * dependencyList
-                                                                                                      */);
+        Path packageFilePath = TestCaseWithNugetArtifactGeneration.generateArtifactFile(baseDirectoryPath,
+                                                                                        packageId,
+                                                                                        packageVersion);
 
         String checksumFileName = packageId + "." + packageVersion + ".nupkg.sha512";
         Path checksumPath = packageFilePath.resolveSibling(checksumFileName);
@@ -132,12 +130,9 @@ public class TempNupkgFileTest
         String expectedPackageId = "NUnit";
         String expectedPackageVersion = "2.5.9.10348";
 
-        Path packageFilePath = TestCaseWithNugetPackageGeneration.generatePackageFile(baseDirectoryPath,
-                                                                                      expectedPackageId,
-                                                                                      expectedPackageVersion,
-                                                                                      (String[]) null/*
-                                                                                                      * dependencyList
-                                                                                                      */);
+        Path packageFilePath = TestCaseWithNugetArtifactGeneration.generateArtifactFile(baseDirectoryPath,
+                                                                                        expectedPackageId,
+                                                                                        expectedPackageVersion);
 
         // WHEN
         try (InputStream nupkgInputStream = new BufferedInputStream(Files.newInputStream(packageFilePath));
@@ -172,12 +167,9 @@ public class TempNupkgFileTest
         String packageId = "NUnit";
         String packageVersion = "2.5.9.10348";
 
-        Path packageFilePath = TestCaseWithNugetPackageGeneration.generatePackageFile(baseDirectoryPath,
-                                                                                      packageId,
-                                                                                      packageVersion,
-                                                                                      (String[]) null/*
-                                                                                                      * dependencyList
-                                                                                                      */);
+        Path packageFilePath = TestCaseWithNugetArtifactGeneration.generateArtifactFile(baseDirectoryPath,
+                                                                                        packageId,
+                                                                                        packageVersion);
 
         // WHEN
         try (InputStream nupkgInputStream = new BufferedInputStream(Files.newInputStream(packageFilePath));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/storage/metadata/nuget/rss/PackageFeedTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/storage/metadata/nuget/rss/PackageFeedTest.java
@@ -1,5 +1,13 @@
 package org.carlspring.strongbox.storage.metadata.nuget.rss;
 
+import org.carlspring.strongbox.booters.PropertiesBooter;
+import org.carlspring.strongbox.config.NugetBootersTestConfig;
+import org.carlspring.strongbox.storage.metadata.nuget.NugetTestResourceUtil;
+import org.carlspring.strongbox.storage.metadata.nuget.TempNupkgFile;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
+
+import javax.inject.Inject;
+import javax.xml.bind.JAXBException;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -8,25 +16,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
 
-import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
-
 import org.apache.commons.io.FileUtils;
-import org.carlspring.strongbox.booters.PropertiesBooter;
-import org.carlspring.strongbox.config.NugetBootersTestConfig;
-import org.carlspring.strongbox.storage.metadata.nuget.NugetTestResourceUtil;
-import org.carlspring.strongbox.storage.metadata.nuget.TempNupkgFile;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class RSS
@@ -122,12 +121,9 @@ public class PackageFeedTest
         // GIVEN
         String packageId = "NUnit";
         String packageVersion = "2.5.9.10348";
-        Path packageFilePath = TestCaseWithNugetPackageGeneration.generatePackageFile(baseDirectoryPath,
-                                                                                      packageId,
-                                                                                      packageVersion,
-                                                                                      (String[]) null/*
-                                                                                                      * dependencyList
-                                                                                                      */);
+        Path packageFilePath = TestCaseWithNugetArtifactGeneration.generateArtifactFile(baseDirectoryPath,
+                                                                                        packageId,
+                                                                                        packageVersion);
 
         try (InputStream nupkgInputStream = new BufferedInputStream(Files.newInputStream(packageFilePath));
                 TempNupkgFile nupkgFile = new TempNupkgFile(nupkgInputStream);)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithNugetArtifactGeneration.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithNugetArtifactGeneration.java
@@ -104,8 +104,8 @@ public class TestCaseWithNugetArtifactGeneration
                    NugetFormatException,
                    JAXBException
     {
-        ArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
-        generator.generateArtifact(id, version, 0);
+        NugetArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
+        generator.generateArtifact(id, version);
     }
 
     public void generateAlphaNugetArtifact(String repositoryDir,
@@ -116,9 +116,9 @@ public class TestCaseWithNugetArtifactGeneration
                    NugetFormatException,
                    JAXBException
     {
-        ArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
+        NugetArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
 
-        generator.generateArtifact(id, getNugetSnapshotVersion(version), 0);
+        generator.generateArtifact(id, getNugetSnapshotVersion(version));
     }
 
     private String getNugetSnapshotVersion(String version)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithNugetArtifactGeneration.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithNugetArtifactGeneration.java
@@ -1,7 +1,8 @@
 package org.carlspring.strongbox.testing;
 
 import org.carlspring.strongbox.artifact.coordinates.NugetArtifactCoordinates;
-import org.carlspring.strongbox.artifact.generator.NugetPackageGenerator;
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+import org.carlspring.strongbox.artifact.generator.NugetArtifactGenerator;
 import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
@@ -22,8 +23,9 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
-public class TestCaseWithNugetPackageGeneration
+public class TestCaseWithNugetArtifactGeneration
         extends TestCaseWithRepository
 {
 
@@ -36,10 +38,10 @@ public class TestCaseWithNugetPackageGeneration
     @Inject
     protected RepositoryPathResolver repositoryPathResolver;
 
-    public void generateRepositoryPackages(String storageId,
-                                           String repositoryId,
-                                           String packageId,
-                                           int count)
+    public void generateRepositoryArtifacts(String storageId,
+                                            String repositoryId,
+                                            String packageId,
+                                            int count)
             throws NoSuchAlgorithmException,
                    NugetFormatException,
                    JAXBException,
@@ -51,8 +53,8 @@ public class TestCaseWithNugetPackageGeneration
         {
             String packageVersion = String.format("1.0.%s", i);
             NugetArtifactCoordinates coordinates = new NugetArtifactCoordinates(packageId, packageVersion, "nupkg");
-            Path packageFilePath = generatePackageFile(packageId, packageVersion);
-            try (InputStream is = new BufferedInputStream(Files.newInputStream(packageFilePath)))
+            Path artifactFilePath = generateArtifactFile(packageId, packageVersion);
+            try (InputStream is = new BufferedInputStream(Files.newInputStream(artifactFilePath)))
             {
                 RepositoryPath repositoryPath = repositoryPathResolver.resolve(storageId,
                                                                                repositoryId,
@@ -62,22 +64,20 @@ public class TestCaseWithNugetPackageGeneration
         }
     }
 
-    public Path generatePackageFile(String packageId,
-                                    String packageVersion,
-                                    String... dependencyList)
+    public Path generateArtifactFile(String packageId,
+                                     String packageVersion)
             throws NoSuchAlgorithmException,
                    NugetFormatException,
                    JAXBException,
                    IOException
     {
         String basedir = propertiesBooter.getHomeDirectory() + "/tmp";
-        return generatePackageFile(basedir, packageId, packageVersion, dependencyList);
+        return generateArtifactFile(basedir, packageId, packageVersion);
     }
 
-    public static Path generatePackageFile(String basedir,
-                                           String packageId,
-                                           String packageVersion,
-                                           String... dependencyList)
+    public static Path generateArtifactFile(String basedir,
+                                            String packageId,
+                                            String packageVersion)
             throws NugetFormatException,
                    JAXBException,
                    IOException,
@@ -85,8 +85,8 @@ public class TestCaseWithNugetPackageGeneration
     {
         String packageFileName = packageId + "." + packageVersion + ".nupkg";
 
-        NugetPackageGenerator nugetPackageGenerator = new NugetPackageGenerator(basedir);
-        nugetPackageGenerator.generateNugetPackage(packageId, packageVersion, dependencyList);
+        ArtifactGenerator nugetArtifactGenerator = new NugetArtifactGenerator(basedir);
+        nugetArtifactGenerator.generateArtifact(packageId, packageVersion, 0);
 
         Path basePath = Paths.get(basedir).normalize().toAbsolutePath();
         return basePath.resolve(packageId)
@@ -96,31 +96,29 @@ public class TestCaseWithNugetPackageGeneration
                        .toAbsolutePath();
     }
 
-    public void generateNugetPackage(String repositoryDir,
-                                     String id,
-                                     String version,
-                                     String... dependencyList)
+    public void generateNugetArtifact(String repositoryDir,
+                                      String id,
+                                      String version)
             throws IOException,
                    NoSuchAlgorithmException,
                    NugetFormatException,
                    JAXBException
     {
-        NugetPackageGenerator generator = new NugetPackageGenerator(repositoryDir);
-        generator.generateNugetPackage(id, version, dependencyList);
+        ArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
+        generator.generateArtifact(id, version, 0);
     }
 
-    public void generateAlphaNugetPackage(String repositoryDir,
-                                          String id,
-                                          String version,
-                                          String... dependencyList)
+    public void generateAlphaNugetArtifact(String repositoryDir,
+                                           String id,
+                                           String version)
             throws IOException,
                    NoSuchAlgorithmException,
                    NugetFormatException,
                    JAXBException
     {
-        NugetPackageGenerator generator = new NugetPackageGenerator(repositoryDir);
+        ArtifactGenerator generator = new NugetArtifactGenerator(repositoryDir);
 
-        generator.generateNugetPackage(id, getNugetSnapshotVersion(version), dependencyList);
+        generator.generateArtifact(id, getNugetSnapshotVersion(version), 0);
     }
 
     private String getNugetSnapshotVersion(String version)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
@@ -93,7 +93,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     {
         String packageId = "Org.Carlspring.Strongbox.Examples.Nuget.Mono.Delete";
         String packageVersion = "1.0.0";
-        Path packageFile = generatePackageFile(packageId, packageVersion);
+        Path packageFile = generateArtifactFile(packageId, packageVersion);
         byte[] packageContent = readPackageContent(packageFile);
 
         // Push
@@ -133,7 +133,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         //Hosted repository
         String packageId = "Org.Carlspring.Strongbox.Examples.Nuget.Mono.Header";
         String packageVersion = "1.0.0";
-        Path packageFile = generatePackageFile(packageId, packageVersion);
+        Path packageFile = generateArtifactFile(packageId, packageVersion);
         byte[] packageContent = readPackageContent(packageFile);
 
         createPushRequest(packageContent).when()
@@ -184,7 +184,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     {
         String packageId = "Org.Carlspring.Strongbox.Examples.Nuget.Mono";
         String packageVersion = "1.0.0";
-        Path packageFile = generatePackageFile(packageId, packageVersion);
+        Path packageFile = generateArtifactFile(packageId, packageVersion);
         long packageSize = Files.size(packageFile);
         byte[] packageContent = readPackageContent(packageFile);
 
@@ -268,7 +268,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     {
         String packageId = "Org.Carlspring.Strongbox.Nuget.Test.Search";
         String packageVersion = "1.0.0";
-        byte[] packageContent = readPackageContent(generatePackageFile(packageId, packageVersion));
+        byte[] packageContent = readPackageContent(generateArtifactFile(packageId, packageVersion));
 
         // Push
         createPushRequest(packageContent).when()
@@ -312,7 +312,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     {
         String packageId = "Org.Carlspring.Strongbox.Nuget.Test.LastVersion";
         String packageVersion = "1.0.0";
-        byte[] packageContent = readPackageContent(generatePackageFile(packageId, packageVersion));
+        byte[] packageContent = readPackageContent(generateArtifactFile(packageId, packageVersion));
 
         // Push
         createPushRequest(packageContent).when()
@@ -355,7 +355,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
 
         // VERSION 2.0.0
         packageVersion = "2.0.0";
-        packageContent = readPackageContent(generatePackageFile(packageId, packageVersion));
+        packageContent = readPackageContent(generateArtifactFile(packageId, packageVersion));
         createPushRequest(packageContent).when()
                                          .put(getContextBaseUrl() + "/storages/" + STORAGE_ID + "/" +
                                                  REPOSITORY_RELEASES_1 + "/")

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NugetRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NugetRestAssuredBaseTest.java
@@ -7,7 +7,7 @@ import org.carlspring.strongbox.services.RepositoryManagementService;
 import org.carlspring.strongbox.services.StorageManagementService;
 import org.carlspring.strongbox.storage.MutableStorage;
 import org.carlspring.strongbox.storage.repository.MutableRepository;
-import org.carlspring.strongbox.testing.TestCaseWithNugetPackageGeneration;
+import org.carlspring.strongbox.testing.TestCaseWithNugetArtifactGeneration;
 
 import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Alex Oreshkevich
  */
 public abstract class NugetRestAssuredBaseTest
-        extends TestCaseWithNugetPackageGeneration
+        extends TestCaseWithNugetArtifactGeneration
 {
 
     public final static int DEFAULT_PORT = 48080;


### PR DESCRIPTION
Fixes #1295.

# Tasks
* [x] Rename all classes wihich contain `NugetPackage` to `NugetArtifact`.
* [x] Make the `NugetArtifactGenerator` implement the `ArtifactGenerator` interface.
* [x] Create [Pull Request](https://github.com/strongbox/strongbox-web-integration-tests/pull/47) for `s-w-i-t`.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.