### PR TITLE
Issue 1171: Dropping privileges from authorization configuration

### DIFF
--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/test/java/org/carlspring/strongbox/authentication/api/impl/ldap/LdapAuthenticationProviderTest.java
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/test/java/org/carlspring/strongbox/authentication/api/impl/ldap/LdapAuthenticationProviderTest.java
@@ -106,7 +106,5 @@ public class LdapAuthenticationProviderTest
 
             return new PropertiesPropertySource(STRONGBOX_AUTHENTICATION_PROVIDERS, properties);
         }
-
     }
-
 }

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/domain/AuthorizationConfig.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/domain/AuthorizationConfig.java
@@ -1,7 +1,6 @@
 package org.carlspring.strongbox.authorization.domain;
 
 import org.carlspring.strongbox.authorization.dto.AuthorizationConfigDto;
-import org.carlspring.strongbox.authorization.dto.PrivilegeDto;
 import org.carlspring.strongbox.authorization.dto.RoleDto;
 
 import javax.annotation.concurrent.Immutable;
@@ -20,12 +19,9 @@ public class AuthorizationConfig
 
     private final Set<Role> roles;
 
-    private final Set<Privilege> privileges;
-
     public AuthorizationConfig(final AuthorizationConfigDto source)
     {
         this.roles = immuteRoles(source.getRoles());
-        this.privileges = immutePrivileges(source.getPrivileges());
     }
 
     private Set<Role> immuteRoles(final Set<RoleDto> source)
@@ -34,19 +30,9 @@ public class AuthorizationConfig
                 Collectors.toSet())) : Collections.emptySet();
     }
 
-    private Set<Privilege> immutePrivileges(final Set<PrivilegeDto> source)
-    {
-        return source != null ? ImmutableSet.copyOf(source.stream().map(Privilege::new).collect(
-                Collectors.toSet())) : Collections.emptySet();
-    }
-
     public Set<Role> getRoles()
     {
         return roles;
     }
-
-    public Set<Privilege> getPrivileges()
-    {
-        return privileges;
-    }
 }
+

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/dto/AuthorizationConfigDto.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/dto/AuthorizationConfigDto.java
@@ -21,8 +21,6 @@ public class AuthorizationConfigDto
 
     private Set<RoleDto> roles = new LinkedHashSet<>();
 
-    private Set<PrivilegeDto> privileges = new LinkedHashSet<>();
-
     public Set<RoleDto> getRoles()
     {
         return roles;
@@ -31,16 +29,6 @@ public class AuthorizationConfigDto
     public void setRoles(Set<RoleDto> roles)
     {
         this.roles = roles;
-    }
-
-    public Set<PrivilegeDto> getPrivileges()
-    {
-        return privileges;
-    }
-
-    public void setPrivileges(final Set<PrivilegeDto> privileges)
-    {
-        this.privileges = privileges;
     }
 
     @Override
@@ -52,14 +40,7 @@ public class AuthorizationConfigDto
             return false;
         }
         final AuthorizationConfigDto config = (AuthorizationConfigDto) o;
-        return java.util.Objects.equals(roles, config.roles) &&
-               java.util.Objects.equals(privileges, config.privileges);
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return java.util.Objects.hash(roles, privileges);
+        return java.util.Objects.equals(roles, config.roles);
     }
 
     @Override
@@ -67,9 +48,7 @@ public class AuthorizationConfigDto
     {
         final StringBuilder sb = new StringBuilder("AuthorizationConfig{");
         sb.append("roles=").append(roles);
-        sb.append(", privileges=").append(privileges);
         sb.append('}');
         return sb.toString();
     }
-
 }

--- a/strongbox-security/strongbox-user-management/src/main/resources/etc/conf/strongbox-authorization.yaml
+++ b/strongbox-security/strongbox-user-management/src/main/resources/etc/conf/strongbox-authorization.yaml
@@ -13,7 +13,3 @@ authorizationConfiguration:
       description: Deployment role
       privileges:
         - Deploy
-  privileges:
-    - name: EXAMPLE_PRIVILEGE
-      description: This is an example of how you could add some custom privilege. Feel
-        free to use it by name at the REST API side to access restriction purposes.


### PR DESCRIPTION
Fixes #1171 

1. Removed privileges fields from the classes [AuthorizationConfigDto](https://github.com/strongbox/strongbox/blob/8960501406eaad51958a00427ecb2dd7a4329605/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/dto/AuthorizationConfigDto.java) and [AuthorizationConfig](https://github.com/strongbox/strongbox/blob/c12bfbf7b5f2611c53954b1429b1128250b6c3ad/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/domain/AuthorizationConfig.java)
2. Removed [authorizationConfiguration.privileges ](https://github.com/ogryniuk/strongbox/commit/c8c157de1b2082914c40dcf1353ec2a8764ad345#diff-045acd1c1929e3ce3b4875dcb519d296L16)
3. Improved the syntax of LdapAuthenticationProviderTest ([deleted unnecessary empty spaces](https://github.com/strongbox/strongbox/blob/6462384966d1230bbd2e4cc8ee9db940213f9c1b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/src/test/java/org/carlspring/strongbox/authentication/api/impl/ldap/LdapAuthenticationProviderTest.java#L109)) 