### PR TITLE
Issue-1165: Cron job tests migration.

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -92,10 +93,6 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT
     public void expiredArtifactsCleanupCronJobShouldCleanupDatabaseAndStorage()
             throws Exception
     {
-        final String storageId = "storage-common-proxies";
-        final String repositoryId = "maven-central";
-        final String path = "org/carlspring/properties-injector/1.5/properties-injector-1.5.jar";
-
         Optional<ArtifactEntry> artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
                                                                                                                  repositoryId,
                                                                                                                  path));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -27,11 +27,13 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -66,22 +68,22 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
                                             @RepositoryAttributes(allowsForceDeletion = true, trashEnabled = true)
                                             Repository repository1,
                                             @MavenRepository(repositoryId = REPOSITORY_RELEASES_2)
-                                            @RepositoryAttributes(allowsForceDeletion = false, trashEnabled = true)
+                                            @RepositoryAttributes(trashEnabled = true)
                                             Repository repository2,
                                             @MavenRepository(storageId = STORAGE1, repositoryId = REPOSITORY_RELEASES_1)
-                                            @RepositoryAttributes(allowsForceDeletion = false, trashEnabled = true)
+                                            @RepositoryAttributes(trashEnabled = true)
                                             Repository repository3,
-                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one", 
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one",
                                                                versions = "1.0")
                                             Path artifact1,
-                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-two", 
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-two",
                                                                versions = "1.0")
                                             Path artifact2,
-                                            @MavenTestArtifact(storageId = STORAGE1, 
-                                                               repositoryId = REPOSITORY_RELEASES_1, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one", 
+                                            @MavenTestArtifact(storageId = STORAGE1,
+                                                               repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one",
                                                                versions = "1.0")
                                             Path artifact3)
             throws Exception
@@ -97,7 +99,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
 
         RepositoryFiles.delete(path, false);
 
-        assertNotNull(Files.exists(repositoryTrashPath), "There is no path to the repository trash!");
+        Files.exists(repositoryTrashPath);
         assertFalse(Files.exists(artifact1.normalize()), "The repository path exists!");
         assertTrue(Files.exists(RepositoryFiles.trash((RepositoryPath) artifact1.normalize())), "The repository trash is empty!");
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
@@ -3,25 +3,30 @@ package org.carlspring.strongbox.cron.jobs;
 import org.carlspring.strongbox.config.Maven2LayoutProviderCronTasksTestConfig;
 import org.carlspring.strongbox.cron.domain.CronTaskConfigurationDto;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
+import org.carlspring.strongbox.repository.IndexedMavenRepositoryFeatures;
 import org.carlspring.strongbox.services.ArtifactSearchService;
 import org.carlspring.strongbox.storage.indexing.IndexTypeEnum;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.search.SearchRequest;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 
 import javax.inject.Inject;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
@@ -35,12 +40,13 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Martin Todorov
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
-                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @EnabledIf(expression = "#{containsObject('repositoryIndexManager')}", loadContext = true)
 @Execution(CONCURRENT)
 public class DownloadRemoteMavenIndexCronJobTestIT
@@ -51,25 +57,19 @@ public class DownloadRemoteMavenIndexCronJobTestIT
 
     private static final String REPOSITORY_PROXIED_RELEASES = "drmicj-proxied-releases";
 
+    private static final String PROXY_REPOSITORY_URL = "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_RELEASES + "/";
+
+    private static final String GROUP_ID = "org.carlspring.strongbox.indexes.download";
+
+    private static final String ARTIFACT_ID1 = "strongbox-test-one";
+
+    private static final String ARTIFACT_ID2 = "strongbox-test-two";
+
+    private static final String VERSION = "1.0";
+
 
     @Inject
     private ArtifactSearchService artifactSearchService;
-
-    private Set<MutableRepository> getRepositories()
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_RELEASES, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_PROXIED_RELEASES, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
-    @AfterEach
-    public void removeRepositories()
-            throws Exception
-    {
-        removeRepositories(getRepositories());
-    }
 
     @Override
     @BeforeEach
@@ -77,40 +77,39 @@ public class DownloadRemoteMavenIndexCronJobTestIT
             throws Exception
     {
         super.init(testInfo);
+    }
 
-        createRepository(STORAGE0, REPOSITORY_RELEASES, true);
+    @Test
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testDownloadRemoteIndexAndExecuteSearch(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES, setup = MavenIndexedRepositorySetup.class)
+                    Repository repository,
+            @Remote(url = PROXY_REPOSITORY_URL)
+            @MavenRepository(repositoryId = REPOSITORY_PROXIED_RELEASES, setup = MavenIndexedRepositorySetup.class)
+                    Repository proxyRepository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES, id = GROUP_ID + ":" +
+                                                                        ARTIFACT_ID1, versions = { VERSION })
+                    Path artifact1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES, id = GROUP_ID + ":" +
+                                                                        ARTIFACT_ID2, versions = { VERSION })
+                    Path artifact2)
+            throws Exception
+    {
+        IndexedMavenRepositoryFeatures features = (IndexedMavenRepositoryFeatures) getFeatures();
 
-        createProxyRepository(STORAGE0,
-                              REPOSITORY_PROXIED_RELEASES,
-                              "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_RELEASES);
+        features.reIndex(STORAGE0, repository.getId(), "/");
+        features.reIndex(STORAGE0, proxyRepository.getId(), "/");
 
-        generateArtifact(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES).getAbsolutePath(),
-                         "org.carlspring.strongbox.indexes.download:strongbox-test-one:1.0:jar");
-
-        generateArtifact(getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES).getAbsolutePath(),
-                         "org.carlspring.strongbox.indexes.download:strongbox-test-two:1.0:jar");
-
-        reIndex(STORAGE0, REPOSITORY_RELEASES, "/");
-        reIndex(STORAGE0, REPOSITORY_PROXIED_RELEASES, "/");
-
-        packIndex(STORAGE0, REPOSITORY_RELEASES);
+        // Make sure the repository that is being proxied has a packed index to serve:
+        features.pack(STORAGE0, repository.getId());
 
         // Requests against the local index of the hosted repository from which we're later on proxying:
         // org.carlspring.strongbox.indexes.download:strongbox-test-one:1.0:jar
+        String query1 = String.format("+g:%s +a:%s +v:%s +p:jar", GROUP_ID, ARTIFACT_ID1, VERSION);
         SearchRequest request1 = new SearchRequest(STORAGE0,
-                                                   REPOSITORY_RELEASES,
-                                                   "+g:org.carlspring.strongbox.indexes.download " +
-                                                   "+a:strongbox-test-one " +
-                                                   "+v:1.0 " +
-                                                   "+p:jar",
-                                                   MavenIndexerSearchProvider.ALIAS);
-        // org.carlspring.strongbox.indexes.download:strongbox-test-two:1.0:jar
-        SearchRequest request2 = new SearchRequest(STORAGE0,
-                                                   REPOSITORY_RELEASES,
-                                                   "+g:org.carlspring.strongbox.indexes.download " +
-                                                   "+a:strongbox-test-two " +
-                                                   "+v:1.0 " +
-                                                   "+p:jar",
+                                                   repository.getId(),
+                                                   query1,
                                                    MavenIndexerSearchProvider.ALIAS);
 
         // Check that the artifacts exist in the hosted repository's local index
@@ -119,16 +118,18 @@ public class DownloadRemoteMavenIndexCronJobTestIT
 
         System.out.println(request1.getQuery() + " found matches!");
 
+        // org.carlspring.strongbox.indexes.download:strongbox-test-two:1.0:jar
+        String query2 = String.format("+g:%s +a:%s +v:%s +p:jar", GROUP_ID, ARTIFACT_ID2, VERSION);
+        SearchRequest request2 = new SearchRequest(STORAGE0,
+                                                   repository.getId(),
+                                                   query2,
+                                                   MavenIndexerSearchProvider.ALIAS);
+
         assertTrue(artifactSearchService.contains(request2),
                    "Failed to find any results for " + request2.getQuery() + " in the hosted repository!");
 
         System.out.println(request2.getQuery() + " found matches!");
-    }
 
-    @Test
-    public void testDownloadRemoteIndexAndExecuteSearch()
-            throws Exception
-    {
         final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
 
@@ -140,21 +141,15 @@ public class DownloadRemoteMavenIndexCronJobTestIT
                 // Requests against the remote index on the proxied repository:
                 // org.carlspring.strongbox.indexes.download:strongbox-test-one:1.0:jar
                 SearchRequest request3 = new SearchRequest(STORAGE0,
-                                                           REPOSITORY_PROXIED_RELEASES,
-                                                           "+g:org.carlspring.strongbox.indexes.download " +
-                                                           "+a:strongbox-test-one " +
-                                                           "+v:1.0 " +
-                                                           "+p:jar",
+                                                           proxyRepository.getId(),
+                                                           query1,
                                                            MavenIndexerSearchProvider.ALIAS);
                 request3.addOption("indexType", IndexTypeEnum.REMOTE.getType());
 
                 // org.carlspring.strongbox.indexes.download:strongbox-test-two:1.0:jar
                 SearchRequest request4 = new SearchRequest(STORAGE0,
-                                                           REPOSITORY_PROXIED_RELEASES,
-                                                           "+g:org.carlspring.strongbox.indexes.download " +
-                                                           "+a:strongbox-test-two " +
-                                                           "+v:1.0 " +
-                                                           "+p:jar",
+                                                           proxyRepository.getId(),
+                                                           query2,
                                                            MavenIndexerSearchProvider.ALIAS);
                 request4.addOption("indexType", IndexTypeEnum.REMOTE.getType());
 
@@ -179,12 +174,13 @@ public class DownloadRemoteMavenIndexCronJobTestIT
         });
 
         addCronJobConfig(jobKey, jobName, DownloadRemoteMavenIndexCronJobTestSubj.class, STORAGE0,
-                         REPOSITORY_PROXIED_RELEASES);
+                         proxyRepository.getId());
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
     }
-    
-    public static class DownloadRemoteMavenIndexCronJobTestSubj extends DownloadRemoteMavenIndexCronJob 
+
+    public static class DownloadRemoteMavenIndexCronJobTestSubj
+            extends DownloadRemoteMavenIndexCronJob
     {
 
         @Override
@@ -193,7 +189,7 @@ public class DownloadRemoteMavenIndexCronJobTestIT
         {
             return true;
         }
-        
+
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJobTestIT.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @EnabledIf(expression = "#{containsObject('repositoryIndexManager')}", loadContext = true)
 @Execution(CONCURRENT)
 public class DownloadRemoteMavenIndexCronJobTestIT
@@ -82,18 +82,21 @@ public class DownloadRemoteMavenIndexCronJobTestIT
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void testDownloadRemoteIndexAndExecuteSearch(
-            @MavenRepository(repositoryId = REPOSITORY_RELEASES, setup = MavenIndexedRepositorySetup.class)
-                    Repository repository,
-            @Remote(url = PROXY_REPOSITORY_URL)
-            @MavenRepository(repositoryId = REPOSITORY_PROXIED_RELEASES, setup = MavenIndexedRepositorySetup.class)
-                    Repository proxyRepository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES, id = GROUP_ID + ":" +
-                                                                        ARTIFACT_ID1, versions = { VERSION })
-                    Path artifact1,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES, id = GROUP_ID + ":" +
-                                                                        ARTIFACT_ID2, versions = { VERSION })
-                    Path artifact2)
+    public void testDownloadRemoteIndexAndExecuteSearch(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                                                         setup = MavenIndexedRepositorySetup.class)
+                                                        Repository repository,
+                                                        @Remote(url = PROXY_REPOSITORY_URL)
+                                                        @MavenRepository(repositoryId = REPOSITORY_PROXIED_RELEASES,
+                                                                         setup = MavenIndexedRepositorySetup.class)
+                                                        Repository proxyRepository,
+                                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                                           id = GROUP_ID + ":" + ARTIFACT_ID1,
+                                                                           versions = { VERSION })
+                                                        Path artifact1,
+                                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                                           id = GROUP_ID + ":" + ARTIFACT_ID2,
+                                                                           versions = { VERSION })
+                                                        Path artifact2)
             throws Exception
     {
         IndexedMavenRepositoryFeatures features = (IndexedMavenRepositoryFeatures) getFeatures();
@@ -173,7 +176,10 @@ public class DownloadRemoteMavenIndexCronJobTestIT
             }
         });
 
-        addCronJobConfig(jobKey, jobName, DownloadRemoteMavenIndexCronJobTestSubj.class, STORAGE0,
+        addCronJobConfig(jobKey,
+                         jobName,
+                         DownloadRemoteMavenIndexCronJobTestSubj.class,
+                         STORAGE0,
                          proxyRepository.getId());
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
@@ -48,6 +48,7 @@ public class RebuildMavenIndexesCronJobTestIT
 {
 
     private static final String REPOSITORY_RELEASES_1 = "rmicj-releases";
+    
     private static final String ARTIFACT_BASE_PATH_STRONGBOX_INDEXES = "org/carlspring/strongbox/indexes/strongbox-test-one";
 
     private static final String GROUP_ID = "org.carlspring.strongbox.indexes.download";
@@ -60,7 +61,8 @@ public class RebuildMavenIndexesCronJobTestIT
 
     @Inject
     private ArtifactSearchService artifactSearchService;
-
+    
+    
     @Override
     @BeforeEach
     public void init(TestInfo testInfo)
@@ -72,15 +74,17 @@ public class RebuildMavenIndexesCronJobTestIT
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void testRebuildArtifactsIndexes(
-            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1, setup = MavenIndexedRepositorySetup.class)
-                    Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
-                                                                          ARTIFACT_ID1, versions = { VERSION })
-                    Path artifact1,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
-                                                                          ARTIFACT_ID2, versions = { VERSION })
-                    Path artifact2)
+    public void testRebuildArtifactsIndexes(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1,
+                                                             setup = MavenIndexedRepositorySetup.class)
+                                            Repository repository,
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = GROUP_ID + ":" + ARTIFACT_ID1,
+                                                               versions = { VERSION })
+                                            Path artifact1,
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = GROUP_ID + ":" + ARTIFACT_ID2,
+                                                               versions = { VERSION })
+                                            Path artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
@@ -121,15 +125,17 @@ public class RebuildMavenIndexesCronJobTestIT
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void testRebuildIndexesInRepository(
-            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1, setup = MavenIndexedRepositorySetup.class)
-                    Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
-                                                                          ARTIFACT_ID1, versions = { VERSION })
-                    Path artifact1,
-            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
-                                                                          ARTIFACT_ID2, versions = { VERSION })
-                    Path artifact2)
+    public void testRebuildIndexesInRepository(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1,
+                                                                setup = MavenIndexedRepositorySetup.class)
+                                               Repository repository,
+                                               @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                                  id = GROUP_ID + ":" + ARTIFACT_ID1,
+                                                                  versions = { VERSION })
+                                               Path artifact1,
+                                               @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                                  id = GROUP_ID + ":" + ARTIFACT_ID2,
+                                                                  versions = { VERSION })
+                                               Path artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
@@ -1,28 +1,28 @@
 package org.carlspring.strongbox.cron.jobs;
 
-import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.config.Maven2LayoutProviderCronTasksTestConfig;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
 import org.carlspring.strongbox.services.ArtifactSearchService;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.search.SearchRequest;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
-import java.io.File;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -48,60 +49,38 @@ public class RebuildMavenIndexesCronJobTestIT
 
     private static final String REPOSITORY_RELEASES_1 = "rmicj-releases";
     private static final String ARTIFACT_BASE_PATH_STRONGBOX_INDEXES = "org/carlspring/strongbox/indexes/strongbox-test-one";
-    
-    @Inject
-    private PropertiesBooter propertiesBooter;
+
+    private static final String GROUP_ID = "org.carlspring.strongbox.indexes.download";
+
+    private static final String ARTIFACT_ID1 = "strongbox-test-one";
+
+    private static final String ARTIFACT_ID2 = "strongbox-test-two";
+
+    private static final String VERSION = "1.0";
 
     @Inject
     private ArtifactSearchService artifactSearchService;
 
-    private File repositoryReleasesDasedir1;
-
-    private Set<MutableRepository> getRepositories(TestInfo testInfo)
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
-    @PostConstruct
-    public void setup() 
-    {
-        repositoryReleasesDasedir1 = new File(propertiesBooter.getVaultDirectory() +
-                                              "/storages/" + STORAGE0 + "/" +
-                                              REPOSITORY_RELEASES_1);
-    }
-    
     @Override
     @BeforeEach
     public void init(TestInfo testInfo)
             throws Exception
     {
         super.init(testInfo);
-
-        createRepository(STORAGE0,
-                         getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
-                         true);
-
-        generateArtifact(getRepositoryBasedir(repositoryReleasesDasedir1, testInfo),
-                         "org.carlspring.strongbox.indexes:strongbox-test-one:1.0:jar");
-
-        generateArtifact(getRepositoryBasedir(repositoryReleasesDasedir1, testInfo),
-                         "org.carlspring.strongbox.indexes:strongbox-test-two:1.0:jar");
-    }
-
-    @AfterEach
-    public void removeRepositories(TestInfo testInfo)
-            throws Exception
-    {
-        removeRepositories(getRepositories(testInfo));
     }
 
     @Test
-    public void testRebuildArtifactsIndexes(TestInfo testInfo)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testRebuildArtifactsIndexes(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1, setup = MavenIndexedRepositorySetup.class)
+                    Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
+                                                                          ARTIFACT_ID1, versions = { VERSION })
+                    Path artifact1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
+                                                                          ARTIFACT_ID2, versions = { VERSION })
+                    Path artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
@@ -112,12 +91,10 @@ public class RebuildMavenIndexesCronJobTestIT
         {
             if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
             {
+                String query = String.format("+g:%s +a:%s +v:%s +p:jar", GROUP_ID, ARTIFACT_ID1, VERSION);
                 SearchRequest request = new SearchRequest(STORAGE0,
-                                                          getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
-                                                          "+g:org.carlspring.strongbox.indexes " +
-                                                          "+a:strongbox-test-one " +
-                                                          "+v:1.0 " +
-                                                          "+p:jar",
+                                                          repository.getId(),
+                                                          query,
                                                           MavenIndexerSearchProvider.ALIAS);
 
                 try
@@ -135,14 +112,24 @@ public class RebuildMavenIndexesCronJobTestIT
                          jobName,
                          RebuildMavenIndexesCronJob.class,
                          STORAGE0,
-                         getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
+                         repository.getId(),
                          properties -> properties.put("basePath", ARTIFACT_BASE_PATH_STRONGBOX_INDEXES));
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
     }
 
     @Test
-    public void testRebuildIndexesInRepository(TestInfo testInfo)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testRebuildIndexesInRepository(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1, setup = MavenIndexedRepositorySetup.class)
+                    Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
+                                                                          ARTIFACT_ID1, versions = { VERSION })
+                    Path artifact1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = GROUP_ID + ":" +
+                                                                          ARTIFACT_ID2, versions = { VERSION })
+                    Path artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
@@ -154,22 +141,18 @@ public class RebuildMavenIndexesCronJobTestIT
             {
                 try
                 {
+                    String query1 = String.format("+g:%s +a:%s +v:%s +p:jar", GROUP_ID, ARTIFACT_ID1, VERSION);
                     SearchRequest request1 = new SearchRequest(STORAGE0,
-                                                               getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
-                                                               "+g:org.carlspring.strongbox.indexes " +
-                                                               "+a:strongbox-test-one " +
-                                                               "+v:1.0 " +
-                                                               "+p:jar",
+                                                               repository.getId(),
+                                                               query1,
                                                                MavenIndexerSearchProvider.ALIAS);
 
                     assertTrue(artifactSearchService.contains(request1));
 
+                    String query2 = String.format("+g:%s +a:%s +v:%s +p:jar", GROUP_ID, ARTIFACT_ID2, VERSION);
                     SearchRequest request2 = new SearchRequest(STORAGE0,
-                                                               getRepositoryName(REPOSITORY_RELEASES_1, testInfo),
-                                                               "+g:org.carlspring.strongbox.indexes " +
-                                                               "+a:strongbox-test-two " +
-                                                               "+v:1.0 " +
-                                                               "+p:jar",
+                                                               repository.getId(),
+                                                               query2,
                                                                MavenIndexerSearchProvider.ALIAS);
 
                     assertTrue(artifactSearchService.contains(request2));
@@ -185,7 +168,7 @@ public class RebuildMavenIndexesCronJobTestIT
                          jobName,
                          RebuildMavenIndexesCronJob.class,
                          STORAGE0,
-                         getRepositoryName(REPOSITORY_RELEASES_1, testInfo));
+                         repository.getId());
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -93,7 +93,11 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                                                                          ARTIFACT_ID1, versions = { "2.0-20190701.202015-1",
                                                                                                     "2.0-20190701.202101-2",
                                                                                                     "2.0-20190701.202203-3" })
-                    List<Path> artifact1)
+                    List<Path> artifact1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+                                                                         ARTIFACT_ID2, versions = { "2.0-20190701.202015-1",
+                                                                                                    "2.0-20190701.202101-2" })
+                    List<Path> artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
@@ -142,6 +146,11 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                   ArtifactManagementTestExecutionListener.class })
     public void testRemoveTimestampedSnapshotInRepository(
             @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS, policy = SNAPSHOT) Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+                                                                         ARTIFACT_ID1, versions = { "2.0-20190701.202015-1",
+                                                                                                    "2.0-20190701.202101-2",
+                                                                                                    "2.0-20190701.202203-3" })
+                    List<Path> artifact1,
             @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
                                                                          ARTIFACT_ID2, versions = { "2.0-20190701.202015-1",
                                                                                                     "2.0-20190701.202101-2" })

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -3,39 +3,44 @@ package org.carlspring.strongbox.cron.jobs;
 import org.carlspring.strongbox.artifact.MavenArtifactUtils;
 import org.carlspring.strongbox.config.Maven2LayoutProviderCronTasksTestConfig;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.services.ArtifactMetadataService;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import javax.inject.Inject;
-import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.awaitility.Awaitility.await;
+import static org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum.SNAPSHOT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -49,19 +54,15 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
 
     private static final String REPOSITORY_SNAPSHOTS = "rtmscj-snapshots";
 
-    private static final String ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED = "org/carlspring/strongbox/strongbox-timestamped-first";
+    private static final String ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_FIRST = "org/carlspring/strongbox/strongbox-timestamped-first";
+    private static final String ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_SECOND = "org/carlspring/strongbox/strongbox-timestamped-second";
+
+    private static final String GROUP_ID = "org.carlspring.strongbox";
+    private static final String ARTIFACT_ID1 = "strongbox-timestamped-first";
+    private static final String ARTIFACT_ID2 = "strongbox-timestamped-second";
 
     @Inject
     private ArtifactMetadataService artifactMetadataService;
-
-    private Set<MutableRepository> getRepositoriesToClean(TestInfo testInfo)
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        return repositories;
-    }
 
     @Override
     @BeforeEach
@@ -69,65 +70,38 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
             throws Exception
     {
         super.init(testInfo);
-
-        //Create repository rtmscj-snapshots in storage0
-        createRepository(STORAGE0,
-                         getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo),
-                         RepositoryPolicyEnum.SNAPSHOT.getPolicy(),
-                         false);
-
-        File repositoryBasedir = getRepositoryBasedir(STORAGE0, getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo));
-
-        createTimestampedSnapshotArtifact(repositoryBasedir.getAbsolutePath(),
-                                          "org.carlspring.strongbox",
-                                          "strongbox-timestamped-first",
-                                          "2.0",
-                                          "jar",
-                                          null,
-                                          3);
-
-        createTimestampedSnapshotArtifact(repositoryBasedir.getAbsolutePath(),
-                                          "org.carlspring.strongbox",
-                                          "strongbox-timestamped-second",
-                                          "2.0",
-                                          "jar",
-                                          null,
-                                          2);
-
-        rebuildArtifactsMetadata(testInfo);
     }
 
-    @AfterEach
-    public void removeRepositories(TestInfo testInfo)
-            throws Exception
-    {
-        removeRepositories(getRepositoriesToClean(testInfo));
-    }
-
-    private void rebuildArtifactsMetadata(TestInfo testInfo)
+    private void rebuildArtifactsMetadata(Repository repository)
             throws Exception
     {
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo),
-                                                "org/carlspring/strongbox/strongbox-timestamped-first");
+                                                repository.getId(),
+                                                ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_FIRST);
 
         artifactMetadataService.rebuildMetadata(STORAGE0,
-                                                getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo),
-                                                "org/carlspring/strongbox/strongbox-timestamped-second");
+                                                repository.getId(),
+                                                ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_SECOND);
     }
 
     @Test
-    public void testRemoveTimestampedSnapshot(TestInfo testInfo)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testRemoveTimestampedSnapshot(
+            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS, policy = SNAPSHOT) Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+                                                                         ARTIFACT_ID1, versions = { "2.0-20190701.202015-1",
+                                                                                                    "2.0-20190701.202101-2",
+                                                                                                    "2.0-20190701.202203-3" })
+                    List<Path> artifact1)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
-        final String repositoryName = getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo);
-        final File repositoryBasedir = getRepositoryBasedir(STORAGE0, repositoryName);
-        final String artifactPath = repositoryBasedir +
-                                    "/org/carlspring/strongbox/strongbox-timestamped-first";
 
-        File file = new File(artifactPath, "2.0-SNAPSHOT");
+        rebuildArtifactsMetadata(repository);
+
+        final Path artifact1ParentPath = artifact1.get(0).getParent();
 
         jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
@@ -135,9 +109,11 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
             {
                 if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
                 {
-                    assertEquals(1, file.listFiles((dir, name) -> name.endsWith(".jar")).length,
-                                 "Amount of timestamped snapshots doesn't equal 1.");
-                    assertTrue(getSnapshotArtifactVersion(repositoryBasedir, file).endsWith("-3"));
+                    long timestampedSnapshots = Files.walk(artifact1ParentPath).filter(
+                            path -> path.toString().endsWith(".jar")).count();
+
+                    assertEquals(1, timestampedSnapshots, "Amount of timestamped snapshots doesn't equal 1.");
+                    assertTrue(getSnapshotArtifactVersion(artifact1ParentPath).endsWith("-3"));
                 }
             }
             catch (Exception e)
@@ -150,11 +126,10 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                          jobName,
                          RemoveTimestampedMavenSnapshotCronJob.class,
                          STORAGE0,
-                         getRepositoryName(REPOSITORY_SNAPSHOTS,
-                                           testInfo),
+                         repository.getId(),
                          properties ->
                          {
-                             properties.put("basePath", ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED);
+                             properties.put("basePath", ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_FIRST);
                              properties.put("numberToKeep", "1");
                              properties.put("keepPeriod", "0");
                          });
@@ -163,17 +138,22 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     }
 
     @Test
-    public void testRemoveTimestampedSnapshotInRepository(TestInfo testInfo)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testRemoveTimestampedSnapshotInRepository(
+            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS, policy = SNAPSHOT) Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+                                                                         ARTIFACT_ID2, versions = { "2.0-20190701.202015-1",
+                                                                                                    "2.0-20190701.202101-2" })
+                    List<Path> artifact2)
             throws Exception
     {
         final UUID jobKey = expectedJobKey;
         final String jobName = expectedJobName;
-        final String repositoryName = getRepositoryName(REPOSITORY_SNAPSHOTS, testInfo);
-        final File repositoryBasedir = getRepositoryBasedir(STORAGE0, repositoryName);
-        final String artifactPath = repositoryBasedir +
-                                    "/org/carlspring/strongbox/strongbox-timestamped-second";
 
-        final File file = new File(artifactPath, "2.0-SNAPSHOT");
+        rebuildArtifactsMetadata(repository);
+
+        final Path artifact2ParentPath = artifact2.get(0).getParent();
 
         jobManager.registerExecutionListener(jobKey.toString(), (jobKey1, statusExecuted) ->
         {
@@ -181,9 +161,12 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
             {
                 if (StringUtils.equals(jobKey1, jobKey.toString()) && statusExecuted)
                 {
-                    assertEquals(1, file.listFiles((dir, name) -> name.endsWith(".jar")).length,
-                                 "Amount of timestamped snapshots doesn't equal 1.");
-                    assertTrue(getSnapshotArtifactVersion(repositoryBasedir, file).endsWith("-2"));
+                    long timestampedSnapshots = Files.walk(artifact2ParentPath).filter(
+                            path -> path.toString().endsWith(".jar")).count();
+
+                    assertEquals(1, timestampedSnapshots, "Amount of timestamped snapshots doesn't equal 1.");
+
+                    assertTrue(getSnapshotArtifactVersion(artifact2ParentPath).endsWith("-2"));
                 }
             }
             catch (Exception e)
@@ -196,7 +179,7 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                          jobName,
                          RemoveTimestampedMavenSnapshotCronJob.class,
                          STORAGE0,
-                         repositoryName,
+                         repository.getId(),
                          properties ->
                          {
                              properties.put("basePath", null);
@@ -207,17 +190,21 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
     }
 
-    private String getSnapshotArtifactVersion(File repositoryBasedir,
-                                              File artifactFile)
+    private String getSnapshotArtifactVersion(Path artifactPath)
+            throws IOException
     {
-        File[] files = artifactFile.listFiles((dir, name) -> name.endsWith(".jar"));
-        Path path = files[0].toPath();
-        Path other = repositoryBasedir.toPath();
-        Path relativize = other.relativize(path);
-        String unixBasedRelativePath = FilenameUtils.separatorsToUnix(relativize.toString());
-        Artifact artifact = MavenArtifactUtils.convertPathToArtifact(unixBasedRelativePath);
+        Optional<Path> path = Files.walk(artifactPath).filter(p -> p.toString().endsWith(".jar")).findFirst();
+        if (path.isPresent())
+        {
+            String unixBasedRelativePath = FilenameUtils.separatorsToUnix(path.get().toString());
+            Artifact artifact = MavenArtifactUtils.convertPathToArtifact(unixBasedRelativePath);
+            if (artifact != null)
+            {
+                return artifact.getVersion();
+            }
+        }
 
-        return artifact.getVersion();
+        return StringUtils.EMPTY;
     }
 
 }


### PR DESCRIPTION
Fixes for #1165.

Refactoring test cases to use new annotations.

* [x] `org.carlspring.strongbox.cron.jobs.CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.ClearTrashCronJobFromMaven2RepositoryTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.DownloadRemoteMavenIndexCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.RebuildMavenIndexesCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.RemoveTimestampedMavenSnapshotCronJobTestIT`
