### PR TITLE
Issue-1165: Maven Version Validator tests migration.

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
@@ -1,55 +1,68 @@
 package org.carlspring.strongbox.storage.validation.version;
 
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import java.nio.file.Path;
+
+import org.apache.maven.artifact.Artifact;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
-import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
-import org.carlspring.strongbox.storage.repository.ImmutableRepository;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-
 /**
  * @author stodorov
+ * @author Pablo Tirado
  */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
 public class MavenReleaseVersionValidatorTest
 {
 
-    private MutableRepository repository;
+    private static final String MRVV_RELEASES = "mrvv-releases";
+    private static final String GROUP_ID = "org.carlspring.maven";
+    private static final String ARTIFACT_ID = "my-maven-plugin";
 
     private MavenReleaseVersionValidator validator = new MavenReleaseVersionValidator();
 
-
-    @BeforeEach
-    public void setUp()
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
+    @Test
+    public void shouldSupportRepository(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository)
     {
-        repository = new MutableRepository("mrvv-releases");
-        repository.setPolicy(RepositoryPolicyEnum.RELEASE.toString());
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setBasedir("");
+        assertTrue(validator.supports(repository));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void shouldSupportRepository()
-    {
-        assertTrue(validator.supports(new ImmutableRepository(repository)));
-    }
-
-    @Test
-    public void testReleaseValidation()
+    public void testReleaseValidation(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
+                                      @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                         versions = { "1" })
+                                      Path validArtifact1Path,
+                                      @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                         versions = { "1.0" })
+                                      Path validArtifact2Path)
             throws VersionValidationException
     {
-        /**
+        /*
          * Test valid artifacts
          */
         Artifact validArtifact1 = generateArtifact("1");
@@ -58,16 +71,26 @@ public class MavenReleaseVersionValidatorTest
         ArtifactCoordinates coordinates1 = new MockedMavenArtifactCoordinates(validArtifact1);
         ArtifactCoordinates coordinates2 = new MockedMavenArtifactCoordinates(validArtifact2);
 
-        validator.validate(new ImmutableRepository(repository), coordinates1);
-        validator.validate(new ImmutableRepository(repository), coordinates2);
+        validator.validate(repository, coordinates1);
+        validator.validate(repository, coordinates2);
 
         // If we've gotten here without an exception, then things are alright.
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testInvalidArtifacts()
+    public void testInvalidArtifacts(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
+                                     @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = {"1.0-SNAPSHOT"})
+                                     Path invalidArtifact1Path,
+                                     @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = {"1.0-20131004.115330-1"})
+                                     Path invalidArtifact4Path)
     {
-        /**
+        /*
          * Test invalid artifacts
          */
         Artifact invalidArtifact1 = generateArtifact("1.0-SNAPSHOT");
@@ -78,7 +101,7 @@ public class MavenReleaseVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates1);
+            validator.validate(repository, coordinates1);
             fail("Incorrectly validated artifact with version 1.0-SNAPSHOT!");
         }
         catch (VersionValidationException e)
@@ -87,7 +110,7 @@ public class MavenReleaseVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates4);
+            validator.validate(repository, coordinates4);
             fail("Incorrectly validated artifact with version 1.0-20131004.115330-1!");
         }
         catch (VersionValidationException e)
@@ -97,13 +120,7 @@ public class MavenReleaseVersionValidatorTest
 
     private Artifact generateArtifact(String version)
     {
-        return new DefaultArtifact("org.carlspring.maven",
-                                   "my-maven-plugin",
-                                   version,
-                                   "compile",
-                                   "jar",
-                                   null,
-                                   new DefaultArtifactHandler("jar"));
+        String gavtc = String.format("%s:%s:%s:jar", GROUP_ID, ARTIFACT_ID, version);
+        return MavenArtifactTestUtils.getArtifactFromGAVTC(gavtc);
     }
-
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
@@ -12,6 +12,7 @@ import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.Test;
@@ -54,12 +55,9 @@ public class MavenReleaseVersionValidatorTest
     public void testReleaseValidation(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
                                       @MavenTestArtifact(repositoryId = MRVV_RELEASES,
                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                         versions = { "1" })
-                                      Path validArtifact1Path,
-                                      @MavenTestArtifact(repositoryId = MRVV_RELEASES,
-                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                         versions = { "1.0" })
-                                      Path validArtifact2Path)
+                                                         versions = { "1",
+                                                                      "1.0" })
+                                      List<Path> validArtifactPaths)
             throws VersionValidationException
     {
         /*
@@ -83,12 +81,9 @@ public class MavenReleaseVersionValidatorTest
     public void testInvalidArtifacts(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
                                      @MavenTestArtifact(repositoryId = MRVV_RELEASES,
                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = {"1.0-SNAPSHOT"})
-                                     Path invalidArtifact1Path,
-                                     @MavenTestArtifact(repositoryId = MRVV_RELEASES,
-                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = {"1.0-20131004.115330-1"})
-                                     Path invalidArtifact4Path)
+                                                        versions = { "1.0-SNAPSHOT",
+                                                                     "1.0-20131004.115330-1" })
+                                     List<Path> invalidArtifactPaths)
     {
         /*
          * Test invalid artifacts

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
@@ -1,52 +1,76 @@
 package org.carlspring.strongbox.storage.validation.version;
 
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import java.nio.file.Path;
+
+import org.apache.maven.artifact.Artifact;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import static org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum.SNAPSHOT;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
-import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
-import org.carlspring.strongbox.storage.repository.ImmutableRepository;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-
 /**
  * @author stodorov
+ * @author Pablo Tirado
  */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
 public class MavenSnapshotVersionValidatorTest
 {
 
-    MutableRepository repository;
+    private static final String REPOSITORY_ID = "test-repository-for-maven-snapshot-validation";
+    private static final String GROUP_ID = "org.carlspring.maven";
+    private static final String ARTIFACT_ID = "my-maven-plugin";
 
-    MavenSnapshotVersionValidator validator = new MavenSnapshotVersionValidator();
+    private MavenSnapshotVersionValidator validator = new MavenSnapshotVersionValidator();
 
-
-    @BeforeEach
-    public void setUp()
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
+    @Test
+    public void shouldSupportRepository(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT) 
+                                        Repository repository)
     {
-        repository = new MutableRepository("test-repository-for-maven-snapshot-validation");
-        repository.setPolicy(RepositoryPolicyEnum.SNAPSHOT.toString());
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setBasedir("");
+        assertTrue(validator.supports(repository));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void shouldSupportRepository()
-    {
-        assertTrue(validator.supports(new ImmutableRepository(repository)));
-    }
-
-    @Test
-    public void testSnapshotValidation()
+    public void testSnapshotValidation(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT)
+                                       Repository repository,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                          versions = { "1.0-SNAPSHOT" })
+                                       Path validArtifact1Path,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                          versions = { "1.0-20131004.115330-1" })
+                                       Path validArtifact4Path,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                          versions = { "1.0.8-20151025.032208-1" })
+                                       Path validArtifact5Path,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                          versions = { "1.0.8-alpha-1-20151025.032208-1" })
+                                       Path validArtifact6Path)
             throws VersionValidationException
     {
         Artifact validArtifact1 = generateArtifact("1.0-SNAPSHOT");
@@ -59,16 +83,35 @@ public class MavenSnapshotVersionValidatorTest
         ArtifactCoordinates coordinates5 = new MockedMavenArtifactCoordinates(validArtifact5);
         ArtifactCoordinates coordinates6 = new MockedMavenArtifactCoordinates(validArtifact6);
 
-        validator.validate(new ImmutableRepository(repository), coordinates1);
-        validator.validate(new ImmutableRepository(repository), coordinates4);
-        validator.validate(new ImmutableRepository(repository), coordinates5);
-        validator.validate(new ImmutableRepository(repository), coordinates6);
+        validator.validate(repository, coordinates1);
+        validator.validate(repository, coordinates4);
+        validator.validate(repository, coordinates5);
+        validator.validate(repository, coordinates6);
 
         // If we've gotten here without an exception, then things are alright.
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testInvalidArtifacts()
+    public void testInvalidArtifacts(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT)
+                                     Repository repository,
+                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = { "1" })
+                                     Path invalidArtifact1Path,
+                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = { "1.0" })
+                                     Path invalidArtifact2Path,
+                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = { "1.0.1" })
+                                     Path invalidArtifact3Path,
+                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = { "1.0.1-alpha" })
+                                     Path invalidArtifact4Path)
     {
         Artifact invalidArtifact1 = generateArtifact("1");
         Artifact invalidArtifact2 = generateArtifact("1.0");
@@ -82,7 +125,7 @@ public class MavenSnapshotVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates1);
+            validator.validate(repository, coordinates1);
 
             fail("Incorrectly validated artifact with version 1!");
         }
@@ -92,7 +135,7 @@ public class MavenSnapshotVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates2);
+            validator.validate(repository, coordinates2);
 
             fail("Incorrectly validated artifact with version 1.0!");
         }
@@ -102,7 +145,7 @@ public class MavenSnapshotVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates3);
+            validator.validate(repository, coordinates3);
 
             fail("Incorrectly validated artifact with version 1.0.1!");
         }
@@ -112,7 +155,7 @@ public class MavenSnapshotVersionValidatorTest
 
         try
         {
-            validator.validate(new ImmutableRepository(repository), coordinates4);
+            validator.validate(repository, coordinates4);
 
             fail("Incorrectly validated artifact with version 1.0.1!");
         }
@@ -123,13 +166,7 @@ public class MavenSnapshotVersionValidatorTest
 
     private Artifact generateArtifact(String version)
     {
-        return new DefaultArtifact("org.carlspring.maven",
-                                   "my-maven-plugin",
-                                   version,
-                                   "compile",
-                                   "jar",
-                                   null,
-                                   new DefaultArtifactHandler("jar"));
+        String gavtc = String.format("%s:%s:%s:jar", GROUP_ID, ARTIFACT_ID, version);
+        return MavenArtifactTestUtils.getArtifactFromGAVTC(gavtc);
     }
-
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
@@ -12,6 +12,7 @@ import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.Test;
@@ -57,20 +58,11 @@ public class MavenSnapshotVersionValidatorTest
                                        Repository repository,
                                        @MavenTestArtifact(repositoryId = REPOSITORY_ID,
                                                           id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                          versions = { "1.0-SNAPSHOT" })
-                                       Path validArtifact1Path,
-                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                          versions = { "1.0-20131004.115330-1" })
-                                       Path validArtifact4Path,
-                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                          versions = { "1.0.8-20151025.032208-1" })
-                                       Path validArtifact5Path,
-                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                          versions = { "1.0.8-alpha-1-20151025.032208-1" })
-                                       Path validArtifact6Path)
+                                                          versions = { "1.0-SNAPSHOT",
+                                                                       "1.0-20131004.115330-1",
+                                                                       "1.0.8-20151025.032208-1",
+                                                                       "1.0.8-alpha-1-20151025.032208-1"})
+                                       List<Path> validArtifactPaths)
             throws VersionValidationException
     {
         Artifact validArtifact1 = generateArtifact("1.0-SNAPSHOT");
@@ -98,20 +90,11 @@ public class MavenSnapshotVersionValidatorTest
                                      Repository repository,
                                      @MavenTestArtifact(repositoryId = REPOSITORY_ID,
                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = { "1" })
-                                     Path invalidArtifact1Path,
-                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = { "1.0" })
-                                     Path invalidArtifact2Path,
-                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = { "1.0.1" })
-                                     Path invalidArtifact3Path,
-                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
-                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
-                                                        versions = { "1.0.1-alpha" })
-                                     Path invalidArtifact4Path)
+                                                        versions = { "1",
+                                                                     "1.0",
+                                                                     "1.0.1",
+                                                                     "1.0.1-alpha" })
+                                     List<Path> invalidArtifactPaths)
     {
         Artifact invalidArtifact1 = generateArtifact("1");
         Artifact invalidArtifact2 = generateArtifact("1.0");


### PR DESCRIPTION
Fixes for #1165.

Refactoring test cases to use new annotations.

* [x] `org.carlspring.strongbox.storage.validation.version.MavenReleaseVersionValidatorTest`
* [x] `org.carlspring.strongbox.storage.validation.version.MavenSnapshotVersionValidatorTest` 