### PR TITLE
Issue-1165: Storage indexing tests migrations.

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
@@ -2,22 +2,27 @@ package org.carlspring.strongbox.storage.indexing;
 
 import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+import org.carlspring.strongbox.providers.io.RootRepositoryPath;
 import org.carlspring.strongbox.repository.IndexedMavenRepositoryFeatures;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.search.SearchResult;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.index.ArtifactInfo;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -37,65 +42,46 @@ public class RepositoryIndexerTest
 {
 
     private static final String REPOSITORY_RELEASES = "ri-releases";
+    private static final String GROUP_ID = "org.carlspring.strongbox";
+    private static final String ARTIFACT_ID = "strongbox-commons";
+    private static final String ARTIFACT_BASE_PATH_STRONGBOX = "org/carlspring/strongbox/strongbox-commons";
 
-    @BeforeAll
-    public static void cleanUp()
-            throws Exception
-    {
-        cleanUp(getRepositoriesToClean());
-    }
-
-    @BeforeEach
-    public void initialize()
-            throws Exception
-    {
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES,
-                                      true,
-                                      "org.carlspring.strongbox:strongbox-commons",
-                                      "1.0", "1.1", "1.2");
-    }
-
-    @AfterEach
-    public void removeRepositories()
-            throws Exception
-    {
-        removeRepositories(getRepositoriesToClean());
-    }
-
-    public static Set<MutableRepository> getRepositoriesToClean()
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_RELEASES, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testIndex() throws Exception
+    public void testIndex(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                           setup = MavenIndexedRepositorySetup.class)
+                          Repository repository,
+                          @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                             id = GROUP_ID + ":" + ARTIFACT_ID,
+                                             versions = { "1.0",
+                                                          "1.1",
+                                                          "1.2" })
+                          List<Path> artifactPaths)
+            throws Exception
     {
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
         RepositoryIndexer repositoryIndexer = repositoryIndexManager.getRepositoryIndexer(STORAGE0 + ":" +
-                                                                                          REPOSITORY_RELEASES + ":" +
+                                                                                          repository.getId() + ":" +
                                                                                           IndexTypeEnum.LOCAL.getType());
 
         IndexedMavenRepositoryFeatures features = (IndexedMavenRepositoryFeatures) getFeatures();
 
-        int x = features.reIndex(STORAGE0, REPOSITORY_RELEASES, "org/carlspring/strongbox/strongbox-commons");
+        int numberOfFiles = features.reIndex(STORAGE0, repository.getId(), ARTIFACT_BASE_PATH_STRONGBOX);
 
-        features.pack(STORAGE0, REPOSITORY_RELEASES);
+        features.pack(STORAGE0, repository.getId());
 
-        File repositoryBasedir = getRepositoryBasedir(STORAGE0, REPOSITORY_RELEASES);
+        final RootRepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
 
-        assertTrue(new File(repositoryBasedir.getAbsolutePath(),
-                            ".index/local/nexus-maven-repository-index.gz").exists(), "Failed to pack index!");
-        assertTrue(new File(repositoryBasedir.getAbsolutePath(),
-                            ".index/local/nexus-maven-repository-index-packer.properties").exists(),
-                   "Failed to pack index!");
+        final Path indexPacked = repositoryPath.resolve(".index/local/nexus-maven-repository-index.gz");
+        assertTrue(Files.exists(indexPacked), "Failed to pack index!");
+
+        final Path indexProperties = repositoryPath.resolve(".index/local/nexus-maven-repository-index-packer.properties");
+        assertTrue(Files.exists(indexProperties), "Failed to pack index!");
 
         assertEquals(6,
 
-                     x,  // one is jar another pom, both would be added into the same Lucene document
+                     numberOfFiles,  // one is jar another pom, both would be added into the same Lucene document
                      "6 artifacts expected!");
 
         Set<SearchResult> search = repositoryIndexer.search("org.carlspring.strongbox",

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/StrongboxIndexerTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/StrongboxIndexerTest.java
@@ -2,18 +2,20 @@ package org.carlspring.strongbox.storage.indexing;
 
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.services.ArtifactManagementService;
-import org.carlspring.strongbox.storage.repository.MutableRepository;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.util.IndexContextHelper;
 
 import javax.inject.Inject;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.lucene.search.Query;
 import org.apache.maven.index.FlatSearchRequest;
@@ -23,9 +25,8 @@ import org.apache.maven.index.MAVEN;
 import org.apache.maven.index.expr.SourcedSearchExpression;
 import org.apache.maven.index.expr.UserInputSearchExpression;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
@@ -60,6 +61,10 @@ public class StrongboxIndexerTest
 
     private static final String REPOSITORY_RELEASES_6 = "injector-releases-6";
 
+    private static final String GROUP_ID = "org.carlspring";
+
+    private static final String ARTIFACT_ID = "properties-injector";
+
     /**
      * org/carlspring/ioc/PropertyValueInjector
      * org/carlspring/ioc/InjectionException
@@ -82,46 +87,24 @@ public class StrongboxIndexerTest
     @Inject
     private Optional<Indexer> indexer;
 
-    @BeforeAll
-    @AfterAll
-    public static void cleanUp()
-            throws Exception
-    {
-        cleanUp(getRepositoriesToClean(REPOSITORY_RELEASES_1,
-                                       REPOSITORY_RELEASES_2,
-                                       REPOSITORY_RELEASES_3,
-                                       REPOSITORY_RELEASES_4,
-                                       REPOSITORY_RELEASES_5,
-                                       REPOSITORY_RELEASES_6));
-    }
-
-    public static Set<MutableRepository> getRepositoriesToClean(String... repositoryId)
-    {
-        Set<MutableRepository> repositories = new LinkedHashSet<>();
-
-        Arrays.asList(repositoryId).forEach(
-                r -> repositories.add(createRepositoryMock(STORAGE0, r, Maven2LayoutProvider.ALIAS))
-        );
-        return repositories;
-    }
-
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByClassName()
+    public void indexerShouldBeCapableToSearchByClassName(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1,
+                                                                           setup = MavenIndexedRepositorySetup.class)
+                                                          Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_1, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_1,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.jar");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    jarArtifact.getInputStream());
 
-        String contextId = IndexContextHelper.getContextId(STORAGE0, REPOSITORY_RELEASES_1,
+        String contextId = IndexContextHelper.getContextId(STORAGE0, repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES, new UserInputSearchExpression("PropertiesResources"));
@@ -129,27 +112,26 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_1));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByFQN()
+    public void indexerShouldBeCapableToSearchByFQN(@MavenRepository(repositoryId = REPOSITORY_RELEASES_2,
+                                                                     setup = MavenIndexedRepositorySetup.class)
+                                                    Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_2, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_2,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.jar");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    jarArtifact.getInputStream());
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_2,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES,
@@ -158,35 +140,31 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_2));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void indexerShouldBeCapableToSearchByFullSha1Hash()
+    public void indexerShouldBeCapableToSearchByFullSha1Hash(@MavenRepository(repositoryId = REPOSITORY_RELEASES_3,
+                                                                              setup = MavenIndexedRepositorySetup.class)
+                                                             Repository repository,
+                                                             @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_3,
+                                                                                id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                versions = { "1.8" })
+                                                             Path artifactPath)
             throws Exception
     {
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES_3,
-                                      true,
-                                      "org.carlspring:properties-injector",
-                                      "1.8");
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
-        String sha1 = Files.readAllLines(getVaultDirectoryPath().resolve("storages")
-                                                                .resolve(STORAGE0)
-                                                                .resolve(REPOSITORY_RELEASES_3)
-                                                                .resolve("org")
-                                                                .resolve("carlspring")
-                                                                .resolve("properties-injector")
-                                                                .resolve("1.8")
-                                                                .resolve("properties-injector-1.8.jar.sha1")
-                                                                .toAbsolutePath()).get(0);
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
+                                                                       repository.getId(),
+                                                                       "org/carlspring/properties-injector/1.8/properties-injector-1.8.jar.sha1");
+
+        String sha1 = Files.readAllLines(repositoryPath).get(0);
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_3,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
 
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
@@ -195,35 +173,31 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_3));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void indexerShouldBeCapableToSearchByPartialSha1Hash()
+    public void indexerShouldBeCapableToSearchByPartialSha1Hash(@MavenRepository(repositoryId = REPOSITORY_RELEASES_4,
+                                                                                 setup = MavenIndexedRepositorySetup.class)
+                                                                Repository repository,
+                                                                @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_4,
+                                                                                   id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                   versions = { "1.8" })
+                                                                Path artifactPath)
             throws Exception
     {
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES_4,
-                                      true,
-                                      "org.carlspring:properties-injector",
-                                      "1.8");
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
-        String sha1 = Files.readAllLines(getVaultDirectoryPath().resolve("storages")
-                                                                .resolve(STORAGE0)
-                                                                .resolve(REPOSITORY_RELEASES_4)
-                                                                .resolve("org")
-                                                                .resolve("carlspring")
-                                                                .resolve("properties-injector")
-                                                                .resolve("1.8")
-                                                                .resolve("properties-injector-1.8.jar.sha1")
-                                                                .toAbsolutePath()).get(0);
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
+                                                                       repository.getId(),
+                                                                       "org/carlspring/properties-injector/1.8/properties-injector-1.8.jar.sha1");
+
+        String sha1 = Files.readAllLines(repositoryPath).get(0);
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_4,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
 
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
@@ -232,27 +206,27 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_4));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByClassNameFromZippedArtifact()
+    public void indexerShouldBeCapableToSearchByClassNameFromZippedArtifact(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_5,
+                             setup = MavenIndexedRepositorySetup.class)
+            Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_5, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_5,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.zip");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    zipArtifact.getInputStream());
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_5,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES, new UserInputSearchExpression("PropertiesResources"));
@@ -260,26 +234,27 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_5));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByFQNFromZippedArtifact()
+    public void indexerShouldBeCapableToSearchByFQNFromZippedArtifact(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_6,
+                             setup = MavenIndexedRepositorySetup.class)
+            Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_6, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0, 
-                                                                       REPOSITORY_RELEASES_6, 
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.zip");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    zipArtifact.getInputStream());
 
-        String contextId = IndexContextHelper.getContextId(STORAGE0, REPOSITORY_RELEASES_6,
+        String contextId = IndexContextHelper.getContextId(STORAGE0,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES,
@@ -288,7 +263,5 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_6));
     }
 }


### PR DESCRIPTION
Fixes for #1165.

Refactoring test cases to use new annotations.

* [x] `org.carlspring.strongbox.storage.indexing.StrongboxIndexerTest`
* [x] `org.carlspring.strongbox.storage.indexing.RepositoryIndexerTest`