### PR TITLE
Issue-1165: Migrate the Maven layout provider tests to use the new annotations (@ptirador)

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -92,10 +93,6 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT
     public void expiredArtifactsCleanupCronJobShouldCleanupDatabaseAndStorage()
             throws Exception
     {
-        final String storageId = "storage-common-proxies";
-        final String repositoryId = "maven-central";
-        final String path = "org/carlspring/properties-injector/1.5/properties-injector-1.5.jar";
-
         Optional<ArtifactEntry> artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
                                                                                                                  repositoryId,
                                                                                                                  path));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -27,11 +27,13 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
+ * @author Pablo Tirado
  */
 @ContextConfiguration(classes = Maven2LayoutProviderCronTasksTestConfig.class)
 @SpringBootTest
@@ -66,22 +68,22 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
                                             @RepositoryAttributes(allowsForceDeletion = true, trashEnabled = true)
                                             Repository repository1,
                                             @MavenRepository(repositoryId = REPOSITORY_RELEASES_2)
-                                            @RepositoryAttributes(allowsForceDeletion = false, trashEnabled = true)
+                                            @RepositoryAttributes(trashEnabled = true)
                                             Repository repository2,
                                             @MavenRepository(storageId = STORAGE1, repositoryId = REPOSITORY_RELEASES_1)
-                                            @RepositoryAttributes(allowsForceDeletion = false, trashEnabled = true)
+                                            @RepositoryAttributes(trashEnabled = true)
                                             Repository repository3,
-                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one", 
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one",
                                                                versions = "1.0")
                                             Path artifact1,
-                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-two", 
+                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-two",
                                                                versions = "1.0")
                                             Path artifact2,
-                                            @MavenTestArtifact(storageId = STORAGE1, 
-                                                               repositoryId = REPOSITORY_RELEASES_1, 
-                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one", 
+                                            @MavenTestArtifact(storageId = STORAGE1,
+                                                               repositoryId = REPOSITORY_RELEASES_1,
+                                                               id = "org.carlspring.strongbox.clear:strongbox-test-one",
                                                                versions = "1.0")
                                             Path artifact3)
             throws Exception
@@ -97,7 +99,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
 
         RepositoryFiles.delete(path, false);
 
-        assertNotNull(Files.exists(repositoryTrashPath), "There is no path to the repository trash!");
+        Files.exists(repositoryTrashPath);
         assertFalse(Files.exists(artifact1.normalize()), "The repository path exists!");
         assertTrue(Files.exists(RepositoryFiles.trash((RepositoryPath) artifact1.normalize())), "The repository trash is empty!");
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -90,8 +90,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
     {
         RepositoryPath repositoryRootPath = repositoryPathResolver.resolve(repository1);
         RepositoryPath repositoryTrashPath = RepositoryFiles.trash(repositoryRootPath);
-        RepositoryPath path = repositoryPathResolver.resolve(repository1,
-                                                             "org/carlspring/strongbox/clear/strongbox-test-one/1.0");
+        RepositoryPath path = repositoryPathResolver.resolve(repository1, (RepositoryPath) artifact1.normalize());
         RepositoryPath trashPath = RepositoryFiles.trash(path);
         
         assertTrue(Files.exists(repositoryTrashPath), "There is no path to the repository trash!");
@@ -103,8 +102,11 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
         assertFalse(Files.exists(artifact1.normalize()), "The repository path exists!");
         assertTrue(Files.exists(RepositoryFiles.trash((RepositoryPath) artifact1.normalize())), "The repository trash is empty!");
 
-        addCronJobConfig(expectedJobKey, expectedJobName, ClearRepositoryTrashCronJob.class, STORAGE0,
-                         REPOSITORY_RELEASES_1);
+        addCronJobConfig(expectedJobKey,
+                         expectedJobName,
+                         ClearRepositoryTrashCronJob.class,
+                         STORAGE0,
+                         repository1.getId());
 
         await().atMost(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS).untilTrue(receivedExpectedEvent());
         

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/ClearTrashCronJobFromMaven2RepositoryTestIT.java
@@ -98,7 +98,7 @@ public class ClearTrashCronJobFromMaven2RepositoryTestIT
 
         RepositoryFiles.delete(path, false);
 
-        Files.exists(repositoryTrashPath);
+        assertTrue(Files.exists(repositoryTrashPath), "There is no path to the repository trash!");
         assertFalse(Files.exists(artifact1.normalize()), "The repository path exists!");
         assertTrue(Files.exists(RepositoryFiles.trash((RepositoryPath) artifact1.normalize())), "The repository trash is empty!");
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/dependency/snippet/MavenDependencyFormatterTest.java
@@ -2,31 +2,35 @@ package org.carlspring.strongbox.dependency.snippet;
 
 import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
-import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
 import org.carlspring.strongbox.repository.IndexedMavenRepositoryFeatures;
-import org.carlspring.strongbox.services.ArtifactEntryService;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.search.SearchRequest;
 import org.carlspring.strongbox.storage.search.SearchResult;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
 import java.io.IOException;
-import java.util.LinkedHashSet;
+import java.lang.annotation.*;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,6 +38,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * @author carlspring
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -45,7 +50,15 @@ public class MavenDependencyFormatterTest
 
     private static final String REPOSITORY_RELEASES = "mdft-releases";
 
-    public static final String REPOSITORY_BASEDIR = "target/strongbox-vault/storages/storage0/" + REPOSITORY_RELEASES;
+    private static final String GROUP_ID = "org.carlspring.strongbox";
+
+    private static final String ARTIFACT_ID = "maven-snippet";
+
+    private static final String VERSION_1 = "1.0";
+
+    private static final String VERSION_2 = "2.0";
+
+    private static final String CLASSIFIER_SOURCES = "sources";
 
     @Inject
     private CompatibleDependencyFormatRegistry compatibleDependencyFormatRegistry;
@@ -54,83 +67,28 @@ public class MavenDependencyFormatterTest
     private Optional<MavenIndexerSearchProvider> mavenIndexerSearchProvider;
 
     @Inject
-    private ArtifactEntryService artifactEntryService;
-
-    @Inject
     private SnippetGenerator snippetGenerator;
 
-    @BeforeEach
-    public void setUp()
-            throws Exception
-    {
-        // Because there is no smarter way to cleanup... :-|
-        removeEntriesIfAnyExist();
-
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES,
-                                      true,
-                                      "org.carlspring.strongbox:maven-snippet",
-                                      "1.0");
-
-        generateArtifact(REPOSITORY_BASEDIR, "org.carlspring.strongbox:maven-snippet:1.0:jar:sources");
-
-        reIndex(STORAGE0, REPOSITORY_RELEASES, "org/carlspring/strongbox");
-    }
-
-    @AfterEach
-    public void removeRepositories()
-            throws IOException, JAXBException
-    {
-        removeRepositories(getRepositories());
-    }
-
-    private void removeEntriesIfAnyExist()
-    {
-        removeEntryIfExists(new MavenArtifactCoordinates("org.carlspring.strongbox",
-                                                         "maven-snippet",
-                                                         "1.0",
-                                                         null,
-                                                         "jar"));
-        removeEntryIfExists(new MavenArtifactCoordinates("org.carlspring.strongbox",
-                                                         "maven-snippet",
-                                                         "1.0",
-                                                         "sources",
-                                                         "jar"));
-    }
-
-    private void removeEntryIfExists(MavenArtifactCoordinates coordinates1)
-    {
-        ArtifactEntry artifactEntry = artifactEntryService.findOneArtifact(STORAGE0,
-                                                                           REPOSITORY_RELEASES,
-                                                                           coordinates1.toPath());
-
-        if (artifactEntry != null)
-        {
-            artifactEntryService.delete(artifactEntry);
-        }
-    }
-
-    private Set<RepositoryDto> getRepositories()
-    {
-        Set<RepositoryDto> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_RELEASES, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testMavenDependencyGeneration()
-            throws ProviderImplementationException
+    public void testMavenDependencyGeneration(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                                               setup = MavenIndexedRepositorySetup.class)
+                                              Repository repository,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                                 id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                 versions = { VERSION_1 })
+                                              Path artifactPath)
+            throws ProviderImplementationException, IOException
     {
+        reIndex(repository);
+
         DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,
                                                                                                             Maven2LayoutProvider.ALIAS);
         assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
 
-        MavenArtifactCoordinates coordinates = new MavenArtifactCoordinates();
-        coordinates.setGroupId("org.carlspring.strongbox");
-        coordinates.setArtifactId("maven-snippet");
-        coordinates.setVersion("1.0");
-        coordinates.setExtension("jar");
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) RepositoryFiles.readCoordinates(
+                (RepositoryPath) artifactPath.normalize());
 
         String snippet = formatter.getDependencySnippet(coordinates);
 
@@ -147,19 +105,27 @@ public class MavenDependencyFormatterTest
                      "Failed to generate dependency!");
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testMavenDependencyGenerationWithClassifier()
-            throws ProviderImplementationException
+    public void testMavenDependencyGenerationWithClassifier(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                                                             setup = MavenIndexedRepositorySetup.class)
+                                                            Repository repository,
+                                                            @MavenArtifactWithClassifiers(repositoryId = REPOSITORY_RELEASES,
+                                                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                          versions = { VERSION_2 })
+                                                            Path artifactPath)
+            throws ProviderImplementationException, IOException
     {
+        reIndex(repository);
+
         DependencySynonymFormatter formatter = compatibleDependencyFormatRegistry.getProviderImplementation(Maven2LayoutProvider.ALIAS,
                                                                                                             Maven2LayoutProvider.ALIAS);
         assertNotNull(formatter, "Failed to look up dependency synonym formatter!");
 
-        MavenArtifactCoordinates coordinates = new MavenArtifactCoordinates();
-        coordinates.setGroupId("org.carlspring.strongbox");
-        coordinates.setArtifactId("maven-snippet");
-        coordinates.setVersion("2.0");
-        coordinates.setClassifier("sources");
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) RepositoryFiles.readCoordinates(
+                (RepositoryPath) artifactPath.normalize());
+        coordinates.setClassifier(CLASSIFIER_SOURCES);
 
         String snippet = formatter.getDependencySnippet(coordinates);
 
@@ -177,25 +143,35 @@ public class MavenDependencyFormatterTest
                      "Failed to generate dependency!");
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testSearchExactWithDependencySnippet()
+    public void testSearchExactWithDependencySnippet(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                                                      setup = MavenIndexedRepositorySetup.class)
+                                                     Repository repository,
+                                                     @MavenArtifactWithClassifiers(repositoryId = REPOSITORY_RELEASES,
+                                                                                   id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                   versions = { VERSION_1 })
+                                                     Path artifactPath)
+            throws IOException
     {
+
         Assumptions.assumeTrue(mavenIndexerSearchProvider.isPresent());
 
+        reIndex(repository);
         IndexedMavenRepositoryFeatures features = (IndexedMavenRepositoryFeatures) getFeatures();
-        final int x = features.reIndex(STORAGE0,
-                                       REPOSITORY_RELEASES,
-                                       "org/carlspring/strongbox/maven-snippet");
+        final int numberOfFiles = features.reIndex(STORAGE0,
+                                                   repository.getId(),
+                                                   "org/carlspring/strongbox/maven-snippet");
 
-        assertTrue(x >= 3, "Incorrect number of artifacts found!");
+        assertTrue(numberOfFiles >= 3, "Incorrect number of artifacts found!");
+
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) RepositoryFiles.readCoordinates(
+                (RepositoryPath) artifactPath.normalize());
 
         SearchRequest request = new SearchRequest(STORAGE0,
-                                                  REPOSITORY_RELEASES,
-                                                  new MavenArtifactCoordinates("org.carlspring.strongbox",
-                                                                               "maven-snippet",
-                                                                               "1.0",
-                                                                               null,
-                                                                               "jar"),
+                                                  repository.getId(),
+                                                  coordinates,
                                                   MavenIndexerSearchProvider.ALIAS);
 
         SearchResult searchResult = mavenIndexerSearchProvider.get().findExact(request);
@@ -211,20 +187,29 @@ public class MavenDependencyFormatterTest
         }
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testRegisteredSynonyms()
+    public void testRegisteredSynonyms(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+                                                        setup = MavenIndexedRepositorySetup.class)
+                                       Repository repository,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                          id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                          versions = { VERSION_1 })
+                                       Path artifactPath)
+            throws IOException
     {
+        reIndex(repository);
+
+        MavenArtifactCoordinates coordinates = (MavenArtifactCoordinates) RepositoryFiles.readCoordinates(
+                (RepositoryPath) artifactPath.normalize());
+
         List<CodeSnippet> codeSnippets = snippetGenerator.generateSnippets(Maven2LayoutProvider.ALIAS,
-                                                                           new MavenArtifactCoordinates("org.carlspring.strongbox",
-                                                                                                        "maven-snippet",
-                                                                                                        "1.0",
-                                                                                                        null,
-                                                                                                        "jar"));
+                                                                           coordinates);
 
         assertNotNull(codeSnippets, "Failed to look up dependency synonym formatter!");
         assertFalse(codeSnippets.isEmpty(), "No synonyms found!");
         assertEquals(7, codeSnippets.size(), "Incorrect number of dependency synonyms!");
-
 
 
         String[] synonyms = new String[]{ "Maven 2", "Bazel", "Buildr", "Gradle", "Ivy", "Leiningen", "SBT", };
@@ -238,6 +223,31 @@ public class MavenDependencyFormatterTest
 
             i++;
         }
+    }
+
+    private void reIndex(Repository repository)
+    {
+        IndexedMavenRepositoryFeatures features = (IndexedMavenRepositoryFeatures) getFeatures();
+
+        features.reIndex(STORAGE0, repository.getId(), "org/carlspring/strongbox");
+    }
+
+    @Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @MavenTestArtifact(classifiers = { CLASSIFIER_SOURCES })
+    private @interface MavenArtifactWithClassifiers
+    {
+
+        @AliasFor(annotation = MavenTestArtifact.class)
+        String id() default "";
+
+        @AliasFor(annotation = MavenTestArtifact.class)
+        String[] versions() default {};
+
+        @AliasFor(annotation = MavenTestArtifact.class)
+        String repositoryId() default "";
+
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -48,10 +48,13 @@ public class MavenGroupRepositoryProviderTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
-    private static final String MGRPT_RELEASES_1 = "mgrpt-releases-1";
-    private static final String MGRPT_RELEASES_2 = "mgrpt-releases-2";
-    private static final String MGRPT_RELEASES_GROUP = "mgrpt-releases-group";
-    private static final String MGRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1 = "mgrpt-releases-group-with-nested-group-level-1";
+    private static final String REPOSITORY_RELEASES_1 = "mgrpt-releases-1";
+
+    private static final String REPOSITORY_RELEASES_2 = "mgrpt-releases-2";
+
+    private static final String REPOSITORY_GROUP = "mgrpt-releases-group";
+
+    private static final String REPOSITORY_GROUP_WITH_NESTED_GROUP_1 = "mgrpt-releases-group-with-nested-group-level-1";
 
     @Inject
     private RepositoryProviderRegistry repositoryProviderRegistry;
@@ -68,15 +71,15 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludes(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                  @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                  @Group({ MGRPT_RELEASES_1,
-                                           MGRPT_RELEASES_2 })
-                                  @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under:group", versions = "1.2.3") Path a2,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.four:foo", versions = "1.2.4") Path a3,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under:group", versions = "1.2.4") Path a4)
+    public void testGroupIncludes(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                  @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                  @Group({ REPOSITORY_RELEASES_1,
+                                           REPOSITORY_RELEASES_2 })
+                                  @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.under:group", versions = "1.2.3") Path a2,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.four:foo", versions = "1.2.4") Path a3,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.under:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes...");
@@ -104,14 +107,14 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void mavenMetadataFileShouldBeFetchedFromGroupPathRepository(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                                                        @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                                                        @Group({ MGRPT_RELEASES_1,
-                                                                                 MGRPT_RELEASES_2 })
-                                                                        @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under123:group", versions = "1.2.3") Path a2,
-                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under123:group", versions = "1.2.4") Path a3)
+    public void mavenMetadataFileShouldBeFetchedFromGroupPathRepository(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                                                        @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                                                        @Group({ REPOSITORY_RELEASES_1,
+                                                                                 REPOSITORY_RELEASES_2 })
+                                                                        @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.under123:group", versions = "1.2.3") Path a2,
+                                                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.under123:group", versions = "1.2.4") Path a3)
             throws Exception
     {
         generateMavenMetadata(STORAGE0, releases1.getId());
@@ -136,19 +139,19 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludesWithOutOfServiceRepository(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                                            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                                            @Group(repositories = { MGRPT_RELEASES_1,
-                                                                                    MGRPT_RELEASES_2 },
-                                                                   rules = { @Rule(repositories = { MGRPT_RELEASES_1,
-                                                                                                    MGRPT_RELEASES_2 },
+    public void testGroupIncludesWithOutOfServiceRepository(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                                            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                                            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                                                                    REPOSITORY_RELEASES_2 },
+                                                                   rules = { @Rule(repositories = { REPOSITORY_RELEASES_1,
+                                                                                                    REPOSITORY_RELEASES_2 },
                                                                                    pattern = ".*(com|org)/artifacts.in.releases.*"),
-                                                                             @Rule(repositories = { MGRPT_RELEASES_1 },
+                                                                             @Rule(repositories = { REPOSITORY_RELEASES_1 },
                                                                                    pattern = ".*(com|org)/artifacts.in.*",
                                                                                    type = RoutingRuleTypeEnum.DENY)})
-                                                            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                                            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                                            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a2)
+                                                            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                                            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a2)
             throws Exception
     {
 
@@ -173,15 +176,15 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludesWildcardRule(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                              @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                              @Group(repositories = { MGRPT_RELEASES_1,
-                                                                      MGRPT_RELEASES_2 })
-                                              @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.three:foo", versions = "1.2.3") Path a1,
-                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under2:group", versions = "1.2.3") Path a2,
-                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
-                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under2:group", versions = "1.2.4") Path a4)
+    public void testGroupIncludesWildcardRule(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                              @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                              @Group(repositories = { REPOSITORY_RELEASES_1,
+                                                                      REPOSITORY_RELEASES_2 })
+                                              @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.three:foo", versions = "1.2.3") Path a1,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.under2:group", versions = "1.2.3") Path a2,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.under2:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard...");
@@ -201,17 +204,17 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void testGroupIncludesWildcardRuleAgainstNestedRepository(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @Group(repositories = { MGRPT_RELEASES_GROUP,})
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1) Repository releasesGroupWithNestedGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under3:group", versions = "1.2.3") Path a2,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under3:group", versions = "1.2.4") Path a4)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @Group(repositories = { REPOSITORY_GROUP,})
+            @MavenRepository(repositoryId = REPOSITORY_GROUP_WITH_NESTED_GROUP_1) Repository releasesGroupWithNestedGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.under3:group", versions = "1.2.3") Path a2,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.in.releases.under3:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard against nested repositories...");
@@ -231,10 +234,10 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void testGroupAgainstNestedRepository(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @Group(repositories = { MGRPT_RELEASES_1 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "org.carlspring.metadata.by.juan:juancho", versions = "1.2.64") Path a1)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @Group(repositories = { REPOSITORY_RELEASES_1 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard against nested repositories...");
@@ -253,17 +256,17 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupExcludes(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                  @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                  @Group(repositories = { MGRPT_RELEASES_1,
-                                                          MGRPT_RELEASES_2 },
-                                         rules = { @Rule(repositories = { MGRPT_RELEASES_1 },
+    public void testGroupExcludes(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                  @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                  @Group(repositories = { REPOSITORY_RELEASES_1,
+                                                          REPOSITORY_RELEASES_2 },
+                                         rules = { @Rule(repositories = { REPOSITORY_RELEASES_1 },
                                                          pattern = ".*(com|org)/artifacts.denied.*",
                                                          type = RoutingRuleTypeEnum.DENY)})
-                                  @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.6") Path a2,
-                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.7") Path a3)
+                                  @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.6") Path a2,
+                                  @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.7") Path a3)
             throws Exception
     {
         System.out.println("# Testing group excludes...");
@@ -294,16 +297,16 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void deniedRuleShouldBeValid(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-                                        @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-                                        @Group(repositories = { MGRPT_RELEASES_1,
-                                                                MGRPT_RELEASES_2 },
-                                               rules = { @Rule(repositories = { MGRPT_RELEASES_2 },
+    public void deniedRuleShouldBeValid(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+                                        @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+                                        @Group(repositories = { REPOSITORY_RELEASES_1,
+                                                                REPOSITORY_RELEASES_2 },
+                                               rules = { @Rule(repositories = { REPOSITORY_RELEASES_2 },
                                                                pattern = ".*(com|org)/carlspring.metadata.*",
                                                                type = RoutingRuleTypeEnum.DENY)})
-                                        @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+                                        @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
@@ -313,13 +316,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkIfRepositoryAndStorageIsNotProvided(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because its 'repositories' attribute only allows not null repositories ids.
@@ -337,16 +340,16 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkIfRepositoryIsEmpty(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 },
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 },
                    rules = { @Rule(repositories = { StringUtils.EMPTY },
                                    pattern = ".*(com|org)/carlspring.metadata.*",
                                    type = RoutingRuleTypeEnum.DENY)})
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
@@ -356,13 +359,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroupsUnderTheSameStorage(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
 
@@ -380,13 +383,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroups(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because groupStorageId and groupRepositoryId cannot be passed as null.
@@ -403,13 +406,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroupsUnderTheSameRepositoryName(
-            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { MGRPT_RELEASES_1,
-                                    MGRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because groupStorageId cannot be passed as null.

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.ContextConfiguration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
-@Execution(SAME_THREAD)
+@Execution(CONCURRENT)
 public class MavenGroupRepositoryProviderTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -335,6 +335,29 @@ public class MavenGroupRepositoryProviderTest
         testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    @Test
+    public void deniedRoutingRuleShouldWorkIfRepositoryIsNotProvided(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_2) Repository releases2,
+            @Group(repositories = { REPOSITORY_RELEASES_1,
+                                    REPOSITORY_RELEASES_2 })
+            @MavenRepository(repositoryId = REPOSITORY_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            throws Exception
+    {
+        // Rule cannot be created with annotation, because its 'repositories' attribute only allows not null repositories ids.
+        createAndAddRoutingRule(STORAGE0,
+                                releasesGroup.getId(),
+                                Arrays.asList(new MutableRoutingRuleRepository(STORAGE0, null)),
+                                ".*(com|org)/carlspring.metadata.*",
+                                RoutingRuleTypeEnum.DENY);
+
+        testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
+    }
+
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -49,10 +49,10 @@ public class MavenGroupRepositoryProviderTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
-    private static final String GRPT_RELEASES_1 = "grpt-releases-1";
-    private static final String GRPT_RELEASES_2 = "grpt-releases-2";
-    private static final String GRPT_RELEASES_GROUP = "grpt-releases-group";
-    private static final String GRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1 = "grpt-releases-group-with-nested-group-level-1";
+    private static final String MGRPT_RELEASES_1 = "mgrpt-releases-1";
+    private static final String MGRPT_RELEASES_2 = "mgrpt-releases-2";
+    private static final String MGRPT_RELEASES_GROUP = "mgrpt-releases-group";
+    private static final String MGRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1 = "mgrpt-releases-group-with-nested-group-level-1";
 
     @Inject
     private RepositoryProviderRegistry repositoryProviderRegistry;
@@ -69,15 +69,15 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludes(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                  @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                  @Group({ GRPT_RELEASES_1,
-                                           GRPT_RELEASES_2 })
-                                  @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.under:group", versions = "1.2.3") Path a2,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.four:foo", versions = "1.2.4") Path a3,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.under:group", versions = "1.2.4") Path a4)
+    public void testGroupIncludes(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                  @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                  @Group({ MGRPT_RELEASES_1,
+                                           MGRPT_RELEASES_2 })
+                                  @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under:group", versions = "1.2.3") Path a2,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.four:foo", versions = "1.2.4") Path a3,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes...");
@@ -105,14 +105,14 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void mavenMetadataFileShouldBeFetchedFromGroupPathRepository(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                                                        @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                                                        @Group({ GRPT_RELEASES_1,
-                                                                                 GRPT_RELEASES_2})
-                                                                        @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                                                        @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                                                        @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.under123:group", versions = "1.2.3") Path a2,
-                                                                        @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.under123:group", versions = "1.2.4") Path a3)
+    public void mavenMetadataFileShouldBeFetchedFromGroupPathRepository(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                                                        @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                                                        @Group({ MGRPT_RELEASES_1,
+                                                                                 MGRPT_RELEASES_2 })
+                                                                        @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under123:group", versions = "1.2.3") Path a2,
+                                                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under123:group", versions = "1.2.4") Path a3)
             throws Exception
     {
         generateMavenMetadata(STORAGE0, releases1.getId());
@@ -137,19 +137,19 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludesWithOutOfServiceRepository(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                                            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                                            @Group(repositories = { GRPT_RELEASES_1,
-                                                                                    GRPT_RELEASES_2 },
-                                                                   rules = { @Rule(repositories = { GRPT_RELEASES_1,
-                                                                                                    GRPT_RELEASES_2 },
+    public void testGroupIncludesWithOutOfServiceRepository(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                                            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                                            @Group(repositories = { MGRPT_RELEASES_1,
+                                                                                    MGRPT_RELEASES_2 },
+                                                                   rules = { @Rule(repositories = { MGRPT_RELEASES_1,
+                                                                                                    MGRPT_RELEASES_2 },
                                                                                    pattern = ".*(com|org)/artifacts.in.releases.*"),
-                                                                             @Rule(repositories = { GRPT_RELEASES_1 },
+                                                                             @Rule(repositories = { MGRPT_RELEASES_1 },
                                                                                    pattern = ".*(com|org)/artifacts.in.*",
                                                                                    type = RoutingRuleTypeEnum.DENY)})
-                                                            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                                            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-                                                            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a2)
+                                                            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                                            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+                                                            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a2)
             throws Exception
     {
 
@@ -174,16 +174,16 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupIncludesWildcardRule(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                              @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                              @Group(repositories = { GRPT_RELEASES_1,
-                                                                      GRPT_RELEASES_2 })
+    public void testGroupIncludesWildcardRule(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                              @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                              @Group(repositories = { MGRPT_RELEASES_1,
+                                                                      MGRPT_RELEASES_2 })
                                               @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
-                                              @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                              @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.three:foo", versions = "1.2.3") Path a1,
-                                              @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.under2:group", versions = "1.2.3") Path a2,
-                                              @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
-                                              @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.under2:group", versions = "1.2.4") Path a4)
+                                              @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.three:foo", versions = "1.2.3") Path a1,
+                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under2:group", versions = "1.2.3") Path a2,
+                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
+                                              @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under2:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard...");
@@ -203,19 +203,19 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void testGroupIncludesWildcardRuleAgainstNestedRepository(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 })
             @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @Group(repositories = { GRPT_RELEASES_GROUP,})
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @Group(repositories = { MGRPT_RELEASES_GROUP,})
             @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1) Repository releasesGroupWithNestedGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.in.releases.under3:group", versions = "1.2.3") Path a2,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.in.releases.under3:group", versions = "1.2.4") Path a4)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1) Repository releasesGroupWithNestedGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under3:group", versions = "1.2.3") Path a2,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.two:foo", versions = "1.2.4") Path a3,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.in.releases.under3:group", versions = "1.2.4") Path a4)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard against nested repositories...");
@@ -235,11 +235,11 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void testGroupAgainstNestedRepository(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @Group(repositories = { GRPT_RELEASES_1 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @Group(repositories = { MGRPT_RELEASES_1 })
             @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "org.carlspring.metadata.by.juan:juancho", versions = "1.2.64") Path a1)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "org.carlspring.metadata.by.juan:juancho", versions = "1.2.64") Path a1)
             throws Exception
     {
         System.out.println("# Testing group includes with wildcard against nested repositories...");
@@ -258,17 +258,17 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupExcludes(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                  @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                  @Group(repositories = { GRPT_RELEASES_1,
-                                                          GRPT_RELEASES_2 },
-                                         rules = { @Rule(repositories = { GRPT_RELEASES_1 },
+    public void testGroupExcludes(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                  @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                  @Group(repositories = { MGRPT_RELEASES_1,
+                                                          MGRPT_RELEASES_2 },
+                                         rules = { @Rule(repositories = { MGRPT_RELEASES_1 },
                                                          pattern = ".*(com|org)/artifacts.denied.*",
                                                          type = RoutingRuleTypeEnum.DENY)})
-                                  @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.6") Path a2,
-                                  @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.7") Path a3)
+                                  @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.6") Path a2,
+                                  @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "com.artifacts.denied.by.wildcard:foo", versions = "1.2.7") Path a3)
             throws Exception
     {
         System.out.println("# Testing group excludes...");
@@ -299,16 +299,16 @@ public class MavenGroupRepositoryProviderTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void deniedRuleShouldBeValid(@MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-                                        @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-                                        @Group(repositories = { GRPT_RELEASES_1,
-                                                                GRPT_RELEASES_2 },
-                                               rules = { @Rule(repositories = { GRPT_RELEASES_2},
+    public void deniedRuleShouldBeValid(@MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+                                        @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+                                        @Group(repositories = { MGRPT_RELEASES_1,
+                                                                MGRPT_RELEASES_2 },
+                                               rules = { @Rule(repositories = { MGRPT_RELEASES_2 },
                                                                pattern = ".*(com|org)/carlspring.metadata.*",
                                                                type = RoutingRuleTypeEnum.DENY)})
-                                        @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-                                        @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-                                        @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+                                        @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+                                        @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
@@ -318,13 +318,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkIfRepositoryAndStorageIsNotProvided(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because its 'repositories' attribute only allows not null repositories ids.
@@ -342,16 +342,16 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkIfRepositoryIsEmpty(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 },
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 },
                    rules = { @Rule(repositories = { StringUtils.EMPTY },
                                    pattern = ".*(com|org)/carlspring.metadata.*",
                                    type = RoutingRuleTypeEnum.DENY)})
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         testDeny(releases1.getId(), releases2.getId(), releasesGroup, (RepositoryPath) a2.normalize());
@@ -361,13 +361,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroupsUnderTheSameStorage(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
 
@@ -385,13 +385,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroups(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because groupStorageId and groupRepositoryId cannot be passed as null.
@@ -408,13 +408,13 @@ public class MavenGroupRepositoryProviderTest
                   ArtifactManagementTestExecutionListener.class })
     @Test
     public void deniedRoutingRuleShouldWorkForAllGroupsUnderTheSameRepositoryName(
-            @MavenRepository(repositoryId = GRPT_RELEASES_1) Repository releases1,
-            @MavenRepository(repositoryId = GRPT_RELEASES_2) Repository releases2,
-            @Group(repositories = { GRPT_RELEASES_1,
-                                    GRPT_RELEASES_2 })
-            @MavenRepository(repositoryId = GRPT_RELEASES_GROUP) Repository releasesGroup,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
-            @MavenTestArtifact(repositoryId = GRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
+            @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
+            @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
+            @Group(repositories = { MGRPT_RELEASES_1,
+                                    MGRPT_RELEASES_2 })
+            @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.accepted:foo", versions = "1.2.6") Path a1,
+            @MavenTestArtifact(repositoryId = MGRPT_RELEASES_2, id = "org.carlspring.metadata.will.not.be:retrieved", versions = "1.2.64") Path a2)
             throws Exception
     {
         // Rule cannot be created with annotation, because groupStorageId cannot be passed as null.

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -13,7 +13,6 @@ import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIn
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
-import org.carlspring.strongbox.testing.storage.repository.RepositoryAttributes;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group.Rule;
@@ -178,7 +177,6 @@ public class MavenGroupRepositoryProviderTest
                                               @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
                                               @Group(repositories = { MGRPT_RELEASES_1,
                                                                       MGRPT_RELEASES_2 })
-                                              @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
                                               @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
                                               @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.three:foo", versions = "1.2.3") Path a1,
                                               @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under2:group", versions = "1.2.3") Path a2,
@@ -207,10 +205,8 @@ public class MavenGroupRepositoryProviderTest
             @MavenRepository(repositoryId = MGRPT_RELEASES_2) Repository releases2,
             @Group(repositories = { MGRPT_RELEASES_1,
                                     MGRPT_RELEASES_2 })
-            @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
             @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
             @Group(repositories = { MGRPT_RELEASES_GROUP,})
-            @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
             @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP_WITH_NESTED_GROUP_LEVEL_1) Repository releasesGroupWithNestedGroup,
             @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.one:foo", versions = "1.2.3") Path a1,
             @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "com.artifacts.in.releases.under3:group", versions = "1.2.3") Path a2,
@@ -237,7 +233,6 @@ public class MavenGroupRepositoryProviderTest
     public void testGroupAgainstNestedRepository(
             @MavenRepository(repositoryId = MGRPT_RELEASES_1) Repository releases1,
             @Group(repositories = { MGRPT_RELEASES_1 })
-            @RepositoryAttributes(allowsRedeployment = false, allowsDelete = false)
             @MavenRepository(repositoryId = MGRPT_RELEASES_GROUP) Repository releasesGroup,
             @MavenTestArtifact(repositoryId = MGRPT_RELEASES_1, id = "org.carlspring.metadata.by.juan:juancho", versions = "1.2.64") Path a1)
             throws Exception

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenGroupRepositoryProviderTest.java
@@ -34,7 +34,7 @@ import org.springframework.test.context.ContextConfiguration;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * @author mtodorov
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD)
 public class MavenGroupRepositoryProviderTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/RepositoryIndexerTest.java
@@ -92,16 +92,17 @@ public class RepositoryIndexerTest
 
         assertEquals(3, search.size(), "Only three versions of the strongbox-commons artifact were expected!");
 
-        search = repositoryIndexer.search("org.carlspring.strongbox", "strongbox-commons", "1.0", "jar", null);
-        assertEquals(1, search.size(), "org.carlspring.strongbox:strongbox-commons:1.0 should not been deleted!");
+        search = repositoryIndexer.search(GROUP_ID, ARTIFACT_ID, "1.0", "jar", null);
+        assertEquals(1, search.size(), GROUP_ID + ":" + ARTIFACT_ID + ":1.0 should not been deleted!");
 
-        search = repositoryIndexer.search("+g:org.carlspring.strongbox +a:strongbox-commons +v:1.0");
-        assertEquals(2, search.size(), "org.carlspring.strongbox:strongbox-commons:1.0 should not been deleted!");
+        final String query = String.format("+g:%s +a:%s +v:1.0", GROUP_ID, ARTIFACT_ID);
+        search = repositoryIndexer.search(query);
+        assertEquals(2, search.size(), GROUP_ID + ":" + ARTIFACT_ID + ":1.0  should not been deleted!");
 
         repositoryIndexer.delete(asArtifactInfo(search));
-        search = repositoryIndexer.search("org.carlspring.strongbox", "strongbox-commons", "1.0", null, null);
+        search = repositoryIndexer.search(GROUP_ID, ARTIFACT_ID, "1.0", null, null);
 
-        assertEquals(0, search.size(), "org.carlspring.strongbox:strongbox-commons:1.0 should have been deleted!");
+        assertEquals(0, search.size(), GROUP_ID + ":" + ARTIFACT_ID + ":1.0 should have been deleted!");
     }
 
     private Collection<ArtifactInfo> asArtifactInfo(Set<SearchResult> results)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/StrongboxIndexerTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/StrongboxIndexerTest.java
@@ -2,18 +2,20 @@ package org.carlspring.strongbox.storage.indexing;
 
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.services.ArtifactManagementService;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.util.IndexContextHelper;
 
 import javax.inject.Inject;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.lucene.search.Query;
 import org.apache.maven.index.FlatSearchRequest;
@@ -23,9 +25,8 @@ import org.apache.maven.index.MAVEN;
 import org.apache.maven.index.expr.SourcedSearchExpression;
 import org.apache.maven.index.expr.UserInputSearchExpression;
 import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
@@ -60,6 +61,10 @@ public class StrongboxIndexerTest
 
     private static final String REPOSITORY_RELEASES_6 = "injector-releases-6";
 
+    private static final String GROUP_ID = "org.carlspring";
+
+    private static final String ARTIFACT_ID = "properties-injector";
+
     /**
      * org/carlspring/ioc/PropertyValueInjector
      * org/carlspring/ioc/InjectionException
@@ -82,46 +87,24 @@ public class StrongboxIndexerTest
     @Inject
     private Optional<Indexer> indexer;
 
-    @BeforeAll
-    @AfterAll
-    public static void cleanUp()
-            throws Exception
-    {
-        cleanUp(getRepositoriesToClean(REPOSITORY_RELEASES_1,
-                                       REPOSITORY_RELEASES_2,
-                                       REPOSITORY_RELEASES_3,
-                                       REPOSITORY_RELEASES_4,
-                                       REPOSITORY_RELEASES_5,
-                                       REPOSITORY_RELEASES_6));
-    }
-
-    public static Set<RepositoryDto> getRepositoriesToClean(String... repositoryId)
-    {
-        Set<RepositoryDto> repositories = new LinkedHashSet<>();
-
-        Arrays.asList(repositoryId).forEach(
-                r -> repositories.add(createRepositoryMock(STORAGE0, r, Maven2LayoutProvider.ALIAS))
-        );
-        return repositories;
-    }
-
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByClassName()
+    public void indexerShouldBeCapableToSearchByClassName(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1,
+                                                                           setup = MavenIndexedRepositorySetup.class)
+                                                          Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_1, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_1,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.jar");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    jarArtifact.getInputStream());
 
-        String contextId = IndexContextHelper.getContextId(STORAGE0, REPOSITORY_RELEASES_1,
+        String contextId = IndexContextHelper.getContextId(STORAGE0, repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES, new UserInputSearchExpression("PropertiesResources"));
@@ -129,27 +112,26 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_1));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByFQN()
+    public void indexerShouldBeCapableToSearchByFQN(@MavenRepository(repositoryId = REPOSITORY_RELEASES_2,
+                                                                     setup = MavenIndexedRepositorySetup.class)
+                                                    Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_2, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_2,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.jar");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    jarArtifact.getInputStream());
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_2,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES,
@@ -158,35 +140,31 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_2));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void indexerShouldBeCapableToSearchByFullSha1Hash()
+    public void indexerShouldBeCapableToSearchByFullSha1Hash(@MavenRepository(repositoryId = REPOSITORY_RELEASES_3,
+                                                                              setup = MavenIndexedRepositorySetup.class)
+                                                             Repository repository,
+                                                             @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_3,
+                                                                                id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                versions = { "1.8" })
+                                                             Path artifactPath)
             throws Exception
     {
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES_3,
-                                      true,
-                                      "org.carlspring:properties-injector",
-                                      "1.8");
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
-        String sha1 = Files.readAllLines(getVaultDirectoryPath().resolve("storages")
-                                                                .resolve(STORAGE0)
-                                                                .resolve(REPOSITORY_RELEASES_3)
-                                                                .resolve("org")
-                                                                .resolve("carlspring")
-                                                                .resolve("properties-injector")
-                                                                .resolve("1.8")
-                                                                .resolve("properties-injector-1.8.jar.sha1")
-                                                                .toAbsolutePath()).get(0);
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
+                                                                       repository.getId(),
+                                                                       "org/carlspring/properties-injector/1.8/properties-injector-1.8.jar.sha1");
+
+        String sha1 = Files.readAllLines(repositoryPath).get(0);
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_3,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
 
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
@@ -195,35 +173,31 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_3));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void indexerShouldBeCapableToSearchByPartialSha1Hash()
+    public void indexerShouldBeCapableToSearchByPartialSha1Hash(@MavenRepository(repositoryId = REPOSITORY_RELEASES_4,
+                                                                                 setup = MavenIndexedRepositorySetup.class)
+                                                                Repository repository,
+                                                                @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_4,
+                                                                                   id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                                                   versions = { "1.8" })
+                                                                Path artifactPath)
             throws Exception
     {
-        createRepositoryWithArtifacts(STORAGE0,
-                                      REPOSITORY_RELEASES_4,
-                                      true,
-                                      "org.carlspring:properties-injector",
-                                      "1.8");
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
-        String sha1 = Files.readAllLines(getVaultDirectoryPath().resolve("storages")
-                                                                .resolve(STORAGE0)
-                                                                .resolve(REPOSITORY_RELEASES_4)
-                                                                .resolve("org")
-                                                                .resolve("carlspring")
-                                                                .resolve("properties-injector")
-                                                                .resolve("1.8")
-                                                                .resolve("properties-injector-1.8.jar.sha1")
-                                                                .toAbsolutePath()).get(0);
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
+                                                                       repository.getId(),
+                                                                       "org/carlspring/properties-injector/1.8/properties-injector-1.8.jar.sha1");
+
+        String sha1 = Files.readAllLines(repositoryPath).get(0);
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_4,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
 
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
@@ -232,27 +206,27 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_4));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByClassNameFromZippedArtifact()
+    public void indexerShouldBeCapableToSearchByClassNameFromZippedArtifact(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_5,
+                             setup = MavenIndexedRepositorySetup.class)
+            Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_5, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0,
-                                                                       REPOSITORY_RELEASES_5,
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.zip");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    zipArtifact.getInputStream());
 
         String contextId = IndexContextHelper.getContextId(STORAGE0,
-                                                           REPOSITORY_RELEASES_5,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES, new UserInputSearchExpression("PropertiesResources"));
@@ -260,26 +234,27 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_5));
     }
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void indexerShouldBeCapableToSearchByFQNFromZippedArtifact()
+    public void indexerShouldBeCapableToSearchByFQNFromZippedArtifact(
+            @MavenRepository(repositoryId = REPOSITORY_RELEASES_6,
+                             setup = MavenIndexedRepositorySetup.class)
+            Repository repository)
             throws Exception
     {
-        createRepository(STORAGE0, REPOSITORY_RELEASES_6, true);
-
         Indexer indexer = this.indexer.get();
         RepositoryIndexManager repositoryIndexManager = this.repositoryIndexManager.get();
 
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(STORAGE0, 
-                                                                       REPOSITORY_RELEASES_6, 
+                                                                       repository.getId(),
                                                                        "org/carlspring/properties-injector/1.7/properties-injector-1.7.zip");
         artifactManagementService.validateAndStore(repositoryPath,
                                                    zipArtifact.getInputStream());
 
-        String contextId = IndexContextHelper.getContextId(STORAGE0, REPOSITORY_RELEASES_6,
+        String contextId = IndexContextHelper.getContextId(STORAGE0,
+                                                           repository.getId(),
                                                            IndexTypeEnum.LOCAL.getType());
         RepositoryIndexer ri = repositoryIndexManager.getRepositoryIndexer(contextId);
         Query q = indexer.constructQuery(MAVEN.CLASSNAMES,
@@ -288,7 +263,5 @@ public class StrongboxIndexerTest
         FlatSearchResponse response = indexer.searchFlat(new FlatSearchRequest(q, ri.getIndexingContext()));
 
         assertThat(response.getTotalHitsCount(), CoreMatchers.equalTo(1));
-
-        removeRepositories(getRepositoriesToClean(REPOSITORY_RELEASES_6));
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidatorTest.java
@@ -1,58 +1,64 @@
 package org.carlspring.strongbox.storage.validation.artifactid;
 
-import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
-import org.carlspring.strongbox.providers.io.RepositoryFileAttributes;
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.validation.artifact.LowercaseValidationException;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
-import org.junit.jupiter.api.BeforeEach;
+import javax.inject.Inject;
+import java.nio.file.Path;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Created by dinesh on 12/10/17.
+ * @author Pablo Tirado
  */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
 public class MavenArtifactIdLowercaseValidatorTest
 {
 
-    @Spy
-    MavenArtifactIdLowercaseValidator mavenArtifactIdLowercaseValidator = new MavenArtifactIdLowercaseValidator();
+    private static final String REPOSITORY_RELEASES = "mailvt-releases";
 
-    MavenArtifactCoordinates mavenArtifactCoordinates;
+    private static final String GROUP_ID = "org.carlspring.maven.is.uppercase";
 
-    @Mock
-    RepositoryFileAttributes repositoryFileAttributes;
+    private static final String ARTIFACT_ID = "my-maven-ARTIFACT";
 
-    @BeforeEach
-    public void setUp()
-    {
-        initMocks(this);
-        mavenArtifactCoordinates = new MavenArtifactCoordinates("org.dinesh.artifact.is.uppercase",
-                                                                "my-maven-Artifact",
-                                                                "1.0",
-                                                                "classfier",
-                                                                "extension");
-        // repositoryFileSystem
-    }
+    @Inject
+    private MavenArtifactIdLowercaseValidator mavenArtifactIdLowercaseValidator;
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void validateGroupIdCase()
+    public void validateGroupIdCase(@MavenRepository(repositoryId = REPOSITORY_RELEASES)
+                                    Repository repository,
+                                    @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                       id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                       versions = { "1.0" })
+                                    Path path)
             throws Exception
     {
-        doReturn(repositoryFileAttributes).when(mavenArtifactIdLowercaseValidator).getAttributes(any());
-        when(repositoryFileAttributes.getCoordinates()).thenReturn(mavenArtifactCoordinates);
+        RepositoryPath repositoryPath = (RepositoryPath) path.normalize();
+        ArtifactCoordinates coordinates = RepositoryFiles.readCoordinates(repositoryPath);
 
-        assertThrows(LowercaseValidationException.class, () -> {
-            mavenArtifactIdLowercaseValidator.validate(null, mavenArtifactCoordinates);
-        });
+        assertThrows(LowercaseValidationException.class,
+                     () -> mavenArtifactIdLowercaseValidator.validate(repository, coordinates));
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
@@ -1,55 +1,66 @@
 package org.carlspring.strongbox.storage.validation.version;
 
+import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
+import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.DefaultArtifactHandler;
-import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
-import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
-import org.carlspring.strongbox.storage.repository.RepositoryData;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-
 /**
  * @author stodorov
+ * @author Pablo Tirado
  */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
 @Execution(CONCURRENT)
 public class MavenReleaseVersionValidatorTest
 {
 
-    private RepositoryDto repository;
+    private static final String MRVV_RELEASES = "mrvv-releases";
+    private static final String GROUP_ID = "org.carlspring.maven";
+    private static final String ARTIFACT_ID = "my-maven-plugin";
 
     private MavenReleaseVersionValidator validator = new MavenReleaseVersionValidator();
 
-
-    @BeforeEach
-    public void setUp()
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
+    @Test
+    public void shouldSupportRepository(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository)
     {
-        repository = new RepositoryDto("mrvv-releases");
-        repository.setPolicy(RepositoryPolicyEnum.RELEASE.toString());
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setBasedir("");
+        assertTrue(validator.supports(repository));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void shouldSupportRepository()
-    {
-        assertTrue(validator.supports(new RepositoryData(repository)));
-    }
-
-    @Test
-    public void testReleaseValidation()
+    public void testReleaseValidation(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
+                                      @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                         versions = { "1",
+                                                                      "1.0" })
+                                      List<Path> validArtifactPaths)
             throws VersionValidationException
     {
-        /**
+        /*
          * Test valid artifacts
          */
         Artifact validArtifact1 = generateArtifact("1");
@@ -58,16 +69,23 @@ public class MavenReleaseVersionValidatorTest
         ArtifactCoordinates coordinates1 = new MockedMavenArtifactCoordinates(validArtifact1);
         ArtifactCoordinates coordinates2 = new MockedMavenArtifactCoordinates(validArtifact2);
 
-        validator.validate(new RepositoryData(repository), coordinates1);
-        validator.validate(new RepositoryData(repository), coordinates2);
+        validator.validate(repository, coordinates1);
+        validator.validate(repository, coordinates2);
 
         // If we've gotten here without an exception, then things are alright.
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testInvalidArtifacts()
+    public void testInvalidArtifacts(@MavenRepository(repositoryId = MRVV_RELEASES) Repository repository,
+                                     @MavenTestArtifact(repositoryId = MRVV_RELEASES,
+                                                        id = GROUP_ID + ":" + ARTIFACT_ID,
+                                                        versions = { "1.0-SNAPSHOT",
+                                                                     "1.0-20131004.115330-1" })
+                                     List<Path> invalidArtifactPaths)
     {
-        /**
+        /*
          * Test invalid artifacts
          */
         Artifact invalidArtifact1 = generateArtifact("1.0-SNAPSHOT");
@@ -78,7 +96,7 @@ public class MavenReleaseVersionValidatorTest
 
         try
         {
-            validator.validate(new RepositoryData(repository), coordinates1);
+            validator.validate(repository, coordinates1);
             fail("Incorrectly validated artifact with version 1.0-SNAPSHOT!");
         }
         catch (VersionValidationException e)
@@ -87,7 +105,7 @@ public class MavenReleaseVersionValidatorTest
 
         try
         {
-            validator.validate(new RepositoryData(repository), coordinates4);
+            validator.validate(repository, coordinates4);
             fail("Incorrectly validated artifact with version 1.0-20131004.115330-1!");
         }
         catch (VersionValidationException e)
@@ -97,13 +115,7 @@ public class MavenReleaseVersionValidatorTest
 
     private Artifact generateArtifact(String version)
     {
-        return new DefaultArtifact("org.carlspring.maven",
-                                   "my-maven-plugin",
-                                   version,
-                                   "compile",
-                                   "jar",
-                                   null,
-                                   new DefaultArtifactHandler("jar"));
+        String gavtc = String.format("%s:%s:%s:jar", GROUP_ID, ARTIFACT_ID, version);
+        return MavenArtifactTestUtils.getArtifactFromGAVTC(gavtc);
     }
-
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidatorTest.java
@@ -1,20 +1,20 @@
 package org.carlspring.strongbox.storage.validation.version;
 
 import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
-import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -58,19 +58,17 @@ public class MavenReleaseVersionValidatorTest
                                                          versions = { "1",
                                                                       "1.0" })
                                       List<Path> validArtifactPaths)
-            throws VersionValidationException
+            throws VersionValidationException, IOException
     {
         /*
          * Test valid artifacts
          */
-        Artifact validArtifact1 = generateArtifact("1");
-        Artifact validArtifact2 = generateArtifact("1.0");
-
-        ArtifactCoordinates coordinates1 = new MockedMavenArtifactCoordinates(validArtifact1);
-        ArtifactCoordinates coordinates2 = new MockedMavenArtifactCoordinates(validArtifact2);
-
-        validator.validate(repository, coordinates1);
-        validator.validate(repository, coordinates2);
+        for (Path validArtifactPath : validArtifactPaths)
+        {
+            RepositoryPath repositoryPath = (RepositoryPath) validArtifactPath.normalize();
+            ArtifactCoordinates coordinates = RepositoryFiles.readCoordinates(repositoryPath);
+            validator.validate(repository, coordinates);
+        }
 
         // If we've gotten here without an exception, then things are alright.
     }
@@ -84,38 +82,25 @@ public class MavenReleaseVersionValidatorTest
                                                         versions = { "1.0-SNAPSHOT",
                                                                      "1.0-20131004.115330-1" })
                                      List<Path> invalidArtifactPaths)
+            throws IOException
     {
         /*
          * Test invalid artifacts
          */
-        Artifact invalidArtifact1 = generateArtifact("1.0-SNAPSHOT");
-        Artifact invalidArtifact4 = generateArtifact("1.0-20131004.115330-1");
+        for (Path invalidArtifactPath : invalidArtifactPaths)
+        {
+            RepositoryPath repositoryPath = (RepositoryPath) invalidArtifactPath.normalize();
+            ArtifactCoordinates coordinates = RepositoryFiles.readCoordinates(repositoryPath);
 
-        ArtifactCoordinates coordinates1 = new MockedMavenArtifactCoordinates(invalidArtifact1);
-        ArtifactCoordinates coordinates4 = new MockedMavenArtifactCoordinates(invalidArtifact4);
-
-        try
-        {
-            validator.validate(repository, coordinates1);
-            fail("Incorrectly validated artifact with version 1.0-SNAPSHOT!");
-        }
-        catch (VersionValidationException e)
-        {
-        }
-
-        try
-        {
-            validator.validate(repository, coordinates4);
-            fail("Incorrectly validated artifact with version 1.0-20131004.115330-1!");
-        }
-        catch (VersionValidationException e)
-        {
+            try
+            {
+                validator.validate(repository, coordinates);
+                fail("Incorrectly validated artifact with version " + coordinates.getVersion());
+            }
+            catch (VersionValidationException e)
+            {
+            }
         }
     }
 
-    private Artifact generateArtifact(String version)
-    {
-        String gavtc = String.format("%s:%s:%s:jar", GROUP_ID, ARTIFACT_ID, version);
-        return MavenArtifactTestUtils.getArtifactFromGAVTC(gavtc);
-    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenIndexedWithoutClassNamesRepositorySetup.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenIndexedWithoutClassNamesRepositorySetup.java
@@ -1,0 +1,23 @@
+package org.carlspring.strongbox.testing;
+
+import org.carlspring.strongbox.storage.repository.RepositoryDto;
+import org.carlspring.strongbox.testing.storage.repository.RepositorySetup;
+import org.carlspring.strongbox.yaml.configuration.repository.MavenRepositoryConfigurationDto;
+
+/**
+ * @author Pablo Tirado
+ */
+public class MavenIndexedWithoutClassNamesRepositorySetup
+        implements RepositorySetup
+{
+
+    @Override
+    public void setup(RepositoryDto repository)
+    {
+        MavenRepositoryConfigurationDto mavenRepositoryConfiguration = new MavenRepositoryConfigurationDto();
+        mavenRepositoryConfiguration.setIndexingEnabled(true);
+        mavenRepositoryConfiguration.setIndexingClassNamesEnabled(false);
+        repository.setRepositoryConfiguration(mavenRepositoryConfiguration);
+    }
+
+}


### PR DESCRIPTION
Fixes for #1165.

Refactoring test cases to use new annotations.

* [x] `org.carlspring.strongbox.cron.jobs.CleanupExpiredArtifactsFromProxyRepositoriesCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.ClearTrashCronJobFromMaven2RepositoryTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.DownloadRemoteMavenIndexCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.RebuildMavenIndexesCronJobTestIT`
* [x] `org.carlspring.strongbox.cron.jobs.RemoveTimestampedMavenSnapshotCronJobTestIT`

* [x] `org.carlspring.strongbox.storage.validation.version.MavenReleaseVersionValidatorTest`
* [x] `org.carlspring.strongbox.storage.validation.version.MavenSnapshotVersionValidatorTest` 

* [x] `org.carlspring.strongbox.storage.indexing.StrongboxIndexerTest`
* [x] `org.carlspring.strongbox.storage.indexing.RepositoryIndexerTest`

* [x] `org.carlspring.strongbox.dependency.snippet.MavenDependencyFormatterTest`

* [x] `org.carlspring.strongbox.providers.repository.MavenGroupRepositoryProviderTest` 

* [x] `org.carlspring.strongbox.storage.validation.artifactid.MavenArtifactIdLowercaseValidatorTest` 

* [x] `org.carlspring.strongbox.providers.search.MavenIndexerSearchProviderTest` 