### PR TITLE
Issue-1368: Added classes to handle checked exceptions

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
@@ -1,15 +1,13 @@
 package org.carlspring.strongbox.util;
 
-import java.io.IOException;
-import java.lang.reflect.UndeclaredThrowableException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.springframework.util.Assert;
+
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.util.Collection;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.springframework.util.Assert;
 
 /**
  * @author Przemyslaw Fusik
@@ -29,18 +27,11 @@ public final class ClassLoaderFactory
         Assert.notNull(paths, "paths collection cannot be null");
 
         final URL[] urls;
-        try
+        final URI[] uris = paths.stream().map(Path::toUri).toArray(URI[]::new);
+        urls = new URL[uris.length];
+        for (int i = 0; i < uris.length; i++)
         {
-            final URI[] uris = paths.stream().map(Path::toUri).toArray(size -> new URI[size]);
-            urls = new URL[uris.length];
-            for (int i = 0; i < uris.length; i++)
-            {
-                urls[i] = uris[i].toURL();
-            }
-        }
-        catch (IOException e)
-        {
-            throw new UndeclaredThrowableException(e);
+            urls[i] = ThrowingFunction.unchecked(URI::toURL).apply(uris[i]);
         }
 
         return new URLClassLoader(urls, parent);

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ClassLoaderFactory.java
@@ -26,13 +26,9 @@ public final class ClassLoaderFactory
     {
         Assert.notNull(paths, "paths collection cannot be null");
 
-        final URL[] urls;
-        final URI[] uris = paths.stream().map(Path::toUri).toArray(URI[]::new);
-        urls = new URL[uris.length];
-        for (int i = 0; i < uris.length; i++)
-        {
-            urls[i] = ThrowingFunction.unchecked(URI::toURL).apply(uris[i]);
-        }
+        final URL[] urls = paths.stream().map(Path::toUri)
+                                         .map(ThrowingFunction.unchecked(URI::toURL))
+                                         .toArray(URL[]::new);
 
         return new URLClassLoader(urls, parent);
     }

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingComparator.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingComparator.java
@@ -1,0 +1,27 @@
+package org.carlspring.strongbox.util;
+
+import java.util.Comparator;
+
+/**
+ * @author Dawid Antecki
+ */
+@FunctionalInterface
+public interface ThrowingComparator<T, E extends Throwable>
+{
+    int compareTo(T t1, T t2) throws E;
+
+    static<T, E extends Throwable> Comparator<T> unchecked(ThrowingComparator<T, E> comparator)
+    {
+        return (t1, t2) ->
+        {
+            try
+            {
+                return comparator.compareTo(t1, t2);
+            }
+            catch (Throwable e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingConsumer.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingConsumer.java
@@ -2,6 +2,9 @@ package org.carlspring.strongbox.util;
 
 import java.util.function.Consumer;
 
+/**
+ * @author Dawid Antecki
+ */
 @FunctionalInterface
 public interface ThrowingConsumer<T, E extends Throwable>
 {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingConsumer.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingConsumer.java
@@ -1,0 +1,24 @@
+package org.carlspring.strongbox.util;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ThrowingConsumer<T, E extends Throwable>
+{
+    void accept(T t) throws E;
+
+    static <T, E extends Throwable> Consumer<T> unchecked(ThrowingConsumer<T, E> consumer)
+    {
+        return t ->
+        {
+            try
+            {
+                consumer.accept(t);
+            }
+            catch (Throwable e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingFunction.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingFunction.java
@@ -1,0 +1,24 @@
+package org.carlspring.strongbox.util;
+
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ThrowingFunction<T, R, E extends Throwable>
+{
+    R apply(T t) throws E;
+
+    static <T, R, E extends Throwable> Function<T, R> unchecked(ThrowingFunction<T, R, E> function)
+    {
+        return t ->
+        {
+            try
+            {
+                return function.apply(t);
+            }
+            catch (Throwable e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingFunction.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingFunction.java
@@ -2,6 +2,9 @@ package org.carlspring.strongbox.util;
 
 import java.util.function.Function;
 
+/**
+ * @author Dawid Antecki
+ */
 @FunctionalInterface
 public interface ThrowingFunction<T, R, E extends Throwable>
 {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingPredicate.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingPredicate.java
@@ -1,23 +1,22 @@
 package org.carlspring.strongbox.util;
 
-import java.util.function.Supplier;
+import java.util.function.Predicate;
 
 /**
  * @author Dawid Antecki
  */
 @FunctionalInterface
-public interface ThrowingSupplier<T, E extends Throwable>
+public interface ThrowingPredicate<T, E extends Throwable>
 {
+    boolean test(T t) throws E;
 
-    T get() throws E;
-
-    static <T, E extends Throwable> Supplier<T> unchecked(ThrowingSupplier<T, E> supplier)
+    static<T, E extends Throwable> Predicate<T> unchecked(ThrowingPredicate<T, E> predicate)
     {
-        return () ->
+        return t ->
         {
             try
             {
-                return supplier.get();
+                return predicate.test(t);
             }
             catch (Throwable e)
             {

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingSupplier.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/util/ThrowingSupplier.java
@@ -1,0 +1,25 @@
+package org.carlspring.strongbox.util;
+
+import java.util.function.Supplier;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Exception>
+{
+
+    T get() throws E;
+
+    static <T> Supplier<T> unchecked(ThrowingSupplier<T, ?> supplier)
+    {
+        return () ->
+        {
+            try
+            {
+                return supplier.get();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/jobs/CronJobsDefinitionsRegistry.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/jobs/CronJobsDefinitionsRegistry.java
@@ -1,14 +1,14 @@
 package org.carlspring.strongbox.cron.jobs;
 
+import com.google.common.collect.ImmutableSet;
+import org.carlspring.strongbox.util.ThrowingFunction;
+import org.reflections.Reflections;
+import org.springframework.stereotype.Component;
+
 import java.lang.reflect.Modifier;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.ImmutableSet;
-import org.reflections.Reflections;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Przemyslaw Fusik
@@ -26,16 +26,7 @@ public class CronJobsDefinitionsRegistry
                 c -> !Modifier.isAbstract(c.getModifiers()) && !c.isInterface()).collect(Collectors.toSet());
 
         cronJobDefinitions = cronJobs.stream()
-                                     .map(clazz -> {
-                                         try
-                                         {
-                                             return clazz.newInstance().getCronJobDefinition();
-                                         }
-                                         catch (Exception ex)
-                                         {
-                                             throw new UndeclaredThrowableException(ex);
-                                         }
-                                     })
+                                     .map(ThrowingFunction.unchecked(clazz -> clazz.newInstance().getCronJobDefinition()))
                                      .collect(ImmutableSet.toImmutableSet());
     }
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
@@ -93,7 +93,7 @@ public class CronTaskDataServiceImpl
 
         try
         {
-            return ThrowingFunction.unchecked((CronTasksConfigurationDto x) -> SerializationUtils.clone(x)).apply(configuration);
+            return SerializationUtils.clone(configuration);
         }
         finally
         {

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
@@ -93,11 +93,7 @@ public class CronTaskDataServiceImpl
 
         try
         {
-            return SerializationUtils.clone(configuration);
-        }
-        catch (Exception e)
-        {
-            throw new UndeclaredThrowableException(e);
+            return ThrowingFunction.unchecked((CronTasksConfigurationDto x) -> SerializationUtils.clone(x)).apply(configuration);
         }
         finally
         {

--- a/strongbox-data-service/src/main/java/com/orientechnologies/orient/object/jpa/OJPAObjectDatabaseTxEntityManagerFactory.java
+++ b/strongbox-data-service/src/main/java/com/orientechnologies/orient/object/jpa/OJPAObjectDatabaseTxEntityManagerFactory.java
@@ -1,18 +1,17 @@
 package com.orientechnologies.orient.object.jpa;
 
-import javax.persistence.*;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.metamodel.Metamodel;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Map;
-import java.util.logging.Logger;
-
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
 import com.orientechnologies.orient.jdbc.OrientDataSource;
 import com.orientechnologies.orient.jdbc.OrientJdbcConnection;
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+import org.carlspring.strongbox.util.ThrowingSupplier;
+
+import javax.persistence.*;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.metamodel.Metamodel;
+import java.sql.Connection;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * @author Sergey Bespalov
@@ -66,15 +65,7 @@ public class OJPAObjectDatabaseTxEntityManagerFactory
     private EntityManager createEntityManager(final OJPAProperties properties)
     {
 
-        Connection connection;
-        try
-        {
-            connection = dataSource.getConnection();
-        }
-        catch (SQLException e)
-        {
-            throw new UndeclaredThrowableException(e);
-        }
+        Connection connection = ThrowingSupplier.unchecked(dataSource::getConnection).get();
 
         OObjectDatabaseTx db = new OObjectDatabaseTx((ODatabaseDocumentInternal) ((OrientJdbcConnection) connection).getDatabase());
         Boolean automaticSchemaGeneration = Boolean.valueOf(properties.getOrDefault(

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
@@ -22,6 +22,7 @@ import org.carlspring.strongbox.users.domain.Privileges;
 import org.carlspring.strongbox.users.domain.SystemRole;
 import org.springframework.stereotype.Service;
 
+
 /**
  * @author Alex Oreshkevich
  * @author Przemyslaw Fusik
@@ -61,11 +62,7 @@ public class AuthorizationConfigServiceImpl
 
         try
         {
-            return SerializationUtils.clone(authorizationConfig);
-        }
-        catch (Exception e)
-        {
-            throw new UndeclaredThrowableException(e);
+            return ThrowingFunction.unchecked((AuthorizationConfigDto x) -> SerializationUtils.clone(x)).apply(authorizationConfig);
         }
         finally
         {

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/service/impl/AuthorizationConfigServiceImpl.java
@@ -62,7 +62,7 @@ public class AuthorizationConfigServiceImpl
 
         try
         {
-            return ThrowingFunction.unchecked((AuthorizationConfigDto x) -> SerializationUtils.clone(x)).apply(authorizationConfig);
+            return SerializationUtils.clone(authorizationConfig);
         }
         finally
         {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/coordinates/ArtifactLayoutDescription.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/coordinates/ArtifactLayoutDescription.java
@@ -1,19 +1,18 @@
 package org.carlspring.strongbox.artifact.coordinates;
 
+import org.carlspring.strongbox.util.ThrowingFunction;
+import org.reflections.ReflectionUtils;
+
 import java.beans.BeanInfo;
-import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import org.reflections.ReflectionUtils;
 
 public class ArtifactLayoutDescription
 {
@@ -72,14 +71,9 @@ public class ArtifactLayoutDescription
                                                           .get();
 
         BeanInfo beanInfo;
-        try
-        {
-            beanInfo = Introspector.getBeanInfo(artifactCoordinatesClass);
-        }
-        catch (IntrospectionException e)
-        {
-            throw new UndeclaredThrowableException(e);
-        }
+
+        beanInfo = ThrowingFunction.unchecked((Class x) -> Introspector.getBeanInfo(x)).apply(artifactCoordinatesClass);
+
 
         Arrays.stream(beanInfo.getPropertyDescriptors())
               .map(p -> parseProperty(p))

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.carlspring.strongbox.util.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,17 +77,7 @@ public class StorageBooter
                 logger.info(" -> Initializing repositories...");
             }
 
-            for (Repository repository : repositories)
-            {
-                try
-                {
-                    initializeRepository(repository);
-                }
-                catch (IOException e)
-                {
-                    throw new RuntimeException("Failed to initialize the repository '" + repository + "'.", e);
-                }
-            }
+            repositories.forEach(ThrowingConsumer.unchecked(this::initializeRepository));
         }
         else
         {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/ExpiredRepositoryPathHandler.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/ExpiredRepositoryPathHandler.java
@@ -9,6 +9,7 @@ public interface ExpiredRepositoryPathHandler
 {
 
     default boolean supports(RepositoryPath repositoryPath)
+            throws IOException
     {
         return true;
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
@@ -35,6 +35,7 @@ import org.carlspring.strongbox.providers.repository.group.GroupRepositorySetCol
 import org.carlspring.strongbox.services.support.ArtifactRoutingRulesChecker;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.util.ThrowingFunction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -282,14 +283,7 @@ public class GroupRepositoryProvider
 
     private ArtifactCoordinates getArtifactCoordinates(Path p)
     {
-        try
-        {
-            return RepositoryFiles.readCoordinates((RepositoryPath) p);
-        }
-        catch (IOException e)
-        {
-            throw new RuntimeException(String.format("Failed to resolve ArtifactCoordinates for [%s]", p), e);
-        }
+        return ThrowingFunction.unchecked(RepositoryFiles::readCoordinates).apply((RepositoryPath) p);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
@@ -251,8 +251,7 @@ public class GroupRepositoryProvider
 
                 // count coordinates intersection
                 groupLimit += repositoryResult.stream()
-                                              .map((p) -> resultMap.put(getArtifactCoordinates(p),
-                                                                        p))
+                                              .map(ThrowingFunction.unchecked((Path p) -> resultMap.put(getArtifactCoordinates(p), p)))
                                               .filter(p -> p != null)
                                               .collect(Collectors.toList())
                                               .size();
@@ -281,9 +280,9 @@ public class GroupRepositoryProvider
         return resultList.subList(skip, toIndex);
     }
 
-    private ArtifactCoordinates getArtifactCoordinates(Path p)
+    private ArtifactCoordinates getArtifactCoordinates(Path p) throws IOException
     {
-        return ThrowingFunction.unchecked(RepositoryFiles::readCoordinates).apply((RepositoryPath) p);
+        return RepositoryFiles.readCoordinates((RepositoryPath) p);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
@@ -98,7 +98,7 @@ public class ConfigurationManagementServiceImpl
 
         try
         {
-            return ThrowingFunction.unchecked((MutableConfiguration x) -> SerializationUtils.clone(x)).apply(configuration);
+            return SerializationUtils.clone(configuration);
         }
         finally
         {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImpl.java
@@ -98,11 +98,7 @@ public class ConfigurationManagementServiceImpl
 
         try
         {
-            return SerializationUtils.clone(configuration);
-        }
-        catch (Exception e)
-        {
-            throw new UndeclaredThrowableException(e);
+            return ThrowingFunction.unchecked((MutableConfiguration x) -> SerializationUtils.clone(x)).apply(configuration);
         }
         finally
         {
@@ -392,7 +388,7 @@ public class ConfigurationManagementServiceImpl
     /**
      * Sets the repository <--> storage relationships explicitly, as initially, when these are deserialized from the
      * XML, they have no such relationship.
-     * @throws IOException 
+     * @throws IOException
      */
     private void setRepositoryStorageRelationships() throws IOException
     {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
@@ -27,6 +27,7 @@ import org.carlspring.strongbox.storage.ArtifactStorageException;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.validation.resource.ArtifactOperationsValidator;
+import org.carlspring.strongbox.util.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -243,21 +244,10 @@ public class RepositoryManagementServiceImpl
             final Map<String, ? extends Repository> repositories = storage.getRepositories();
             for (Repository repository : repositories.values())
             {
-                final String storageId = storage.getId();
-                final String repositoryId = repository.getId();
-
-                try
+                if (repository.isTrashEnabled())
                 {
-                    if (repository.isTrashEnabled())
-                    {
-                        RootRepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
-                        RepositoryFiles.undelete(repositoryPath);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException("Unable to undelete trash for storage " + storageId + " in repository " +
-                                               repositoryId, e);
+                    RootRepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
+                    ThrowingConsumer.unchecked(RepositoryFiles::undelete).accept(repositoryPath);
                 }
             }
         }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -264,8 +264,7 @@ public class TestArtifactContext implements AutoCloseable
         Path directoryWhereGeneratedArtifactsWasPlaced = path.getParent();
         try (Stream<Path> s = Files.list(directoryWhereGeneratedArtifactsWasPlaced))
         {
-            s.filter(p -> !Files.isDirectory(p)).map(ThrowingFunction.unchecked(p -> p))
-                                                .forEach(ThrowingConsumer.unchecked(Files::delete));
+            s.filter(p -> !Files.isDirectory(p)).forEach(ThrowingConsumer.unchecked(Files::delete));
         }
     }
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -24,6 +24,8 @@ import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.services.ArtifactManagementService;
+import org.carlspring.strongbox.util.ThrowingConsumer;
+import org.carlspring.strongbox.util.ThrowingFunction;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,15 +211,8 @@ public class TestArtifactContext implements AutoCloseable
         {
             throw new UndeclaredThrowableException(ioe);
         }
-        
-        try
-        {
-            Files.delete(e.getValue());
-        }
-        catch (IOException ioe)
-        {
-            throw new UndeclaredThrowableException(ioe);
-        }
+
+        ThrowingConsumer.unchecked(Files::delete).accept(e.getValue());
     }
     
     private int repositoryPathChecksumComparator(RepositoryPath p1,
@@ -225,15 +220,9 @@ public class TestArtifactContext implements AutoCloseable
     {
         Boolean isChecksumP1;
         Boolean isChecksumP2;
-        try
-        {
-            isChecksumP1 = RepositoryFiles.isChecksum(p1);
-            isChecksumP2 = RepositoryFiles.isChecksum(p2);
-        }
-        catch (IOException e)
-        {
-            throw new UndeclaredThrowableException(e);
-        }
+
+        isChecksumP1 = ThrowingFunction.unchecked(RepositoryFiles::isChecksum).apply(p1);
+        isChecksumP2 = ThrowingFunction.unchecked(RepositoryFiles::isChecksum).apply(p2);
         
         if (isChecksumP1 && isChecksumP2)
         {
@@ -275,16 +264,8 @@ public class TestArtifactContext implements AutoCloseable
         Path directoryWhereGeneratedArtifactsWasPlaced = path.getParent();
         try (Stream<Path> s = Files.list(directoryWhereGeneratedArtifactsWasPlaced))
         {
-            s.filter(p -> !Files.isDirectory(p)).forEach(p -> {
-                try
-                {
-                    Files.delete(p);
-                }
-                catch (IOException e)
-                {
-                    throw new UndeclaredThrowableException(e);
-                }
-            });
+            s.filter(p -> !Files.isDirectory(p)).map(ThrowingFunction.unchecked(p -> p))
+                                                .forEach(ThrowingConsumer.unchecked(Files::delete));
         }
     }
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -28,7 +28,7 @@ import org.carlspring.strongbox.storage.routing.MutableRoutingRule;
 import org.carlspring.strongbox.storage.routing.MutableRoutingRuleRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
-import org.carlspring.strongbox.util.ThrowingConsumer;
+import org.carlspring.strongbox.util.ThrowingSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +128,7 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         
         Storage storage = Optional.ofNullable(configurationManagementService.getConfiguration()
                                                                             .getStorage(testRepository.storageId()))
-                                  .orElseGet(this::createStorage);
+                                  .orElseGet(ThrowingSupplier.unchecked(this::createStorage));
 
         if (configurationManagementService.getConfiguration()
                                           .getRepository(testRepository.storageId(),
@@ -216,13 +216,12 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
     }
 
     private Storage createStorage()
+            throws IOException
     {
         StorageDto newStorage = new StorageDto(testRepository.storageId());
-        try
-        {
         configurationManagementService.addStorageIfNotExists(newStorage);
 
-        ThrowingConsumer.unchecked(storageManagementService::saveStorage).accept(newStorage);
+        storageManagementService.saveStorage(newStorage);
 
         return configurationManagementService.getConfiguration().getStorage(testRepository.storageId());
     }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -28,6 +28,7 @@ import org.carlspring.strongbox.storage.routing.MutableRoutingRule;
 import org.carlspring.strongbox.storage.routing.MutableRoutingRuleRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
+import org.carlspring.strongbox.util.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,13 +220,9 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         StorageDto newStorage = new StorageDto(testRepository.storageId());
         try
         {
-            configurationManagementService.addStorageIfNotExists(newStorage);
-            storageManagementService.saveStorage(newStorage);
-        }
-        catch (IOException e)
-        {
-            throw new UndeclaredThrowableException(e);
-        }
+        configurationManagementService.addStorageIfNotExists(newStorage);
+
+        ThrowingConsumer.unchecked(storageManagementService::saveStorage).accept(newStorage);
 
         return configurationManagementService.getConfiguration().getStorage(testRepository.storageId());
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
@@ -30,13 +30,14 @@ public class MavenMetadataExpiredRepositoryPathHandler
 
     @Override
     public boolean supports(final RepositoryPath repositoryPath)
+            throws IOException
     {
         if (repositoryPath == null)
         {
             return false;
         }
-        boolean isMetadata = ThrowingFunction.unchecked(RepositoryFiles::isMetadata).apply(repositoryPath);
-        if (!isMetadata)
+
+        if (!RepositoryFiles.isMetadata(repositoryPath))
         {
             return false;
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
@@ -35,8 +35,8 @@ public class MavenMetadataExpiredRepositoryPathHandler
         {
             return false;
         }
-        boolean isNotMetadata = ThrowingFunction.unchecked(RepositoryFiles::isMetadata).apply(repositoryPath);
-        if (!isNotMetadata)
+        boolean isMetadata = ThrowingFunction.unchecked(RepositoryFiles::isMetadata).apply(repositoryPath);
+        if (!isMetadata)
         {
             return false;
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenMetadataExpiredRepositoryPathHandler.java
@@ -4,15 +4,15 @@ import org.carlspring.commons.encryption.EncryptionAlgorithmsEnum;
 import org.carlspring.strongbox.providers.repository.proxied.ProxyRepositoryArtifactResolver;
 import org.carlspring.strongbox.storage.repository.RepositoryData;
 import org.carlspring.strongbox.storage.repository.Repository;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.nio.file.Files;
-
+import org.carlspring.strongbox.util.ThrowingFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+
 import static org.carlspring.strongbox.providers.io.MavenMetadataExpiredRepositoryPathHandler.Decision.*;
 
 /**
@@ -35,16 +35,10 @@ public class MavenMetadataExpiredRepositoryPathHandler
         {
             return false;
         }
-        try
+        boolean isNotMetadata = ThrowingFunction.unchecked(RepositoryFiles::isMetadata).apply(repositoryPath);
+        if (!isNotMetadata)
         {
-            if (!RepositoryFiles.isMetadata(repositoryPath))
-            {
-                return false;
-            }
-        }
-        catch (IOException e)
-        {
-            throw new UndeclaredThrowableException(e);
+            return false;
         }
 
         Repository repository = repositoryPath.getRepository();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenProxyRepositoryPathExpiredEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenProxyRepositoryPathExpiredEventListener.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 
+import org.carlspring.strongbox.util.ThrowingPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.event.EventListener;
@@ -36,7 +37,7 @@ public class MavenProxyRepositoryPathExpiredEventListener
         }
 
         expiredRepositoryPathHandlers.stream()
-                                     .filter(handler -> handler.supports(repositoryPath))
+                                     .filter(ThrowingPredicate.unchecked((handler) -> handler.supports(repositoryPath)))
                                      .forEach(handleExpiration(repositoryPath));
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJobTestIT.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
+import org.carlspring.strongbox.util.ThrowingFunction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -120,14 +121,7 @@ public class RebuildMavenIndexesCronJobTestIT
                                                           "+p:jar",
                                                           MavenIndexerSearchProvider.ALIAS);
 
-                try
-                {
-                    assertTrue(artifactSearchService.contains(request));
-                }
-                catch (Exception e)
-                {
-                    throw new UndeclaredThrowableException(e);
-                }
+                assertTrue(ThrowingFunction.unchecked(artifactSearchService::contains).apply(request));
             }
         });
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -17,12 +17,14 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 public class NpmArtifactGenerator implements ArtifactGenerator
@@ -110,7 +112,15 @@ public class NpmArtifactGenerator implements ArtifactGenerator
         throws IOException
     {
         MessageDigest crypt;
-        crypt = ThrowingFunction.unchecked((String x) -> MessageDigest.getInstance(x)).apply("SHA-1");
+
+        try
+        {
+            crypt = MessageDigest.getInstance("SHA-1");
+        }
+        catch (NoSuchAlgorithmException e)
+        {
+            throw new IOException(e);
+        }
 
         crypt.reset();
         crypt.update(Files.readAllBytes(packagePath));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -1,24 +1,5 @@
 package org.carlspring.strongbox.artifact.generator;
 
-import org.carlspring.commons.io.RandomInputStream;
-import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
-import org.carlspring.strongbox.npm.metadata.Dist;
-import org.carlspring.strongbox.npm.metadata.PackageVersion;
-
-import java.io.BufferedOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.UndeclaredThrowableException;
-import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -26,6 +7,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.carlspring.commons.io.RandomInputStream;
+import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
+import org.carlspring.strongbox.npm.metadata.Dist;
+import org.carlspring.strongbox.npm.metadata.PackageVersion;
+import org.carlspring.strongbox.util.ThrowingFunction;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.util.Base64;
 
 public class NpmArtifactGenerator implements ArtifactGenerator
 {
@@ -112,14 +110,7 @@ public class NpmArtifactGenerator implements ArtifactGenerator
         throws IOException
     {
         MessageDigest crypt;
-        try
-        {
-            crypt = MessageDigest.getInstance("SHA-1");
-        }
-        catch (NoSuchAlgorithmException e)
-        {
-            throw new UndeclaredThrowableException(e);
-        }
+        crypt = ThrowingFunction.unchecked((String x) -> MessageDigest.getInstance(x)).apply("SHA-1");
 
         crypt.reset();
         crypt.update(Files.readAllBytes(packagePath));


### PR DESCRIPTION
Fixes #1368 

Hi, I have a question is this correct way how it's implemented? I am not sure if those interfaces are correct what I mean there was mentioned that we should remove Undeclared exceptions in hand with Runtime exceptions but I am not sure if I should create similar methods that will throw different exceptions in that case Undeclared because now it throws Runtime exception. Also what about implementation of that? I've modified some code to use it, and not sure if I did it correctly. Sometimes I could not to implement it in few places as there was a pop up message that not static methods could not be implemented. I will be grateful if someone could give me some tips if those methods are correctly written or I missed something, also where in the code it should be also implemented.

@carlspring @steve-todorov @fuss86 