### PR TITLE
Issue-1165: Migrate the Maven layout provider tests to use the new annotations (@ptirador)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,8 +98,8 @@
                 </plugins>
             </build>
         </profile>
-		
-		<profile>
+        
+        <profile>
             <id>checkstyle</id>
 
             <activation>
@@ -108,23 +108,23 @@
 
             <build>
                 <plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-checkstyle-plugin</artifactId>
-						<version>3.0.0</version>
-						<dependencies>
-							<dependency>
-								<groupId>com.puppycrawl.tools</groupId>
-								<artifactId>checkstyle</artifactId>
-								<version>8.18</version>
-							</dependency>
-						</dependencies>
-						<configuration>
-							<configLocation>strongbox-checks.xml</configLocation>
-							<consoleOutput>true</consoleOutput>
-						</configuration>
-					</plugin>
-				</plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>8.18</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <configLocation>strongbox-checks.xml</configLocation>
+                            <consoleOutput>true</consoleOutput>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -36,9 +36,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 public class MavenArtifactGeneratorTest
         extends MavenTestCaseWithArtifactGeneration
 {
-
-
-    public static final String REPOSITORY_RELEASES = "matg-releases";
+    private static final String REPOSITORY_RELEASES = "matg-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -1,17 +1,22 @@
 package org.carlspring.strongbox.artifact.generation;
 
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.MavenTestCaseWithArtifactGeneration;
-import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
+import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.util.MessageDigestUtils;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import org.apache.maven.artifact.Artifact;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -22,6 +27,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -32,41 +38,40 @@ public class MavenArtifactGeneratorTest
 {
 
 
+    public static final String REPOSITORY_RELEASES = "matg-releases";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testArtifactGeneration()
+    public void testArtifactGeneration(@MavenRepository(repositoryId = REPOSITORY_RELEASES)
+                                       Repository repository,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                          id = "org.carlspring.strongbox.testing:matg",
+                                                          versions = "1.2.3")
+                                       Path artifactPath)
             throws Exception
     {
-        File basedir = getRepositoryBasedir(STORAGE0, "releases").getAbsoluteFile();
+        Path artifactJarPathMd5 = Paths.get(artifactPath.toString() + ".md5");
 
-        Artifact artifact = MavenArtifactTestUtils.getArtifactFromGAVTC("org.carlspring.strongbox.testing:matg:1.2.3:jar");
+        Path artifactJarPathSha1 = Paths.get(artifactPath.toString() + ".sha1");
 
-        generateArtifact(basedir.getAbsolutePath(), artifact);
+        Path artifactPomPath = Paths.get(artifactPath.toString().replaceAll("jar", "pom"));
+        Path artifactPomPathMd5 = Paths.get(artifactPath.toString().replaceAll("jar", "pom") + ".md5");
+        Path artifactPomPathSha1 = Paths.get(artifactPath.toString().replaceAll("jar", "pom") + ".sha1");
 
-        File artifactJarFile = new File(basedir, "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.jar");
-        File artifactJarFileMD5 = new File(basedir,
-                                           "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.jar.md5");
-        File artifactJarFileSHA1 = new File(basedir,
-                                            "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.jar.sha1");
+        assertTrue(Files.exists(artifactPath), "Failed to generate JAR file!");
+        assertTrue(Files.exists(artifactJarPathMd5), "Failed to generate JAR MD5 file!");
+        assertTrue(Files.exists(artifactJarPathSha1), "Failed to generate JAR SHA1 file!");
 
-        File artifactPomFile = new File(basedir, "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.pom");
-        File artifactPomFileMD5 = new File(basedir,
-                                           "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.pom.md5");
-        File artifactPomFileSHA1 = new File(basedir,
-                                            "org/carlspring/strongbox/testing/matg/1.2.3/matg-1.2.3.pom.sha1");
+        assertTrue(Files.exists(artifactPomPath), "Failed to generate POM file!");
+        assertTrue(Files.exists(artifactPomPathMd5), "Failed to generate POM MD5 file!");
+        assertTrue(Files.exists(artifactPomPathSha1), "Failed to generate POM SHA1 file!");
 
-        assertTrue(artifactJarFile.exists(), "Failed to generate JAR file!");
-        assertTrue(artifactJarFileMD5.exists(), "Failed to generate JAR MD5 file!");
-        assertTrue(artifactJarFileSHA1.exists(), "Failed to generate JAR SHA1 file!");
+        String expectedJarMD5 = calculateChecksum(artifactPath, "MD5");
+        String expectedJarSHA1 = calculateChecksum(artifactPath, "SHA1");
 
-        assertTrue(artifactPomFile.exists(), "Failed to generate POM file!");
-        assertTrue(artifactPomFileMD5.exists(), "Failed to generate POM MD5 file!");
-        assertTrue(artifactPomFileSHA1.exists(), "Failed to generate POM SHA1 file!");
-
-        String expectedJarMD5 = calculateChecksum(artifactJarFile, "MD5");
-        String expectedJarSHA1 = calculateChecksum(artifactJarFile, "SHA1");
-
-        String jarMd5 = MessageDigestUtils.readChecksumFile(artifactJarFileMD5.getAbsolutePath());
-        String jarSha1 = MessageDigestUtils.readChecksumFile(artifactJarFileSHA1.getAbsolutePath());
+        String jarMd5 = MessageDigestUtils.readChecksumFile(artifactJarPathMd5.toString());
+        String jarSha1 = MessageDigestUtils.readChecksumFile(artifactJarPathSha1.toString());
 
         System.out.println("Expected  [MD5 ] (jar): " + expectedJarMD5);
         System.out.println("Generated [MD5 ] (jar): " + jarMd5);
@@ -78,11 +83,11 @@ public class MavenArtifactGeneratorTest
 
         assertEquals(expectedJarSHA1, jarSha1);
 
-        String expectedPomMD5 = calculateChecksum(artifactPomFile, "MD5");
-        String expectedPomSHA1 = calculateChecksum(artifactPomFile, "SHA1");
+        String expectedPomMD5 = calculateChecksum(artifactPomPath, "MD5");
+        String expectedPomSHA1 = calculateChecksum(artifactPomPath, "SHA1");
 
-        String pomMD5 = MessageDigestUtils.readChecksumFile(artifactPomFileMD5.getAbsolutePath());
-        String pomSHA1 = MessageDigestUtils.readChecksumFile(artifactPomFileSHA1.getAbsolutePath());
+        String pomMD5 = MessageDigestUtils.readChecksumFile(artifactPomPathMd5.toString());
+        String pomSHA1 = MessageDigestUtils.readChecksumFile(artifactPomPathSha1.toString());
 
         System.out.println("Expected  [MD5 ] (pom): " + expectedPomMD5);
         System.out.println("Generated [MD5 ] (pom): " + pomMD5);
@@ -95,21 +100,16 @@ public class MavenArtifactGeneratorTest
         assertEquals(expectedPomSHA1, pomSHA1);
     }
 
-    private String calculateChecksum(File file,
+    private String calculateChecksum(Path path,
                                      String type)
             throws Exception
     {
         byte[] buffer = new byte[4096];
         MessageDigest md = MessageDigest.getInstance(type);
 
-        DigestInputStream dis = new DigestInputStream(new FileInputStream(file), md);
-        try
+        try (DigestInputStream dis = new DigestInputStream(Files.newInputStream(path), md))
         {
             while (dis.read(buffer) != -1) ;
-        }
-        finally
-        {
-            dis.close();
         }
 
         return MessageDigestUtils.convertToHexadecimalString(md);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/locator/ArtifactDirectoryLocatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/locator/ArtifactDirectoryLocatorTest.java
@@ -151,10 +151,10 @@ public class ArtifactDirectoryLocatorTest
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
-            id = "com.carlspring.strongbox:foo",
-            versions = { "5.1",
-                         "5.2",
-                         "5.3" })
+                       id = "com.carlspring.strongbox:foo",
+                       versions = { "5.1",
+                                    "5.2",
+                                    "5.3" })
     private @interface MavenArtifactsCarlspringStrongboxFoo
     {
 
@@ -182,9 +182,9 @@ public class ArtifactDirectoryLocatorTest
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
-            id = "org.carlspring.strongbox:locator",
-            versions = { "5.2.1",
-                         "5.2.2" })
+                       id = "org.carlspring.strongbox:locator",
+                       versions = { "5.2.1",
+                                    "5.2.2" })
     private @interface MavenArtifactsCarlspringStrongboxLocator
     {
 
@@ -195,10 +195,10 @@ public class ArtifactDirectoryLocatorTest
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
-            id = "org.carlspring.strongbox.locator:foo-locator",
-            versions = { "1.0",
-                         "1.1",
-                         "1.2" })
+                       id = "org.carlspring.strongbox.locator:foo-locator",
+                       versions = { "1.0",
+                                    "1.1",
+                                    "1.2" })
     private @interface MavenArtifactsCarlspringStrongboxFooLocator
     {
 
@@ -209,10 +209,10 @@ public class ArtifactDirectoryLocatorTest
     @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
-            id = "org.carlspring.strongbox.locator:utils",
-            versions = { "2.1",
-                         "2.2",
-                         "2.3" })
+                       id = "org.carlspring.strongbox.locator:utils",
+                       versions = { "2.1",
+                                    "2.2",
+                                    "2.3" })
     private @interface MavenArtifactsCarlspringStrongboxLocatorUtils
     {
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/io/ArtifactOutputStreamTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/io/ArtifactOutputStreamTest.java
@@ -6,18 +6,15 @@ import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.providers.io.TempRepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 
-import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -25,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.maven.index.artifact.Gav;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -38,6 +34,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -48,14 +45,11 @@ public class ArtifactOutputStreamTest
 {
 
     private static final String REPOSITORY_RELEASES = "aos-releases";
-
-    @Inject
-    private RepositoryPathResolver repositoryPathResolver;
     
     @Test
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
-    public void testCreateWithTemporaryLocation(@TestRepository(repositoryId = REPOSITORY_RELEASES,
-                                                                layout = Maven2LayoutProvider.ALIAS)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    public void testCreateWithTemporaryLocation(@MavenRepository(repositoryId = REPOSITORY_RELEASES)
                                                 Repository repository,
                                                 @MavenTestArtifact(id = "org.carlspring.foo:temp-file-test",
                                                                    repositoryId = REPOSITORY_RELEASES,
@@ -82,8 +76,7 @@ public class ArtifactOutputStreamTest
 
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class})
-    public void testCreateWithTemporaryLocationNoMoveOnClose(@TestRepository(repositoryId = REPOSITORY_RELEASES,
-                                                                             layout = Maven2LayoutProvider.ALIAS)
+    public void testCreateWithTemporaryLocationNoMoveOnClose(@MavenRepository(repositoryId = REPOSITORY_RELEASES)
                                                              Repository repository)
             throws IOException
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.index.artifact.Gav;
-import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +48,9 @@ abstract class BaseMavenMetadataExpirationTest
     protected static final String REPOSITORY_HOSTED = "mvn-hosted-repo-snapshots";
 
     protected static final String REPOSITORY_PROXY = "mvn-proxy-repo-snapshots";
+
+    protected static final String PROXY_REPOSITORY_URL =
+            "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_HOSTED + "/";
 
     protected String groupId = "pl.fuss.maven.metadata";
 
@@ -72,57 +74,55 @@ abstract class BaseMavenMetadataExpirationTest
     protected void mockHostedRepositoryMetadataUpdate(final String hostedRepositoryId,
                                                       final String localSourceRepositoryId,
                                                       final MutableObject<Metadata> versionLevelMetadata,
-                                                      final MutableObject<Metadata> artifactLevelMetadata,
-                                                      final TestInfo testInfo)
+                                                      final MutableObject<Metadata> artifactLevelMetadata)
             throws Exception
     {
         mockLocalRepositoryTestMetadataUpdate(localSourceRepositoryId,
                                               versionLevelMetadata,
-                                              artifactLevelMetadata,
-                                              testInfo);
+                                              artifactLevelMetadata
+        );
 
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml",
-                                        testInfo);
+                                        "maven-metadata.xml"
+        );
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml.sha1",
-                                        testInfo);
+                                        "maven-metadata.xml.sha1"
+        );
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml.md5",
-                                        testInfo);
+                                        "maven-metadata.xml.md5"
+        );
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml",
-                                        testInfo);
+                                        "maven-metadata.xml"
+        );
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml.sha1",
-                                        testInfo);
+                                        "maven-metadata.xml.sha1"
+        );
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml.md5",
-                                        testInfo);
+                                        "maven-metadata.xml.md5"
+        );
     }
 
     protected void mockLocalRepositoryTestMetadataUpdate(String localRepositoryId,
                                                          MutableObject<Metadata> versionLevelMetadata,
-                                                         MutableObject<Metadata> artifactLevelMetadata,
-                                                         TestInfo testInfo)
+                                                         MutableObject<Metadata> artifactLevelMetadata)
             throws Exception
     {
         final Repository repository = getConfiguration().getStorage(STORAGE0).getRepository(localRepositoryId);
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
 
-        Artifact snapshotArtifact = new MavenRepositoryArtifact(new Gav(groupId, getArtifactName(artifactId, testInfo),
+        Artifact snapshotArtifact = new MavenRepositoryArtifact(new Gav(groupId, artifactId,
                                                                         "1.0-20131004.115330-1"));
         MavenArtifactGenerator mavenArtifactGenerator = new MavenArtifactGenerator(repositoryPath);
 
@@ -140,19 +140,18 @@ abstract class BaseMavenMetadataExpirationTest
     protected void storeTestDataInHostedRepository(final String hostedRepositoryId,
                                                    final String localSourceRepositoryId,
                                                    final boolean versionLevel,
-                                                   final String filename,
-                                                   final TestInfo testInfo)
+                                                   final String filename)
             throws Exception
     {
         final RepositoryPath hostedPath = resolvePath(hostedRepositoryId,
                                                       versionLevel,
-                                                      filename,
-                                                      testInfo);
+                                                      filename
+        );
 
         final RepositoryPath testDataSourcePath = resolvePath(localSourceRepositoryId,
                                                               versionLevel,
-                                                              filename,
-                                                              testInfo);
+                                                              filename
+        );
 
         try (InputStream is = Files.newInputStream(testDataSourcePath))
         {
@@ -160,7 +159,7 @@ abstract class BaseMavenMetadataExpirationTest
         }
     }
 
-    protected void mockResolvingProxiedRemoteArtifactsToHostedRepository(final TestInfo testInfo)
+    protected void mockResolvingProxiedRemoteArtifactsToHostedRepository()
     {
         final RemoteRepositoryRetryArtifactDownloadConfiguration configuration = configurationManager.getConfiguration()
                                                                                                      .getRemoteRepositoriesConfiguration()
@@ -170,49 +169,46 @@ abstract class BaseMavenMetadataExpirationTest
 
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml",
-                                                             testInfo);
+                                                             "maven-metadata.xml"
+        );
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml.sha1",
-                                                             testInfo);
+                                                             "maven-metadata.xml.sha1"
+        );
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml.md5",
-                                                             testInfo);
+                                                             "maven-metadata.xml.md5"
+        );
 
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml",
-                                                             testInfo);
+                                                             "maven-metadata.xml"
+        );
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml.sha1",
-                                                             testInfo);
+                                                             "maven-metadata.xml.sha1"
+        );
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml.md5",
-                                                             testInfo);
+                                                             "maven-metadata.xml.md5"
+        );
 
         Mockito.when(artifactResolver.getConfiguration()).thenReturn(configuration);
         Mockito.when(artifactResolver.isAlive()).thenReturn(true);
 
         Mockito.when(artifactResolverFactory.newInstance(argThat(
                 remoteRepository -> remoteRepository != null &&
-                                    remoteRepository.getUrl() != null &&
-                                    remoteRepository.getUrl().contains(
-                                            testInfo.getTestMethod().get().getName())))).thenReturn(artifactResolver);
+                                    remoteRepository.getUrl() != null))).thenReturn(artifactResolver);
     }
 
     private void mockResolvingProxiedRemoteArtifactToHostedRepository(final RestArtifactResolver artifactResolver,
                                                                       final boolean versionLevel,
-                                                                      final String filename,
-                                                                      final TestInfo testInfo)
+                                                                      final String filename)
     {
-        final RepositoryPath hostedRepositoryPath = resolvePath(getRepositoryName(REPOSITORY_HOSTED, testInfo),
+        final RepositoryPath hostedRepositoryPath = resolvePath(REPOSITORY_HOSTED,
                                                                 versionLevel,
-                                                                filename,
-                                                                testInfo);
+                                                                filename
+        );
         final Response response = Mockito.mock(Response.class);
         Mockito.when(response.getEntity()).thenAnswer(
                 invocation -> new Object());
@@ -223,10 +219,10 @@ abstract class BaseMavenMetadataExpirationTest
         final CloseableRestResponse restResponse = Mockito.mock(CloseableRestResponse.class);
         Mockito.when(restResponse.getResponse()).thenReturn(response);
 
-        final RepositoryPath proxiedRepositoryPath = resolvePath(getRepositoryName(REPOSITORY_PROXY, testInfo),
+        final RepositoryPath proxiedRepositoryPath = resolvePath(REPOSITORY_PROXY,
                                                                  versionLevel,
-                                                                 filename,
-                                                                 testInfo);
+                                                                 filename
+        );
         final String proxiedPathRelativized = FilenameUtils.separatorsToUnix(
                 proxiedRepositoryPath.relativize().toString());
 
@@ -240,13 +236,12 @@ abstract class BaseMavenMetadataExpirationTest
 
     protected RepositoryPath resolvePath(final String repositoryId,
                                          final boolean versionLevel,
-                                         final String filename,
-                                         final TestInfo testInfo)
+                                         final String filename)
     {
         final Repository repository = getConfiguration().getStorage(STORAGE0).getRepository(repositoryId);
         RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
         repositoryPath = repositoryPath.resolve(groupId.replaceAll("\\.", "/"));
-        repositoryPath = repositoryPath.resolve(getArtifactName(artifactId, testInfo));
+        repositoryPath = repositoryPath.resolve(artifactId);
         if (versionLevel)
         {
             repositoryPath = repositoryPath.resolve("1.0-SNAPSHOT");
@@ -279,10 +274,4 @@ abstract class BaseMavenMetadataExpirationTest
         return Files.readAllLines(checksumRepositoryPath).stream().findFirst().orElse(null);
     }
 
-    protected String getArtifactName(String artifactId,
-                                     TestInfo testInfo)
-    {
-        String methodName = testInfo.getTestMethod().get().getName();
-        return artifactId + "-" + methodName;
-    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
@@ -36,21 +36,13 @@ import static org.mockito.ArgumentMatchers.*;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 abstract class BaseMavenMetadataExpirationTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass().getName());
-
-    protected static final String REPOSITORY_LOCAL_SOURCE = "mvn-local-source-repo-snapshots";
-
-    protected static final String REPOSITORY_HOSTED = "mvn-hosted-repo-snapshots";
-
-    protected static final String REPOSITORY_PROXY = "mvn-proxy-repo-snapshots";
-
-    protected static final String PROXY_REPOSITORY_URL =
-            "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_HOSTED + "/";
 
     protected String groupId = "pl.fuss.maven.metadata";
 
@@ -79,39 +71,37 @@ abstract class BaseMavenMetadataExpirationTest
     {
         mockLocalRepositoryTestMetadataUpdate(localSourceRepositoryId,
                                               versionLevelMetadata,
-                                              artifactLevelMetadata
-        );
+                                              artifactLevelMetadata);
 
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml"
-        );
+                                        "maven-metadata.xml");
+
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml.sha1"
-        );
+                                        "maven-metadata.xml.sha1");
+
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         true,
-                                        "maven-metadata.xml.md5"
-        );
+                                        "maven-metadata.xml.md5");
+
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml"
-        );
+                                        "maven-metadata.xml");
+
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml.sha1"
-        );
+                                        "maven-metadata.xml.sha1");
+
         storeTestDataInHostedRepository(hostedRepositoryId,
                                         localSourceRepositoryId,
                                         false,
-                                        "maven-metadata.xml.md5"
-        );
+                                        "maven-metadata.xml.md5");
     }
 
     protected void mockLocalRepositoryTestMetadataUpdate(String localRepositoryId,
@@ -145,13 +135,11 @@ abstract class BaseMavenMetadataExpirationTest
     {
         final RepositoryPath hostedPath = resolvePath(hostedRepositoryId,
                                                       versionLevel,
-                                                      filename
-        );
+                                                      filename);
 
         final RepositoryPath testDataSourcePath = resolvePath(localSourceRepositoryId,
                                                               versionLevel,
-                                                              filename
-        );
+                                                              filename);
 
         try (InputStream is = Files.newInputStream(testDataSourcePath))
         {
@@ -169,29 +157,27 @@ abstract class BaseMavenMetadataExpirationTest
 
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml"
-        );
+                                                             "maven-metadata.xml");
+
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml.sha1"
-        );
+                                                             "maven-metadata.xml.sha1");
+
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              true,
-                                                             "maven-metadata.xml.md5"
-        );
+                                                             "maven-metadata.xml.md5");
 
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml"
-        );
+                                                             "maven-metadata.xml");
+
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml.sha1"
-        );
+                                                             "maven-metadata.xml.sha1");
+
         mockResolvingProxiedRemoteArtifactToHostedRepository(artifactResolver,
                                                              false,
-                                                             "maven-metadata.xml.md5"
-        );
+                                                             "maven-metadata.xml.md5");
 
         Mockito.when(artifactResolver.getConfiguration()).thenReturn(configuration);
         Mockito.when(artifactResolver.isAlive()).thenReturn(true);
@@ -205,10 +191,9 @@ abstract class BaseMavenMetadataExpirationTest
                                                                       final boolean versionLevel,
                                                                       final String filename)
     {
-        final RepositoryPath hostedRepositoryPath = resolvePath(REPOSITORY_HOSTED,
+        final RepositoryPath hostedRepositoryPath = resolvePath(getRepositoryHostedId(),
                                                                 versionLevel,
-                                                                filename
-        );
+                                                                filename);
         final Response response = Mockito.mock(Response.class);
         Mockito.when(response.getEntity()).thenAnswer(
                 invocation -> new Object());
@@ -219,10 +204,10 @@ abstract class BaseMavenMetadataExpirationTest
         final CloseableRestResponse restResponse = Mockito.mock(CloseableRestResponse.class);
         Mockito.when(restResponse.getResponse()).thenReturn(response);
 
-        final RepositoryPath proxiedRepositoryPath = resolvePath(REPOSITORY_PROXY,
+        final RepositoryPath proxiedRepositoryPath = resolvePath(getRepositoryProxyId(),
                                                                  versionLevel,
-                                                                 filename
-        );
+                                                                 filename);
+
         final String proxiedPathRelativized = FilenameUtils.separatorsToUnix(
                 proxiedRepositoryPath.relativize().toString());
 
@@ -232,6 +217,10 @@ abstract class BaseMavenMetadataExpirationTest
         Mockito.when(artifactResolver.get(eq(proxiedPathRelativized), any(Long.class))).thenReturn(restResponse);
         Mockito.when(artifactResolver.head(eq(proxiedPathRelativized))).thenReturn(restResponse);
     }
+
+    protected abstract String getRepositoryHostedId();
+
+    protected abstract String getRepositoryProxyId();
 
 
     protected RepositoryPath resolvePath(final String repositoryId,
@@ -266,7 +255,7 @@ abstract class BaseMavenMetadataExpirationTest
     protected String readChecksum(final RepositoryPath checksumRepositoryPath)
             throws IOException
     {
-        if (!Files.exists(checksumRepositoryPath))
+        if (Files.notExists(checksumRepositoryPath))
         {
             return null;
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/BaseMavenMetadataExpirationTest.java
@@ -147,7 +147,7 @@ abstract class BaseMavenMetadataExpirationTest
         }
     }
 
-    protected void mockResolvingProxiedRemoteArtifactsToHostedRepository()
+    protected void mockResolvingProxiedRemoteArtifactsToHostedRepository(final String hostedRepositoryId)
     {
         final RemoteRepositoryRetryArtifactDownloadConfiguration configuration = configurationManager.getConfiguration()
                                                                                                      .getRemoteRepositoriesConfiguration()
@@ -183,8 +183,10 @@ abstract class BaseMavenMetadataExpirationTest
         Mockito.when(artifactResolver.isAlive()).thenReturn(true);
 
         Mockito.when(artifactResolverFactory.newInstance(argThat(
-                remoteRepository -> remoteRepository != null &&
-                                    remoteRepository.getUrl() != null))).thenReturn(artifactResolver);
+                remoteRepository ->
+                        remoteRepository != null &&
+                        remoteRepository.getUrl() != null &&
+                        remoteRepository.getUrl().contains(hostedRepositoryId)))).thenReturn(artifactResolver);
     }
 
     private void mockResolvingProxiedRemoteArtifactToHostedRepository(final RestArtifactResolver artifactResolver,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationMultipleGroupCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationMultipleGroupCaseTest.java
@@ -96,7 +96,7 @@ public class MavenMetadataExpirationMultipleGroupCaseTest
                                            versionLevelMetadataYahr,
                                            artifactLevelMetadataYahr);
 
-        mockResolvingProxiedRemoteArtifactsToHostedRepository();
+        mockResolvingProxiedRemoteArtifactsToHostedRepository(REPOSITORY_HOSTED);
 
         final RepositoryPath hostedPath = resolvePath(hostedRepository.getId(),
                                                       true,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationMultipleGroupCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationMultipleGroupCaseTest.java
@@ -39,11 +39,20 @@ public class MavenMetadataExpirationMultipleGroupCaseTest
         extends BaseMavenMetadataExpirationTest
 {
 
-    private static final String REPOSITORY_GROUP = "mvn-group-repo-snapshots";
+    private static final String REPOSITORY_LOCAL_SOURCE = "mmemgc-local-source-repo-snapshots";
 
-    private static final String REPOSITORY_HOSTED_YAHR = "mvn-hosted-yahr-repo-snapshots";
+    private static final String REPOSITORY_HOSTED = "mmemgc-hosted-repo-snapshots";
 
-    private static final String REPOSITORY_LOCAL_YAHR_SOURCE = "mvn-local-yahr-source-repo-snapshots";
+    private static final String REPOSITORY_PROXY = "mmemgc-proxy-repo-snapshots";
+
+    private static final String PROXY_REPOSITORY_URL =
+            "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_HOSTED + "/";
+
+    private static final String REPOSITORY_GROUP = "mmemgc-group-repo-snapshots";
+
+    private static final String REPOSITORY_HOSTED_YAHR = "mmemgc-hosted-yahr-repo-snapshots";
+
+    private static final String REPOSITORY_LOCAL_YAHR_SOURCE = "mmemgc-local-yahr-source-repo-snapshots";
 
     @Inject
     private GroupRepositoryProvider groupRepositoryProvider;
@@ -71,7 +80,8 @@ public class MavenMetadataExpirationMultipleGroupCaseTest
             @MavenRepository(repositoryId = REPOSITORY_PROXY,
                              setup = MavenIndexedRepositorySetup.class)
             Repository proxyRepository,
-            @Group(repositories = REPOSITORY_PROXY)
+            @Group(repositories = { REPOSITORY_PROXY,
+                                    REPOSITORY_HOSTED_YAHR })
             @MavenRepository(repositoryId = REPOSITORY_GROUP)
             Repository groupRepository)
             throws Exception
@@ -80,6 +90,11 @@ public class MavenMetadataExpirationMultipleGroupCaseTest
                                            localSourceRepository.getId(),
                                            versionLevelMetadata,
                                            artifactLevelMetadata);
+
+        mockHostedRepositoryMetadataUpdate(hostedYahrRepository.getId(),
+                                           localYahrSourceRepository.getId(),
+                                           versionLevelMetadataYahr,
+                                           artifactLevelMetadataYahr);
 
         mockResolvingProxiedRemoteArtifactsToHostedRepository();
 
@@ -147,5 +162,17 @@ public class MavenMetadataExpirationMultipleGroupCaseTest
                                                         EncryptionAlgorithmsEnum.SHA1.getAlgorithm());
 
         assertEquals(calculatedGroupPathChecksum, sha1ProxyPathChecksum);
+    }
+
+    @Override
+    protected String getRepositoryHostedId()
+    {
+        return REPOSITORY_HOSTED;
+    }
+
+    @Override
+    protected String getRepositoryProxyId()
+    {
+        return REPOSITORY_PROXY;
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationProxyCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationProxyCaseTest.java
@@ -36,6 +36,15 @@ public class MavenMetadataExpirationProxyCaseTest
         extends BaseMavenMetadataExpirationTest
 {
 
+    private static final String REPOSITORY_LOCAL_SOURCE = "mmepc-local-source-repo-snapshots";
+
+    private static final String REPOSITORY_HOSTED = "mmepc-hosted-repo-snapshots";
+
+    private static final String REPOSITORY_PROXY = "mmepc-proxy-repo-snapshots";
+
+    private static final String PROXY_REPOSITORY_URL =
+            "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_HOSTED + "/";
+
     @Inject
     private ProxyRepositoryProvider proxyRepositoryProvider;
 
@@ -99,8 +108,7 @@ public class MavenMetadataExpirationProxyCaseTest
         mockHostedRepositoryMetadataUpdate(hostedRepository.getId(),
                                            localSourceRepository.getId(),
                                            versionLevelMetadata,
-                                           artifactLevelMetadata
-        );
+                                           artifactLevelMetadata);
 
         sha1HostedPathChecksum = readChecksum(resolveSiblingChecksum(hostedPath,
                                                                      EncryptionAlgorithmsEnum.SHA1));
@@ -118,6 +126,18 @@ public class MavenMetadataExpirationProxyCaseTest
         calculatedProxiedPathChecksum = calculateChecksum(proxiedPath,
                                                           EncryptionAlgorithmsEnum.SHA1.getAlgorithm());
         assertEquals(sha1ProxiedPathChecksum, calculatedProxiedPathChecksum);
+    }
+
+    @Override
+    protected String getRepositoryHostedId()
+    {
+        return REPOSITORY_HOSTED;
+    }
+
+    @Override
+    protected String getRepositoryProxyId()
+    {
+        return REPOSITORY_PROXY;
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationProxyCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationProxyCaseTest.java
@@ -67,7 +67,7 @@ public class MavenMetadataExpirationProxyCaseTest
                                            versionLevelMetadata,
                                            artifactLevelMetadata);
 
-        mockResolvingProxiedRemoteArtifactsToHostedRepository();
+        mockResolvingProxiedRemoteArtifactsToHostedRepository(REPOSITORY_HOSTED);
 
 
         final RepositoryPath hostedPath = resolvePath(hostedRepository.getId(),

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
@@ -74,7 +74,7 @@ public class MavenMetadataExpirationSingleGroupCaseTest
                                            versionLevelMetadata,
                                            artifactLevelMetadata);
 
-        mockResolvingProxiedRemoteArtifactsToHostedRepository();
+        mockResolvingProxiedRemoteArtifactsToHostedRepository(REPOSITORY_HOSTED);
 
         final RepositoryPath hostedPath = resolvePath(hostedRepository.getId(),
                                                       true,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
@@ -2,24 +2,24 @@ package org.carlspring.strongbox.providers.io;
 
 import org.carlspring.commons.encryption.EncryptionAlgorithmsEnum;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.repository.GroupRepositoryProvider;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 
 import javax.inject.Inject;
 import java.nio.file.Files;
-import java.util.LinkedHashSet;
-import java.util.Set;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import static org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum.SNAPSHOT;
 import static org.carlspring.strongbox.util.MessageDigestUtils.calculateChecksum;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
@@ -42,58 +42,44 @@ public class MavenMetadataExpirationSingleGroupCaseTest
     @Inject
     private GroupRepositoryProvider groupRepositoryProvider;
 
-
-    @BeforeEach
-    public void initialize(TestInfo testInfo)
-            throws Exception
-    {
-        createRepository(STORAGE0,
-                         getRepositoryName(REPOSITORY_LOCAL_SOURCE, testInfo),
-                         RepositoryPolicyEnum.SNAPSHOT.getPolicy(),
-                         false);
-
-        createRepository(STORAGE0,
-                         getRepositoryName(REPOSITORY_HOSTED, testInfo),
-                         RepositoryPolicyEnum.SNAPSHOT.getPolicy(),
-                         false);
-
-        mockHostedRepositoryMetadataUpdate(getRepositoryName(REPOSITORY_HOSTED, testInfo),
-                                           getRepositoryName(REPOSITORY_LOCAL_SOURCE, testInfo),
-                                           versionLevelMetadata,
-                                           artifactLevelMetadata,
-                                           testInfo);
-
-        createProxyRepository(STORAGE0,
-                              getRepositoryName(REPOSITORY_PROXY, testInfo),
-                              "http://localhost:48080/storages/" + STORAGE0 + "/" +
-                              getRepositoryName(REPOSITORY_HOSTED, testInfo) + "/");
-
-        createGroup(STORAGE0,
-                    getRepositoryName(REPOSITORY_GROUP, testInfo),
-                    getRepositoryName(REPOSITORY_PROXY, testInfo));
-
-        mockResolvingProxiedRemoteArtifactsToHostedRepository(testInfo);
-    }
-
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void groupRepositoryVersionLevelMetadataShouldBeRefreshedAsItsSingleProxySubrepository(TestInfo testInfo)
+    public void groupRepositoryVersionLevelMetadataShouldBeRefreshedAsItsSingleProxySubrepository(
+            @MavenRepository(repositoryId = REPOSITORY_HOSTED,
+                             policy = SNAPSHOT)
+            Repository hostedRepository,
+            @MavenRepository(repositoryId = REPOSITORY_LOCAL_SOURCE,
+                             policy = SNAPSHOT)
+            Repository localSourceRepository,
+            @Remote(url = PROXY_REPOSITORY_URL)
+            @MavenRepository(repositoryId = REPOSITORY_PROXY,
+                             setup = MavenIndexedRepositorySetup.class)
+            Repository proxyRepository,
+            @Group(repositories = REPOSITORY_PROXY)
+            @MavenRepository(repositoryId = REPOSITORY_GROUP)
+            Repository groupRepository)
             throws Exception
     {
-        final RepositoryPath hostedPath = resolvePath(getRepositoryName(REPOSITORY_HOSTED, testInfo),
+        mockHostedRepositoryMetadataUpdate(hostedRepository.getId(),
+                                           localSourceRepository.getId(),
+                                           versionLevelMetadata,
+                                           artifactLevelMetadata);
+
+        mockResolvingProxiedRemoteArtifactsToHostedRepository();
+
+        final RepositoryPath hostedPath = resolvePath(hostedRepository.getId(),
                                                       true,
-                                                      "maven-metadata.xml",
-                                                      testInfo);
+                                                      "maven-metadata.xml");
         String sha1HostedPathChecksum = readChecksum(resolveSiblingChecksum(hostedPath, EncryptionAlgorithmsEnum.SHA1));
         assertNotNull(sha1HostedPathChecksum);
 
-        final RepositoryPath proxyPath = resolvePath(getRepositoryName(REPOSITORY_PROXY, testInfo),
+        final RepositoryPath proxyPath = resolvePath(proxyRepository.getId(),
                                                      true,
-                                                     "maven-metadata.xml",
-                                                     testInfo);
-        final RepositoryPath groupPath = resolvePath(getRepositoryName(REPOSITORY_GROUP, testInfo),
+                                                     "maven-metadata.xml");
+
+        final RepositoryPath groupPath = resolvePath(groupRepository.getId(),
                                                      true,
-                                                     "maven-metadata.xml",
-                                                     testInfo);
+                                                     "maven-metadata.xml");
         String sha1ProxyPathChecksum = readChecksum(resolveSiblingChecksum(proxyPath, EncryptionAlgorithmsEnum.SHA1));
         assertNull(sha1ProxyPathChecksum);
 
@@ -114,11 +100,11 @@ public class MavenMetadataExpirationSingleGroupCaseTest
         sha1ProxyPathChecksum = readChecksum(resolveSiblingChecksum(proxyPath, EncryptionAlgorithmsEnum.SHA1));
         assertEquals(sha1ProxyPathChecksum, calculatedGroupPathChecksum);
 
-        mockHostedRepositoryMetadataUpdate(getRepositoryName(REPOSITORY_HOSTED, testInfo),
-                                           getRepositoryName(REPOSITORY_LOCAL_SOURCE, testInfo),
+        mockHostedRepositoryMetadataUpdate(hostedRepository.getId(),
+                                           localSourceRepository.getId(),
                                            versionLevelMetadata,
-                                           artifactLevelMetadata,
-                                           testInfo);
+                                           artifactLevelMetadata
+        );
 
         sha1HostedPathChecksum = readChecksum(resolveSiblingChecksum(hostedPath,
                                                                      EncryptionAlgorithmsEnum.SHA1));
@@ -138,29 +124,4 @@ public class MavenMetadataExpirationSingleGroupCaseTest
         assertEquals(sha1ProxyPathChecksum, calculatedGroupPathChecksum);
     }
 
-
-    @AfterEach
-    public void removeRepositories(TestInfo testInfo)
-            throws Exception
-    {
-        removeRepositories(getRepositories(testInfo));
-    }
-
-    private Set<RepositoryDto> getRepositories(TestInfo testInfo)
-    {
-        Set<RepositoryDto> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_HOSTED, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_PROXY, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_LOCAL_SOURCE, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0,
-                                              getRepositoryName(REPOSITORY_GROUP, testInfo),
-                                              Maven2LayoutProvider.ALIAS));
-        return repositories;
-    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/io/MavenMetadataExpirationSingleGroupCaseTest.java
@@ -37,7 +37,16 @@ public class MavenMetadataExpirationSingleGroupCaseTest
         extends BaseMavenMetadataExpirationTest
 {
 
-    private static final String REPOSITORY_GROUP = "mvn-group-repo-snapshots";
+    private static final String REPOSITORY_LOCAL_SOURCE = "mmesgc-local-source-repo-snapshots";
+
+    private static final String REPOSITORY_HOSTED = "mmesgc-hosted-repo-snapshots";
+
+    private static final String REPOSITORY_PROXY = "mmesgc-proxy-repo-snapshots";
+
+    private static final String PROXY_REPOSITORY_URL =
+            "http://localhost:48080/storages/" + STORAGE0 + "/" + REPOSITORY_HOSTED + "/";
+
+    private static final String REPOSITORY_GROUP = "mmesgc-group-repo-snapshots";
 
     @Inject
     private GroupRepositoryProvider groupRepositoryProvider;
@@ -103,8 +112,7 @@ public class MavenMetadataExpirationSingleGroupCaseTest
         mockHostedRepositoryMetadataUpdate(hostedRepository.getId(),
                                            localSourceRepository.getId(),
                                            versionLevelMetadata,
-                                           artifactLevelMetadata
-        );
+                                           artifactLevelMetadata);
 
         sha1HostedPathChecksum = readChecksum(resolveSiblingChecksum(hostedPath,
                                                                      EncryptionAlgorithmsEnum.SHA1));
@@ -124,4 +132,15 @@ public class MavenMetadataExpirationSingleGroupCaseTest
         assertEquals(sha1ProxyPathChecksum, calculatedGroupPathChecksum);
     }
 
+    @Override
+    protected String getRepositoryHostedId()
+    {
+        return REPOSITORY_HOSTED;
+    }
+
+    @Override
+    protected String getRepositoryProxyId()
+    {
+        return REPOSITORY_PROXY;
+    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
@@ -4,34 +4,31 @@ import org.carlspring.strongbox.config.Maven2LayoutProviderCronTasksTestConfig;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
 import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.storage.Storage;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
 import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
+import org.carlspring.strongbox.testing.repository.MavenRepository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 
-import java.util.LinkedHashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import org.codehaus.plexus.util.StringUtils;
-import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 import static org.mockito.ArgumentMatchers.argThat;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -47,8 +44,13 @@ public class WhenRepositoryIsAliveCleanExpiredArtifactsTestIT
 
     private static final String REMOTE_URL = "http://central.maven.org/maven2/";
 
+    @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void expiredArtifactsCleanerShouldCleanupDatabaseAndStorage()
+    public void expiredArtifactsCleanerShouldCleanupDatabaseAndStorage(@Remote(url = REMOTE_URL)
+                                                                       @MavenRepository(storageId = STORAGE_ID,
+                                                                                        repositoryId = REPOSITORY_ID,
+                                                                                        setup = MavenIndexedRepositorySetup.class)
+                                                                       Repository proxyRepository)
             throws Exception
     {
         ArtifactEntry artifactEntry = downloadAndSaveArtifactEntry();
@@ -60,10 +62,10 @@ public class WhenRepositoryIsAliveCleanExpiredArtifactsTestIT
         localStorageProxyRepositoryExpiredArtifactsCleaner.cleanup(5, artifactEntry.getSizeInBytes() - 1);
 
         Optional<ArtifactEntry> artifactEntryOptional = Optional.ofNullable(
-                artifactEntryService.findOneArtifact(STORAGE_ID,
-                                                     REPOSITORY_ID,
+                artifactEntryService.findOneArtifact(proxyRepository.getStorage().getId(),
+                                                     proxyRepository.getId(),
                                                      getPath()));
-        assertThat(artifactEntryOptional, CoreMatchers.equalTo(Optional.empty()));
+        assertEquals(Optional.empty(), artifactEntryOptional);
 
         final Storage storage = getConfiguration().getStorage(artifactEntry.getStorageId());
         final Repository repository = storage.getRepository(artifactEntry.getRepositoryId());
@@ -72,28 +74,6 @@ public class WhenRepositoryIsAliveCleanExpiredArtifactsTestIT
         assertTrue(RepositoryFiles.artifactExists(repositoryPathResolver.resolve(repository, StringUtils.replace(getPath(),
                                                                                                               "1.3/maven-commons-1.3.jar",
                                                                                                               "maven-metadata.xml"))));
-    }
-
-    private static Set<RepositoryDto> getRepositoriesToClean()
-    {
-        Set<RepositoryDto> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE_ID, REPOSITORY_ID, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
-    }
-
-    @BeforeEach
-    public void init()
-            throws Exception
-    {
-        createProxyRepository(STORAGE_ID, REPOSITORY_ID, REMOTE_URL);
-    }
-
-    @AfterEach
-    public void removeRepositories()
-            throws Exception
-    {
-        removeRepositories(getRepositoriesToClean());
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
@@ -28,7 +28,7 @@ public abstract class BaseMavenGroupRepositoryComponentTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
 
-    protected Set<RepositoryDto> getRepositories()
+    protected Set<Repository> getRepositories()
     {
         return Collections.emptySet();
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
@@ -1,23 +1,12 @@
 package org.carlspring.strongbox.repository.group;
 
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
-import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
-import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
-import org.carlspring.strongbox.yaml.configuration.repository.MavenRepositoryConfigurationDto;
 
-import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Set;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 
 /**
@@ -27,42 +16,6 @@ import org.apache.commons.io.FileUtils;
 public abstract class BaseMavenGroupRepositoryComponentTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
 {
-
-    protected Set<Repository> getRepositories()
-    {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public void createRepository(final String storageId,
-                                 final RepositoryDto repository)
-            throws RepositoryManagementStrategyException, JAXBException, IOException
-    {
-        MavenRepositoryConfigurationDto configuration = new MavenRepositoryConfigurationDto();
-        configuration.setIndexingEnabled(true);
-
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setAllowsForceDeletion(true);
-        repository.setPolicy(RepositoryPolicyEnum.RELEASE.getPolicy());
-        repository.setRepositoryConfiguration(configuration);
-
-        super.createRepository(storageId, repository);
-    }
-
-    protected RepositoryDto createGroup(String repositoryId,
-                                            String storageId,
-                                            String... leafs)
-            throws Exception
-    {
-        RepositoryDto repository = new RepositoryDto(repositoryId);
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setType(RepositoryTypeEnum.GROUP.getType());
-        repository.setGroupRepositories(Sets.newLinkedHashSet(Arrays.asList(leafs)));
-
-        createRepository(storageId, repository);
-
-        return repository;
-    }
 
     protected void copyArtifactMetadata(String sourceRepositoryId,
                                         String destinationRepositoryId,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/BaseMavenGroupRepositoryComponentTest.java
@@ -3,8 +3,8 @@ package org.carlspring.strongbox.repository.group;
 import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
 import org.carlspring.strongbox.storage.Storage;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
 import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.repository.RepositoryDto;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
 import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing;
@@ -15,15 +15,14 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Random;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.AfterEach;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 public abstract class BaseMavenGroupRepositoryComponentTest
         extends TestCaseWithMavenArtifactGenerationAndIndexing
@@ -50,19 +49,6 @@ public abstract class BaseMavenGroupRepositoryComponentTest
         super.createRepository(storageId, repository);
     }
 
-    protected void createLeaf(String storageId,
-                              String repositoryId)
-            throws Exception
-    {
-        RepositoryDto repository = new RepositoryDto(repositoryId);
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setType(new Random().nextInt(2) % 2 == 0 ?
-                           RepositoryTypeEnum.HOSTED.getType() :
-                           RepositoryTypeEnum.PROXY.getType());
-
-        createRepository(storageId, repository);
-    }
-
     protected RepositoryDto createGroup(String repositoryId,
                                             String storageId,
                                             String... leafs)
@@ -76,13 +62,6 @@ public abstract class BaseMavenGroupRepositoryComponentTest
         createRepository(storageId, repository);
 
         return repository;
-    }
-
-    @AfterEach
-    public void removeRepositories()
-            throws Exception
-    {
-        removeRepositories(getRepositories());
     }
 
     protected void copyArtifactMetadata(String sourceRepositoryId,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/index/BaseMavenIndexGroupRepositoryComponentTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/index/BaseMavenIndexGroupRepositoryComponentTest.java
@@ -1,29 +1,30 @@
 package org.carlspring.strongbox.repository.group.index;
 
-import java.io.IOException;
-import java.util.Set;
-
-import javax.inject.Inject;
-
 import org.carlspring.strongbox.providers.io.RootRepositoryPath;
 import org.carlspring.strongbox.repository.group.BaseMavenGroupRepositoryComponentTest;
 import org.carlspring.strongbox.services.ArtifactIndexesService;
-import org.carlspring.strongbox.storage.repository.RepositoryData;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
+import org.carlspring.strongbox.storage.repository.Repository;
 
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * @author Pablo Tirado
+ */
 abstract class BaseMavenIndexGroupRepositoryComponentTest
         extends BaseMavenGroupRepositoryComponentTest
 {
 
     @Inject
-    ArtifactIndexesService artifactIndexesService;
+    protected ArtifactIndexesService artifactIndexesService;
 
-    void rebuildIndexes(Set<RepositoryDto> repositories)
+    void rebuildIndexes(Set<Repository> repositories)
             throws IOException
     {
-        for (RepositoryDto repository : repositories)
+        for (Repository repository : repositories)
         {
-            RootRepositoryPath repositoryPath = repositoryPathResolver.resolve(new RepositoryData(repository));
+            RootRepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
             artifactIndexesService.rebuildIndex(repositoryPath);
         }
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/index/MavenIndexGroupRepositoryComponentOnDeleteTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/index/MavenIndexGroupRepositoryComponentOnDeleteTest.java
@@ -3,12 +3,10 @@ package org.carlspring.strongbox.repository.group.index;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
 import org.carlspring.strongbox.storage.indexing.IndexTypeEnum;
 import org.carlspring.strongbox.storage.indexing.RepositoryIndexer;
 import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
 import org.carlspring.strongbox.storage.search.SearchRequest;
 import org.carlspring.strongbox.testing.MavenIndexedRepositorySetup;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
@@ -21,8 +19,9 @@ import org.carlspring.strongbox.util.IndexContextHelper;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -74,25 +73,10 @@ public class MavenIndexGroupRepositoryComponentOnDeleteTest
 
     private static final String REPOSITORY_GROUP_XH = "group-repo-xh";
 
-    protected Set<RepositoryDto> getRepositories()
+    protected Set<Repository> getRepositories(Repository... repositories)
     {
-        Set<RepositoryDto> repositories = new LinkedHashSet<>();
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XE, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XL, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XZ, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XD, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XG, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_LEAF_XK, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XO, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XB, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XC, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XF, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XH, Maven2LayoutProvider.ALIAS));
-        repositories.add(createRepositoryMock(STORAGE0, REPOSITORY_GROUP_XA, Maven2LayoutProvider.ALIAS));
-
-        return repositories;
+        return Stream.of(repositories).collect(Collectors.toSet());
     }
-
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
@@ -156,7 +140,11 @@ public class MavenIndexGroupRepositoryComponentOnDeleteTest
         generateMavenMetadata(STORAGE0, repositoryLeafXd.getId());
         generateMavenMetadata(STORAGE0, repositoryLeafXk.getId());
 
-        rebuildIndexes(getRepositories());
+        Set<Repository> repositoriesSet = getRepositories(repositoryLeafXe, repositoryLeafXl, repositoryLeafXz,
+                                                          repositoryLeafXd, repositoryLeafXg, repositoryLeafXk,
+                                                          repositoryGroupXo, repositoryGroupXb, repositoryGroupXc,
+                                                          repositoryGroupXf, repositoryGroupXh);
+        rebuildIndexes(repositoriesSet);
 
         String artifactPath = "com/artifacts/to/delete/releases/delete-group/1.2.1/delete-group-1.2.1.jar";
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnAddTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnAddTest.java
@@ -7,7 +7,8 @@ import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecution
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group.Rule;
 
 import java.nio.file.Path;
 
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -67,23 +69,23 @@ public class MavenMetadataGroupRepositoryComponentOnAddTest
             @MavenRepository(repositoryId = REPOSITORY_LEAF_S) Repository repositoryLeafS,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_T) Repository repositoryLeafT,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_U) Repository repositoryLeafU,
-            @TestRepository.Group({ REPOSITORY_LEAF_O,
-                                    REPOSITORY_LEAF_R })
+            @Group({ REPOSITORY_LEAF_O,
+                     REPOSITORY_LEAF_R })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_Y) Repository repositoryGroupY,
-            @TestRepository.Group({ REPOSITORY_GROUP_Y,
-                                    REPOSITORY_LEAF_S,
-                                    REPOSITORY_LEAF_P })
+            @Group({ REPOSITORY_GROUP_Y,
+                     REPOSITORY_LEAF_S,
+                     REPOSITORY_LEAF_P })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_X) Repository repositoryGroupX,
-            @TestRepository.Group({ REPOSITORY_LEAF_T,
-                                    REPOSITORY_GROUP_X })
+            @Group({ REPOSITORY_LEAF_T,
+                     REPOSITORY_GROUP_X })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_W) Repository repositoryGroupW,
-            @TestRepository.Group({ REPOSITORY_GROUP_Y,
-                                    REPOSITORY_LEAF_S,
-                                    REPOSITORY_LEAF_P })
+            @Group({ REPOSITORY_GROUP_Y,
+                     REPOSITORY_LEAF_S,
+                     REPOSITORY_LEAF_P })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_Z) Repository repositoryGroupZ,
-            @TestRepository.Group(repositories = { REPOSITORY_GROUP_Z,
-                                                   REPOSITORY_LEAF_U },
-                    rules = { @TestRepository.Group.Rule(
+            @Group(repositories = { REPOSITORY_GROUP_Z,
+                                    REPOSITORY_LEAF_U },
+                    rules = { @Rule(
                             pattern = ".*(com|org)/artifacts/to/update/releases/update-group.*",
                             repositories = REPOSITORY_LEAF_S,
                             type = DENY)
@@ -102,20 +104,20 @@ public class MavenMetadataGroupRepositoryComponentOnAddTest
                     Path artifactLeafU)
             throws Exception
     {
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_P);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_T);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_S);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_U);
+        generateMavenMetadata(STORAGE0, repositoryLeafP.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafT.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafS.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafU.getId());
 
-        copyArtifactMetadata(REPOSITORY_LEAF_P, REPOSITORY_GROUP_Z, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafP.getId(), repositoryGroupZ.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_P, REPOSITORY_GROUP_X, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafP.getId(), repositoryGroupX.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_P, REPOSITORY_GROUP_W, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafP.getId(), repositoryGroupW.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_P, REPOSITORY_GROUP_ZQ, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafP.getId(), repositoryGroupZQ.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_U, REPOSITORY_GROUP_ZQ, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafU.getId(), repositoryGroupZQ.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/update/releases/update-group/maven-metadata.xml"));
 
         Metadata metadata = mavenMetadataManager.readMetadata(

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnDeleteTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnDeleteTest.java
@@ -10,7 +10,8 @@ import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecution
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group.Rule;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * @author Przemyslaw Fusik
+ * @author PAblo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -75,23 +77,23 @@ public class MavenMetadataGroupRepositoryComponentOnDeleteTest
             @MavenRepository(repositoryId = REPOSITORY_LEAF_D) Repository repositoryLeafD,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_G) Repository repositoryLeafG,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_K) Repository repositoryLeafK,
-            @TestRepository.Group({ REPOSITORY_LEAF_E,
-                                    REPOSITORY_LEAF_Z })
+            @Group({ REPOSITORY_LEAF_E,
+                     REPOSITORY_LEAF_Z })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_C) Repository repositoryGroupC,
-            @TestRepository.Group({ REPOSITORY_GROUP_C,
-                                    REPOSITORY_LEAF_D,
-                                    REPOSITORY_LEAF_L })
+            @Group({ REPOSITORY_GROUP_C,
+                     REPOSITORY_LEAF_D,
+                     REPOSITORY_LEAF_L })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_B) Repository repositoryGroupB,
-            @TestRepository.Group({ REPOSITORY_LEAF_G,
-                                    REPOSITORY_GROUP_B })
+            @Group({ REPOSITORY_LEAF_G,
+                     REPOSITORY_GROUP_B })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_A) Repository repositoryGroupA,
-            @TestRepository.Group({ REPOSITORY_GROUP_C,
-                                    REPOSITORY_LEAF_D,
-                                    REPOSITORY_LEAF_L })
+            @Group({ REPOSITORY_GROUP_C,
+                     REPOSITORY_LEAF_D,
+                     REPOSITORY_LEAF_L })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_F) Repository repositoryGroupF,
-            @TestRepository.Group(repositories = { REPOSITORY_GROUP_F,
-                                                   REPOSITORY_LEAF_K },
-                    rules = { @TestRepository.Group.Rule(
+            @Group(repositories = { REPOSITORY_GROUP_F,
+                                    REPOSITORY_LEAF_K },
+                    rules = { @Rule(
                             pattern = ".*(com|org)/artifacts/to/update/releases/update-group.*",
                             repositories = REPOSITORY_LEAF_D,
                             type = DENY)
@@ -110,20 +112,20 @@ public class MavenMetadataGroupRepositoryComponentOnDeleteTest
                     Path artifactLeafK)
             throws Exception
     {
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_L);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_G);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_D);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_K);
+        generateMavenMetadata(STORAGE0, repositoryLeafL.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafG.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafD.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafK.getId());
 
-        copyArtifactMetadata(REPOSITORY_LEAF_L, REPOSITORY_GROUP_F, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafL.getId(), repositoryGroupF.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_L, REPOSITORY_GROUP_B, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafL.getId(), repositoryGroupB.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_L, REPOSITORY_GROUP_A, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafL.getId(), repositoryGroupA.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_L, REPOSITORY_GROUP_H, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafL.getId(), repositoryGroupH.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_K, REPOSITORY_GROUP_H, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafK.getId(), repositoryGroupH.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/update/releases/update-group/maven-metadata.xml"));
 
         String path = "com/artifacts/to/delete/releases/delete-group/1.2.1/delete-group-1.2.1.jar";

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnUploadTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/repository/group/metadata/MavenMetadataGroupRepositoryComponentOnUploadTest.java
@@ -9,7 +9,8 @@ import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecution
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group.Rule;
 
 import javax.inject.Inject;
 import java.io.FileNotFoundException;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -75,23 +77,23 @@ public class MavenMetadataGroupRepositoryComponentOnUploadTest
             @MavenRepository(repositoryId = REPOSITORY_LEAF_AD) Repository repositoryLeafAd,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_AG) Repository repositoryLeafAg,
             @MavenRepository(repositoryId = REPOSITORY_LEAF_AK) Repository repositoryLeafAk,
-            @TestRepository.Group({ REPOSITORY_LEAF_AE,
-                                    REPOSITORY_LEAF_AZ })
+            @Group({ REPOSITORY_LEAF_AE,
+                     REPOSITORY_LEAF_AZ })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_AC) Repository repositoryGroupAc,
-            @TestRepository.Group({ REPOSITORY_GROUP_AC,
-                                    REPOSITORY_LEAF_AD,
-                                    REPOSITORY_LEAF_AL })
+            @Group({ REPOSITORY_GROUP_AC,
+                     REPOSITORY_LEAF_AD,
+                     REPOSITORY_LEAF_AL })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_AB) Repository repositoryGroupAb,
-            @TestRepository.Group({ REPOSITORY_LEAF_AG,
-                                    REPOSITORY_GROUP_AB })
+            @Group({ REPOSITORY_LEAF_AG,
+                     REPOSITORY_GROUP_AB })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_AA) Repository repositoryGroupAa,
-            @TestRepository.Group({ REPOSITORY_GROUP_AC,
-                                    REPOSITORY_LEAF_AD,
-                                    REPOSITORY_LEAF_AL })
+            @Group({ REPOSITORY_GROUP_AC,
+                     REPOSITORY_LEAF_AD,
+                     REPOSITORY_LEAF_AL })
             @MavenRepository(repositoryId = REPOSITORY_GROUP_AF) Repository repositoryGroupAf,
-            @TestRepository.Group(repositories = { REPOSITORY_GROUP_AF,
-                                                   REPOSITORY_LEAF_AK },
-                    rules = { @TestRepository.Group.Rule(
+            @Group(repositories = { REPOSITORY_GROUP_AF,
+                                    REPOSITORY_LEAF_AK },
+                    rules = { @Rule(
                             pattern = ".*(com|org)/artifacts/to/update/releases/update-group.*",
                             repositories = REPOSITORY_LEAF_AD,
                             type = DENY)
@@ -111,20 +113,20 @@ public class MavenMetadataGroupRepositoryComponentOnUploadTest
             throws Exception
     {
         // BEFORE
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_AL);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_AG);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_AD);
-        generateMavenMetadata(STORAGE0, REPOSITORY_LEAF_AK);
+        generateMavenMetadata(STORAGE0, repositoryLeafAl.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafAg.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafAd.getId());
+        generateMavenMetadata(STORAGE0, repositoryLeafAk.getId());
 
-        copyArtifactMetadata(REPOSITORY_LEAF_AL, REPOSITORY_GROUP_AF, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafAl.getId(), repositoryGroupAf.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_AL, REPOSITORY_GROUP_AB, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafAl.getId(), repositoryGroupAb.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_AL, REPOSITORY_GROUP_AA, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafAl.getId(), repositoryGroupAa.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_AL, REPOSITORY_GROUP_AH, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafAl.getId(), repositoryGroupAh.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/delete/releases/delete-group/maven-metadata.xml"));
-        copyArtifactMetadata(REPOSITORY_LEAF_AK, REPOSITORY_GROUP_AH, FilenameUtils.normalize(
+        copyArtifactMetadata(repositoryLeafAk.getId(), repositoryGroupAh.getId(), FilenameUtils.normalize(
                 "com/artifacts/to/update/releases/update-group/maven-metadata.xml"));
 
         Metadata metadata = mavenMetadataManager.readMetadata(

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -622,31 +622,30 @@ public class ArtifactManagementServiceImplTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testChecksumsStorage(@MavenRepository (repositoryId = "checksums-storage")
+    public void testChecksumsStorage(@MavenRepository(repositoryId = "checksums-storage")
                                      Repository repository,
-                                     @MavenTestArtifact(repositoryId = "checksums-storage",
-                                                        id = "org.carlspring.strongbox:strongbox-checksum-test",
-                                                        versions = { "8.4" })
-                                     Path artifactPath)
+                                     @MavenTestArtifact(resource = "org/carlspring/strongbox/strongbox-checksum-test/8.4/strongbox-checksum-test-8.4.jar")
+                                     Path artifact)
             throws Exception
     {
-        RepositoryPath path = (RepositoryPath) artifactPath.normalize();
+        String artifactPathStr = "org/carlspring/strongbox/strongbox-checksum-test/8.4/strongbox-checksum-test-8.4.jar";
+        RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository).resolve(artifactPathStr);
 
-        try (InputStream is = Files.newInputStream(path))
+        try (InputStream is = Files.newInputStream(artifact))
         {
-            mavenArtifactManagementService.store(path, is);
+            mavenArtifactManagementService.store(repositoryPath, is);
         }
 
         // Obtains two expected checksums
-        String sha1Checksum = new String(Files.readAllBytes(artifactPath.resolveSibling(artifactPath.getFileName()+ ".sha1")));
-        String md5Checksum = new String(Files.readAllBytes(artifactPath.resolveSibling(artifactPath.getFileName()+ ".md5")));
+        String sha1Checksum = new String(Files.readAllBytes(artifact.resolveSibling(artifact.getFileName()+ ".sha1")));
+        String md5Checksum = new String(Files.readAllBytes(artifact.resolveSibling(artifact.getFileName()+ ".md5")));
 
         Map <String, String> expectedChecksums = new HashMap<>();
         expectedChecksums.put("SHA-1", sha1Checksum);
         expectedChecksums.put("MD5", md5Checksum);
 
-        String pathStr = RepositoryFiles.relativizePath(path);
-        ArtifactEntry artifactEntry = artifactEntryService.findOneArtifact(STORAGE0, repository.getId(), pathStr);
+        String path = RepositoryFiles.relativizePath(repositoryPath);
+        ArtifactEntry artifactEntry = artifactEntryService.findOneArtifact(STORAGE0, repository.getId(), path);
 
         assertNotNull(artifactEntry);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -24,7 +24,6 @@ import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 
 import javax.inject.Inject;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -338,28 +337,21 @@ public class ArtifactManagementServiceImplTest
             throws Exception
     {
 
-        String repositoryId = repository1.getId();
+        RepositoryPath artifactRepositoryPath = (RepositoryPath) artifactPath1.normalize();
 
-        String repositoryWithTrashId = repository2.getId();
+        mavenArtifactManagementService.delete(artifactRepositoryPath, true);
 
-        final String artifactPathStr1 = "org/carlspring/strongbox/strongbox-utils/7.0/strongbox-utils-7.0.jar";
-
-        RepositoryPath repositoryPath = (RepositoryPath) artifactPath1.normalize();
-
-        mavenArtifactManagementService.delete(repositoryPath, true);
-
-        assertFalse(new File(getRepositoryBasedir(STORAGE0, repositoryId), artifactPathStr1).exists(),
-                    "Failed to delete artifact during a force delete operation!");
+        assertTrue(Files.notExists(artifactPath1), "Failed to delete artifact during a force delete operation!");
 
         final String artifactPathStr2 = "org/carlspring/strongbox/strongbox-utils/7.2/strongbox-utils-7.2.jar";
 
-        repositoryPath = (RepositoryPath) artifactPath2.normalize();
+        artifactRepositoryPath = (RepositoryPath) artifactPath2.normalize();
 
-        mavenArtifactManagementService.delete(repositoryPath, true);
+        mavenArtifactManagementService.delete(artifactRepositoryPath, true);
 
-        final File repositoryDir = new File(getStorageBasedir(STORAGE0), repositoryWithTrashId + "/.trash");
+        final Path repositoryTrashPath = repositoryPathResolver.resolve(repository2).resolve(".trash");
 
-        assertTrue(new File(repositoryDir, artifactPathStr2).exists(),
+        assertTrue(Files.exists(repositoryTrashPath.resolve(artifactPathStr2)),
                    "Should have moved the artifact to the trash during a force delete operation, " +
                    "when allowsForceDeletion is not enabled!");
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenChecksumServiceTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenChecksumServiceTest.java
@@ -254,25 +254,28 @@ public class MavenChecksumServiceTest
         assertTrue(Files.exists(artifactMetadataMd5),
                    "The checksum file for metadata doesn't exist!");
 
-        OutputStream os1 = Files.newOutputStream(md5File, CREATE_NEW, TRUNCATE_EXISTING);
-        OutputStream os2 = Files.newOutputStream(sha1File, CREATE_NEW, TRUNCATE_EXISTING);
-        OutputStream os3 = Files.newOutputStream(pomMd5, CREATE_NEW, TRUNCATE_EXISTING);
-        OutputStream os4 = Files.newOutputStream(pomSha1, CREATE_NEW, TRUNCATE_EXISTING);
-        OutputStream os5 = Files.newOutputStream(artifactMetadataMd5, CREATE_NEW, TRUNCATE_EXISTING);
-        OutputStream os6 = Files.newOutputStream(artifactMetadataSha1, CREATE_NEW, TRUNCATE_EXISTING);
-
-        os1.write("".getBytes());
-        os1.flush();
-        os2.write("".getBytes());
-        os2.flush();
-        os3.write("".getBytes());
-        os3.flush();
-        os4.write("".getBytes());
-        os4.flush();
-        os5.write("".getBytes());
-        os5.flush();
-        os6.write("".getBytes());
-        os6.flush();
+        try (
+                OutputStream os1 = Files.newOutputStream(md5File, CREATE_NEW, TRUNCATE_EXISTING);
+                OutputStream os2 = Files.newOutputStream(sha1File, CREATE_NEW, TRUNCATE_EXISTING);
+                OutputStream os3 = Files.newOutputStream(pomMd5, CREATE_NEW, TRUNCATE_EXISTING);
+                OutputStream os4 = Files.newOutputStream(pomSha1, CREATE_NEW, TRUNCATE_EXISTING);
+                OutputStream os5 = Files.newOutputStream(artifactMetadataMd5, CREATE_NEW, TRUNCATE_EXISTING);
+                OutputStream os6 = Files.newOutputStream(artifactMetadataSha1, CREATE_NEW, TRUNCATE_EXISTING)
+        )
+        {
+            os1.write("".getBytes());
+            os1.flush();
+            os2.write("".getBytes());
+            os2.flush();
+            os3.write("".getBytes());
+            os3.flush();
+            os4.write("".getBytes());
+            os4.flush();
+            os5.write("".getBytes());
+            os5.flush();
+            os6.write("".getBytes());
+            os6.flush();
+        }
 
         assertEquals(0, Files.size(md5File), "The checksum file for artifact isn't empty!");
         assertEquals(0, Files.size(pomSha1),

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenChecksumServiceTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/MavenChecksumServiceTest.java
@@ -64,8 +64,8 @@ public class MavenChecksumServiceTest
                                                             Repository repository,
                                                             @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
                                                                                id = A1,
-                                                                              versions = { "1.0",
-                                                                                           "2.0" })
+                                                                               versions = { "1.0",
+                                                                                            "2.0" })
                                                             List<Path> artifactGroupPath)
             throws IOException,
                    XmlPullParserException,
@@ -183,7 +183,7 @@ public class MavenChecksumServiceTest
                                                 "org/carlspring/strongbox/checksum");
 
         assertFalse(Files.exists(artifact1Md5),
-                "The checksum file for artifact exist!");
+                    "The checksum file for artifact exist!");
         assertFalse(Files.exists(artifact1Sha1),
                     "The checksum file for artifact exist!");
 
@@ -252,30 +252,27 @@ public class MavenChecksumServiceTest
         assertTrue(Files.exists(artifactMetadataSha1),
                    "The checksum file for metadata doesn't exist!");
         assertTrue(Files.exists(artifactMetadataMd5),
-                "The checksum file for metadata doesn't exist!");
+                   "The checksum file for metadata doesn't exist!");
 
-        try (
-                    OutputStream os1 = Files.newOutputStream(md5File, CREATE_NEW, TRUNCATE_EXISTING);
-                    OutputStream os2 = Files.newOutputStream(sha1File, CREATE_NEW, TRUNCATE_EXISTING);
-                    OutputStream os3 = Files.newOutputStream(pomMd5, CREATE_NEW, TRUNCATE_EXISTING);
-                    OutputStream os4 = Files.newOutputStream(pomSha1, CREATE_NEW, TRUNCATE_EXISTING);
-                    OutputStream os5 = Files.newOutputStream(artifactMetadataMd5, CREATE_NEW, TRUNCATE_EXISTING);
-                    OutputStream os6 = Files.newOutputStream(artifactMetadataSha1, CREATE_NEW, TRUNCATE_EXISTING);
-        )
-        {
-            os1.write("".getBytes());
-            os1.flush();
-            os2.write("".getBytes());
-            os2.flush();
-            os3.write("".getBytes());
-            os3.flush();
-            os4.write("".getBytes());
-            os4.flush();
-            os5.write("".getBytes());
-            os5.flush();
-            os6.write("".getBytes());
-            os6.flush();
-        }
+        OutputStream os1 = Files.newOutputStream(md5File, CREATE_NEW, TRUNCATE_EXISTING);
+        OutputStream os2 = Files.newOutputStream(sha1File, CREATE_NEW, TRUNCATE_EXISTING);
+        OutputStream os3 = Files.newOutputStream(pomMd5, CREATE_NEW, TRUNCATE_EXISTING);
+        OutputStream os4 = Files.newOutputStream(pomSha1, CREATE_NEW, TRUNCATE_EXISTING);
+        OutputStream os5 = Files.newOutputStream(artifactMetadataMd5, CREATE_NEW, TRUNCATE_EXISTING);
+        OutputStream os6 = Files.newOutputStream(artifactMetadataSha1, CREATE_NEW, TRUNCATE_EXISTING);
+
+        os1.write("".getBytes());
+        os1.flush();
+        os2.write("".getBytes());
+        os2.flush();
+        os3.write("".getBytes());
+        os3.flush();
+        os4.write("".getBytes());
+        os4.flush();
+        os5.write("".getBytes());
+        os5.flush();
+        os6.write("".getBytes());
+        os6.flush();
 
         assertEquals(0, Files.size(md5File), "The checksum file for artifact isn't empty!");
         assertEquals(0, Files.size(pomSha1),

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenTestCaseWithArtifactGeneration.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/MavenTestCaseWithArtifactGeneration.java
@@ -10,25 +10,22 @@ import org.carlspring.strongbox.providers.io.LayoutFileSystem;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
-import org.carlspring.strongbox.providers.layout.LayoutProvider;
-import org.carlspring.strongbox.providers.layout.LayoutProviderRegistry;
 import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.repository.HostedRepositoryProvider;
 import org.carlspring.strongbox.repository.MavenRepositoryFeatures;
-import org.carlspring.strongbox.repository.RepositoryManagementStrategy;
 import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
 import org.carlspring.strongbox.services.ConfigurationManagementService;
-import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.MavenRepositoryFactory;
 import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
 import org.carlspring.strongbox.storage.repository.remote.MutableRemoteRepository;
 import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
 
 import javax.inject.Inject;
 import javax.xml.bind.JAXBException;
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.index.artifact.Gav;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 /**
@@ -50,9 +46,6 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 public class MavenTestCaseWithArtifactGeneration
         extends TestCaseWithRepositoryManagement
 {
-
-    @Inject
-    protected LayoutProviderRegistry layoutProviderRegistry;
 
     @Inject
     protected MavenRepositoryFeatures features;
@@ -75,26 +68,6 @@ public class MavenTestCaseWithArtifactGeneration
     @Inject
     protected ConfigurationManager configurationManager;
 
-
-    public MavenArtifact createMavenArtifact(String storageId,
-                                             String repositoryId,
-                                             String groupId,
-                                             String artifactId,
-                                             String version,
-                                             String type)
-    {
-        MavenArtifact artifact = new MavenRepositoryArtifact(groupId,
-                                                             artifactId,
-                                                             version,
-                                                             type);
-
-        RepositoryPath repositoryPath = resolve(getRepositoryBasedir(storageId, repositoryId).getAbsolutePath(),
-                                                artifact);
-
-        artifact.setPath(repositoryPath);
-
-        return artifact;
-    }
 
     public MavenArtifact generateArtifact(String basedir, String gavtc)
             throws IOException,
@@ -195,108 +168,6 @@ public class MavenTestCaseWithArtifactGeneration
         };
     }
 
-    public void generateArtifact(String basedir, String gavtc, String packaging, String... versions)
-            throws IOException,
-                   XmlPullParserException,
-                   NoSuchAlgorithmException
-    {
-        MavenArtifactGenerator generator = createArtifactGenerator(basedir);
-        generator.generate(gavtc, packaging, versions);
-    }
-
-    public void generatePluginArtifact(String basedir, String gavtc, String... versions)
-            throws IOException,
-                   XmlPullParserException,
-                   NoSuchAlgorithmException
-    {
-        MavenArtifactGenerator generator = createArtifactGenerator(basedir);
-        generator.generate(gavtc, "maven-plugin", versions);
-    }
-
-    public InputStream generateArtifactInputStream(String basedir,
-                                                   String repositoryId,
-                                                   String gavtc,
-                                                   boolean useTempDir)
-            throws NoSuchAlgorithmException,
-                   XmlPullParserException,
-                   IOException
-    {
-        File baseDir = new File(basedir + "/" + repositoryId + (useTempDir ? "/.temp" : ""));
-        if (!baseDir.exists())
-        {
-            //noinspection ResultOfMethodCallIgnored
-            baseDir.mkdirs();
-        }
-
-        Artifact artifact = generateArtifact(baseDir.getCanonicalPath(), gavtc);
-
-        return new FileInputStream(new File(baseDir, MavenArtifactUtils.convertArtifactToPath(artifact)));
-    }
-
-    public Artifact createTimestampedSnapshotArtifact(String repositoryBasedir,
-                                                      String groupId,
-                                                      String artifactId,
-                                                      String baseSnapshotVersion)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        return createTimestampedSnapshotArtifact(repositoryBasedir,
-                                                 groupId,
-                                                 artifactId,
-                                                 baseSnapshotVersion,
-                                                 "jar",
-                                                 null,
-                                                 1);
-    }
-
-    public Artifact createTimestampedSnapshotArtifact(String repositoryBasedir,
-                                                      String groupId,
-                                                      String artifactId,
-                                                      String baseSnapshotVersion,
-                                                      int numberOfBuilds)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        return createTimestampedSnapshotArtifact(repositoryBasedir,
-                                                 groupId,
-                                                 artifactId,
-                                                 baseSnapshotVersion,
-                                                 "jar",
-                                                 null,
-                                                 numberOfBuilds);
-    }
-
-    public MavenArtifact createTimestampedSnapshotArtifact(String repositoryBasedir,
-                                                           String groupId,
-                                                           String artifactId,
-                                                           String baseSnapshotVersion,
-                                                           String[] classifiers)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        return createTimestampedSnapshotArtifact(repositoryBasedir,
-                                                 groupId,
-                                                 artifactId,
-                                                 baseSnapshotVersion,
-                                                 "jar",
-                                                 classifiers,
-                                                 1);
-    }
-
-    public MavenArtifact createTimestampedSnapshotArtifact(String repositoryBasedir,
-                                                           String groupId,
-                                                           String artifactId,
-                                                           String baseSnapshotVersion,
-                                                           String packaging,
-                                                           String[] classifiers)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        return createTimestampedSnapshotArtifact(repositoryBasedir,
-                                                 groupId,
-                                                 artifactId,
-                                                 baseSnapshotVersion,
-                                                 packaging,
-                                                 classifiers,
-                                                 1);
-    }
-
     public MavenArtifact createTimestampedSnapshotArtifact(String repositoryBasedir,
                                                            String groupId,
                                                            String artifactId,
@@ -352,21 +223,19 @@ public class MavenTestCaseWithArtifactGeneration
         return repositoryPath;
     }
 
-    public MavenArtifact createTimestampedSnapshot(String repositoryBasedir,
-                                                   String groupId,
-                                                   String artifactId,
-                                                   String baseSnapshotVersion,
-                                                   String packaging,
-                                                   String[] classifiers,
-                                                   int numberOfBuild,
-                                                   String timestamp)
+    public void createTimestampedSnapshot(String repositoryBasedir,
+                                          String groupId,
+                                          String artifactId,
+                                          String baseSnapshotVersion,
+                                          String packaging,
+                                          String[] classifiers,
+                                          int numberOfBuild,
+                                          String timestamp)
             throws NoSuchAlgorithmException, XmlPullParserException, IOException
     {
-        MavenArtifact artifact;
-
         String version = createSnapshotVersion(baseSnapshotVersion, numberOfBuild, timestamp);
 
-        artifact = new MavenRepositoryArtifact(groupId, artifactId, version, packaging);
+        MavenArtifact artifact = new MavenRepositoryArtifact(groupId, artifactId, version, packaging);
         RepositoryPath repositoryPath = resolve(repositoryBasedir, artifact);
         artifact.setPath(repositoryPath);
 
@@ -380,9 +249,6 @@ public class MavenTestCaseWithArtifactGeneration
                 generateArtifact(repositoryBasedir, MavenArtifactTestUtils.getArtifactFromGAVTC(gavtc));
             }
         }
-
-        // Return the main artifact
-        return artifact;
     }
 
     public String createSnapshotVersion(String baseSnapshotVersion, int buildNumber)
@@ -408,52 +274,6 @@ public class MavenTestCaseWithArtifactGeneration
         String version = baseSnapshotVersion + "-" + timestamp + "-" + buildNumber;
 
         return version;
-    }
-
-    /**
-     * Generate a couple of testing artifacts for a specific snapshot (i.e. javadoc, sources, etc)
-     *
-     * @param repositoryBasedir String
-     * @param gavt String
-     * @throws NoSuchAlgorithmException
-     * @throws XmlPullParserException
-     * @throws IOException
-     */
-    public Artifact createSnapshot(String repositoryBasedir, String gavt)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        Artifact snapshot = MavenArtifactTestUtils.getArtifactFromGAVTC(gavt);
-        snapshot.setFile(new File(repositoryBasedir + "/" + MavenArtifactUtils.convertArtifactToPath(snapshot)));
-
-        generateArtifact(repositoryBasedir, snapshot);
-
-        return snapshot;
-    }
-
-    /**
-     * Generate a couple of testing artifacts for a specific snapshot (i.e. javadoc, sources, etc)
-     *
-     * @param repositoryBasedir String
-     * @param gavt String
-     * @throws NoSuchAlgorithmException
-     * @throws XmlPullParserException
-     * @throws IOException
-     */
-    public Artifact createSnapshot(String repositoryBasedir, String gavt, String[] classifiers)
-            throws NoSuchAlgorithmException, XmlPullParserException, IOException
-    {
-        Artifact snapshot = MavenArtifactTestUtils.getArtifactFromGAVTC(gavt);
-        snapshot.setFile(new File(repositoryBasedir + "/" + MavenArtifactUtils.convertArtifactToPath(snapshot)));
-
-        generateArtifact(repositoryBasedir, snapshot);
-
-        for (String classifier : classifiers)
-        {
-            generateArtifact(repositoryBasedir, MavenArtifactTestUtils.getArtifactFromGAVTC(gavt + ":" + classifier));
-
-        }
-
-        return snapshot;
     }
 
     public void changeCreationDate(MavenArtifact artifact)
@@ -487,17 +307,6 @@ public class MavenTestCaseWithArtifactGeneration
     public MavenRepositoryFeatures getFeatures()
     {
         return features;
-    }
-
-    public RepositoryManagementStrategy getManagementStrategy(String storageId,
-                                                              String repositoryId)
-    {
-        Storage storage = getConfiguration().getStorage(storageId);
-        Repository repository = storage.getRepository(repositoryId);
-
-        LayoutProvider layoutProvider = layoutProviderRegistry.getProvider(repository.getLayout());
-
-        return layoutProvider.getRepositoryManagementStrategy();
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithMavenArtifactGenerationAndIndexing.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/TestCaseWithMavenArtifactGenerationAndIndexing.java
@@ -7,7 +7,6 @@ import org.carlspring.strongbox.locator.handlers.GenerateMavenMetadataOperation;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RootRepositoryPath;
-import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
 import org.carlspring.strongbox.providers.search.MavenIndexerSearchProvider;
 import org.carlspring.strongbox.providers.search.SearchException;
 import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
@@ -34,12 +33,10 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -60,6 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author carlspring
+ * @author Pablo Tirado
  */
 public abstract class TestCaseWithMavenArtifactGenerationAndIndexing
         extends MavenTestCaseWithArtifactGeneration
@@ -90,53 +88,6 @@ public abstract class TestCaseWithMavenArtifactGenerationAndIndexing
     @Inject
     private MavenRepositoryFactory mavenRepositoryFactory;
 
-
-    protected RepositoryDto createRepository(String storageId,
-                                             String repositoryId,
-                                             String policy,
-                                             boolean indexing)
-        throws IOException,
-        JAXBException,
-        RepositoryManagementStrategyException
-    {
-        MavenRepositoryConfigurationDto repositoryConfiguration = new MavenRepositoryConfigurationDto();
-        repositoryConfiguration.setIndexingEnabled(indexing);
-
-        return createRepository(storageId, repositoryId, policy, repositoryConfiguration);
-    }
-
-    protected RepositoryDto createRepository(String storageId,
-                                             String repositoryId,
-                                             String policy,
-                                             MavenRepositoryConfigurationDto repositoryConfiguration)
-            throws IOException,
-                   JAXBException,
-                   RepositoryManagementStrategyException
-    {
-        RepositoryDto repository = mavenRepositoryFactory.createRepository(repositoryId);
-        repository.setPolicy(policy);
-        repository.setRepositoryConfiguration(repositoryConfiguration);
-        repository.setBasedir(getRepositoryBasedir(storageId, repositoryId).getAbsolutePath());
-        
-        createRepository(storageId, repository);
-        
-        return repository;
-    }
-
-    protected RepositoryDto createGroup(String storageId,
-                                        String repositoryId,
-                                        String... leafs)
-            throws Exception
-    {
-        RepositoryDto repository = new RepositoryDto(repositoryId);
-        repository.setLayout(Maven2LayoutProvider.ALIAS);
-        repository.setType(RepositoryTypeEnum.GROUP.getType());
-        repository.setGroupRepositories(Sets.newLinkedHashSet(Arrays.asList(leafs)));
-
-        createRepository(storageId, repository);
-
-        return repository;
-    }
 
     @Override
     public void createProxyRepository(String storageId,


### PR DESCRIPTION
# Pull Request Description

This fixes issue #1165.

Fixed and migrated tests:
* [x] `org.carlspring.strongbox.services.ConfigurationManagementServiceImplTest`
* [x] `org.carlspring.strongbox.services.ArtifactSearchServiceImplTest`
* [x] `org.carlspring.strongbox.services.ArtifactMetadataServiceSnapshotsTest`
* [x] `org.carlspring.strongbox.services.ArtifactManagementServiceImplTest` 
* [x] `org.carlspring.strongbox.services.MavenRepositoryManagementServiceImplTest`
* [x] `org.carlspring.strongbox.services.MavenChecksumServiceTest`
* [x] `org.carlspring.strongbox.services.ArtifactMetadataServiceReleasesTest`
* [x] `org.carlspring.strongbox.artifact.generation.MavenArtifactGeneratorTest`
* [x] `org.carlspring.strongbox.artifact.locator.ArtifactDirectoryLocatorTest`
* [x] `org.carlspring.strongbox.io.ArtifactOutputStreamTest`
* [x] `org.carlspring.strongbox.repository.group.BaseMavenGroupRepositoryComponentTest`
* [x] `org.carlspring.strongbox.repository.group.index.BaseMavenIndexGroupRepositoryComponentTest`
* [x] `org.carlspring.strongbox.repository.group.index.MavenIndexGroupRepositoryComponentOnDeleteTest`
* [x] `org.carlspring.strongbox.repository.group.index.MavenIndexGroupRepositoryComponentOnCreateTest`
* [x] `org.carlspring.strongbox.repository.group.metadata.MavenMetadataGroupRepositoryComponentOnUploadTest`
* [x] `org.carlspring.strongbox.repository.group.metadata.MavenMetadataGroupRepositoryComponentOnAddTest`
* [x] `org.carlspring.strongbox.repository.group.metadata.MavenMetadataGroupRepositoryComponentOnDeleteTest`
* [x] `org.carlspring.strongbox.storage.validation.DefaultMavenArtifactCoordinateValidatorsTest`
* [x] `org.carlspring.strongbox.providers.io.BaseMavenMetadataExpirationTest`
* [x] `org.carlspring.strongbox.providers.io.MavenMetadataExpirationProxyCaseTest`
* [x] `org.carlspring.strongbox.providers.io.MavenMetadataExpirationSingleGroupCaseTest` 
* [x] `org.carlspring.strongbox.providers.io.MavenMetadataExpirationMultipleGroupCaseTest`
* [x] `org.carlspring.strongbox.testing.TestCaseWithMavenArtifactGenerationAndIndexing`
* [x] `org.carlspring.strongbox.testing.MavenTestCaseWithArtifactGeneration`

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
