### PR TITLE
Fix MacOS failure in StrongboxIndexerTest

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -215,7 +215,14 @@ public class TestArtifactContext implements AutoCloseable
 
         Files.delete(e.getValue());
     }
-    
+
+    /**
+     * This comparator will sort the paths in reverse alphabetical order, with
+     * checksum files ordered after other types of files.  This is necessary because
+     * Apache Maven Indexer's MinimalArtifactInfoIndexCreator will apply the checksum
+     * from a JAR file to the POM's entry in the index if the JAR file is added to the
+     * repository before the POM.
+     */
     private int repositoryPathChecksumComparator(RepositoryPath p1,
                                                  RepositoryPath p2)
             throws IOException
@@ -224,11 +231,11 @@ public class TestArtifactContext implements AutoCloseable
         Boolean isChecksumP2;
 
         isChecksumP1 = RepositoryFiles.isChecksum(p1);
-        isChecksumP2 = RepositoryFiles.isChecksum(p1);
+        isChecksumP2 = RepositoryFiles.isChecksum(p2);
         
-        if (isChecksumP1 && isChecksumP2)
+        if (isChecksumP1 && isChecksumP2 || !isChecksumP1 && !isChecksumP2)
         {
-            return p1.compareTo(p2);
+            return -1 * p1.compareTo(p2);
         }
         
         return isChecksumP1 ? 1 : -1;


### PR DESCRIPTION
# Pull Request Description

This fixes two failures in `StrongboxIndexerTest` on MacOS with APFS filesystem (our Travis-CI build hosts run HFS+).  The issue causing the failures is complex:

- The class `MinimalArtifactInfoIndexCreator` (https://github.com/apache/maven-indexer/blob/master/indexer-core/src/main/java/org/apache/maven/index/creator/MinimalArtifactInfoIndexCreator.java) in Apache's maven-indexer will associate the checksums from a Java artifact with the POM entry in the index if the Java artifact/checksum exist when the POM is added to the index.  I'm uncertain at this point whether this is intended behavior, but it does not seem to have changed recently.
- The comparator `TestArtifactContext.repositoryPathChecksumComparator` appears to have been implemented incorrectly.  Depending on the order in which paths are added to a collection, sorting using this comparator can yield different results.
- The order in which repository paths are added to the TreeMap in `TestArtifactContext.deployArtifact()` is determined by `Files.newDirectoryStream()` from the JRE, which does not guarantee any particular order.
- On Macs running APFS, the files are returned in an order such that the existing comparator will sort the JAR file ahead of the POM file, triggering the unexpected behavior.
- `StrongboxIndexerTest.indexerShouldBeCapableToSearchByFullSha1Hash` and `StrongboxIndexerTest.indexerShouldBeCapableToSearchByPartialSha1Hash` both fail because they return 2 total hits instead of the expected 1.  One of the hits comes from the POM file, the other comes 
from the JAR file.  This is because both index entries end up with the SHA1 hash that was originally generated from the JAR file.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
