### PR TITLE
Issue-1409 Move the `wrapper.conf` file into `etc` instead of `etc/conf`

### DIFF
--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -211,7 +211,7 @@
                 <configuration>
                     <preWrapperConf>${project.basedir}/src/main/resources/setenv.conf</preWrapperConf>
                     
-                    <configurationDirectory>conf</configurationDirectory>
+                    <configurationDirectory>etc</configurationDirectory>
 
                     <repositoryLayout>flat</repositoryLayout>
                     <assembleDirectory>target/generated-resources/appassembler/jsw/strongbox</assembleDirectory>
@@ -219,8 +219,6 @@
                     <binFileExtensions>
                         <unix>.sh</unix>
                     </binFileExtensions>
-
-                    <configurationDirectory>etc/conf</configurationDirectory>
 
                     <!-- This otherwise causes all the direct and transitive dependencies to be copied under
                          ${dir.strongbox.standalone}/lib, completely unaware of the fact that all the required


### PR DESCRIPTION
# Pull Request Description

This fixes issue #1409 

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [X] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [X] No
