### PR TITLE
Issue-950: Make the strongbox-storage-api's tests work in parallel

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
@@ -29,12 +29,14 @@ import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -43,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(ExecutionMode.SAME_THREAD)
+@Execution(CONCURRENT)
 public class ConfigurationManagerTest
 {
 
@@ -71,10 +73,10 @@ public class ConfigurationManagerTest
     public void setUp()
             throws IOException
     {
-        Path yamlDir = Paths.get(CONFIGURATION_BASEDIR);
-        if (Files.notExists(yamlDir))
+        Path yamlPath = Paths.get(CONFIGURATION_BASEDIR);
+        if (Files.notExists(yamlPath))
         {
-            Files.createDirectories(yamlDir);
+            Files.createDirectories(yamlPath);
         }
 
         yamlMapper = yamlMapperFactory.create(

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/configuration/ConfigurationManagerTest.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,7 +35,6 @@ import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -44,8 +42,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class ConfigurationManagerTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/io/RepositoryPathTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/io/RepositoryPathTest.java
@@ -12,16 +12,13 @@ import java.util.Set;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
  * @author Pablo Tirado
  */
-@Execution(CONCURRENT)
 public class RepositoryPathTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/io/RepositoryPathTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/io/RepositoryPathTest.java
@@ -1,28 +1,31 @@
 package org.carlspring.strongbox.providers.io;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.carlspring.strongbox.booters.PropertiesBooter;
+import org.carlspring.strongbox.storage.repository.RepositoryData;
+import org.carlspring.strongbox.storage.repository.RepositoryDto;
 
-import java.io.File;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 
-import org.carlspring.strongbox.booters.PropertiesBooter;
-import org.carlspring.strongbox.storage.repository.RepositoryData;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
+ * @author Pablo Tirado
  */
+@Execution(CONCURRENT)
 public class RepositoryPathTest
 {
 
-    private static final Path REPOSITORY_BASEDIR = Paths.get(new File("target/strongbox-vault/storages/storage0/releases").getAbsolutePath());
+    private static final Path REPOSITORY_BASEDIR = Paths.get("target/strongbox-vault/storages/storage0/releases").toAbsolutePath();
 
     private RepositoryDto repository;
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProviderTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProviderTest.java
@@ -46,8 +46,8 @@ import static org.mockito.ArgumentMatchers.any;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 class AbstractLayoutProviderTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProviderTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProviderTest.java
@@ -1,18 +1,5 @@
 package org.carlspring.strongbox.providers.layout;
 
-import static org.mockito.ArgumentMatchers.any;
-
-import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.spi.FileSystemProvider;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Inject;
-
 import org.carlspring.strongbox.StorageApiTestConfig;
 import org.carlspring.strongbox.artifact.coordinates.AbstractArtifactCoordinates;
 import org.carlspring.strongbox.booters.PropertiesBooter;
@@ -26,6 +13,17 @@ import org.carlspring.strongbox.services.RepositoryArtifactIdGroupService;
 import org.carlspring.strongbox.storage.StorageDto;
 import org.carlspring.strongbox.storage.repository.RepositoryData;
 import org.carlspring.strongbox.storage.repository.RepositoryDto;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -40,6 +38,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * @author Przemyslaw Fusik
@@ -48,6 +47,7 @@ import org.springframework.test.context.TestExecutionListeners;
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+
 class AbstractLayoutProviderTest
 {
 
@@ -121,19 +121,20 @@ class AbstractLayoutProviderTest
         Set<ArtifactGroupEntry> artifactGroups = layoutProvider.getArtifactGroups(path);
         MatcherAssert.assertThat(artifactGroups, Matchers.notNullValue());
         MatcherAssert.assertThat(artifactGroups.size(), CoreMatchers.equalTo(0));
-        
-        ArtifactGroupEntry artifactGroup = artifactGroupService.findOneOrCreate("storage0", "releases", "abs-lay-prov-test");
-        
+
+        RepositoryArtifactIdGroupEntry repositoryArtifactIdGroup = artifactGroupService.findOneOrCreate("storage0",
+                                                                                                        "releases",
+                                                                                                        "abs-lay-prov-test");
+
         artifactGroups = layoutProvider.getArtifactGroups(path);
         MatcherAssert.assertThat(artifactGroups, Matchers.notNullValue());
         MatcherAssert.assertThat(artifactGroups.size(), CoreMatchers.equalTo(1));
-        MatcherAssert.assertThat(artifactGroups.iterator().next(), Matchers.equalTo(artifactGroup));
-        MatcherAssert.assertThat(artifactGroup, CoreMatchers.instanceOf(RepositoryArtifactIdGroupEntry.class));
-        RepositoryArtifactIdGroupEntry repositoryArtifactIdGroup = (RepositoryArtifactIdGroupEntry) artifactGroup;
+        MatcherAssert.assertThat(artifactGroups.iterator().next(), Matchers.equalTo(repositoryArtifactIdGroup));
+        MatcherAssert.assertThat(repositoryArtifactIdGroup, CoreMatchers.instanceOf(RepositoryArtifactIdGroupEntry.class));
         MatcherAssert.assertThat(repositoryArtifactIdGroup.getArtifactId(), CoreMatchers.equalTo("abs-lay-prov-test"));
         MatcherAssert.assertThat(repositoryArtifactIdGroup.getRepositoryId(), CoreMatchers.equalTo("releases"));
         MatcherAssert.assertThat(repositoryArtifactIdGroup.getStorageId(), CoreMatchers.equalTo("storage0"));
-        MatcherAssert.assertThat(artifactGroup.getClass(), CoreMatchers.equalTo(RepositoryArtifactIdGroupEntry.class));
+        MatcherAssert.assertThat(repositoryArtifactIdGroup.getClass(), CoreMatchers.equalTo(RepositoryArtifactIdGroupEntry.class));
     }
     
     private class StorageFileSystemProviderTest extends LayoutFileSystemProvider
@@ -153,7 +154,6 @@ class AbstractLayoutProviderTest
         @Override
         protected Map<RepositoryFileAttributeType, Object> getRepositoryFileAttributes(RepositoryPath repositoryRelativePath,
                                                                                        RepositoryFileAttributeType... attributeTypes)
-            throws IOException
         {
             return null;
         }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.parallel.Execution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * Functional test and usage example scenarios for {@link ArtifactEntryService}.
@@ -51,7 +49,6 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
 public class ArtifactEntryServiceTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -1,22 +1,5 @@
 package org.carlspring.strongbox.services.impl;
 
-import static org.carlspring.strongbox.services.support.ArtifactEntrySearchCriteria.Builder.anArtifactEntrySearchCriteria;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
-import org.apache.commons.lang3.time.DateUtils;
 import org.carlspring.strongbox.StorageApiTestConfig;
 import org.carlspring.strongbox.artifact.coordinates.AbstractArtifactCoordinates;
 import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
@@ -25,92 +8,127 @@ import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
 import org.carlspring.strongbox.data.service.support.search.PagingCriteria;
 import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.services.ArtifactEntryService;
+
+import javax.inject.Inject;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.time.DateUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.util.CollectionUtils;
+import static org.carlspring.strongbox.services.support.ArtifactEntrySearchCriteria.Builder.anArtifactEntrySearchCriteria;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * Functional test and usage example scenarios for {@link ArtifactEntryService}.
  *
  * @author Alex Oreshkevich
+ * @author Pablo Tirado
  * @see https://dev.carlspring.org/youtrack/issue/SB-711
  */
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(ExecutionMode.SAME_THREAD)
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@Execution(CONCURRENT)
 public class ArtifactEntryServiceTest
 {
 
     private static final Logger logger = LoggerFactory.getLogger(ArtifactEntryServiceTest.class);
 
-    final String storageId = "storage0";
+    private final String STORAGE_ID = "storage0";
 
-    final String repositoryId = "aest";
+    private final String REPOSITORY_ID = "aest";
 
-    final String groupId = "org.carlspring.strongbox.aest";
+    private final String GROUP_ID = "org.carlspring.strongbox.aest";
 
-    final String artifactId = "coordinates-test";
-
-    @Inject
-    ArtifactEntryService artifactEntryService;
+    private final String ARTIFACT_ID = "coordinates-test";
 
     @Inject
-    ArtifactCoordinatesService artifactCoordinatesService;
+    private ArtifactEntryService artifactEntryService;
+
+    @Inject
+    private  ArtifactCoordinatesService artifactCoordinatesService;
 
     @BeforeEach
-    public void setup() {
-        createArtifacts(groupId, artifactId, storageId, repositoryId);
+    public void setup(TestInfo testInfo) {
+
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        createArtifacts(groupId,
+                        ARTIFACT_ID,
+                        STORAGE_ID,
+                        REPOSITORY_ID);
         
-        displayAllEntries();
+        displayAllEntries(groupId);
+    }
+
+    private String getGroupId(String groupId,
+                              TestInfo testInfo)
+    {
+        Assumptions.assumeTrue(testInfo.getTestMethod().isPresent());
+        String methodName = testInfo.getTestMethod().get().getName();
+        return groupId + "." + methodName;
     }
     
     @AfterEach
-    public void cleanup() {
-        List<ArtifactEntry> artifactEntries = findAll();
-        artifactEntries.forEach(e -> e.getCreated());
+    public void cleanup(TestInfo testInfo) {
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        List<ArtifactEntry> artifactEntries = findAll(groupId);
         List<AbstractArtifactCoordinates> artifactCoordinates = artifactEntries.stream()
                                                                                .map(e -> (AbstractArtifactCoordinates) e.getArtifactCoordinates())
                                                                                .collect(Collectors.toList());
         artifactEntryService.delete(artifactEntries);
         artifactCoordinatesService.delete(artifactCoordinates);
         
-        displayAllEntries();
+        displayAllEntries(groupId);
     }
 
-    protected List<ArtifactEntry> findAll()
+    private List<ArtifactEntry> findAll(final String groupId)
     {
         HashMap<String, String> coordinates = new HashMap<>();
         coordinates.put("path", String.format("%s", groupId));
-        List<ArtifactEntry> artifactEntries = new ArrayList<ArtifactEntry>(artifactEntryService.findArtifactList(null, null, coordinates, false));
-        return artifactEntries;
+        return artifactEntryService.findArtifactList(null, null, coordinates, false);
     }
     
-    protected int count() {
-        return findAll().size();
+    protected int count(final String groupId) {
+        return findAll(groupId).size();
     }
     
     @Test
-    public void saveEntityShouldWork()
+    public void saveEntityShouldWork(TestInfo testInfo)
     {
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
         ArtifactEntry artifactEntry = new ArtifactEntry();
-        artifactEntry.setStorageId(storageId);
-        artifactEntry.setRepositoryId(repositoryId);
-        artifactEntry.setArtifactCoordinates(new NullArtifactCoordinates(String.format("%s/%s/%s/%s",
-                                                                                       groupId,
-                                                                                       artifactId + "1234",
-                                                                                       "1.2.3",
-                                                                                       "jar")));
+        artifactEntry.setStorageId(STORAGE_ID);
+        artifactEntry.setRepositoryId(REPOSITORY_ID);
+        artifactEntry.setArtifactCoordinates(createArtifactCoordinates(groupId,
+                                                                       ARTIFACT_ID + "1234",
+                                                                       "1.2.3",
+                                                                       "jar"));
 
         assertThat(artifactEntry.getCreated(), CoreMatchers.nullValue());
 
@@ -127,138 +145,149 @@ public class ArtifactEntryServiceTest
     }
 
     @Test
-    public void cascadeUpdateShouldWork()
+    public void cascadeUpdateShouldWork(TestInfo testInfo)
     {
-        Optional<ArtifactEntry> artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
-                                                                                                                 repositoryId,
-                                                                                                                 "org.carlspring.strongbox.aest/coordinates-test123/1.2.3/jar"));
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        ArtifactCoordinates jarCoordinates = createArtifactCoordinates(groupId, ARTIFACT_ID + "123", "1.2.3", "jar");
+        ArtifactCoordinates pomCoordinates = createArtifactCoordinates(groupId, ARTIFACT_ID + "123", "1.2.3", "pom");
+
+        Optional<ArtifactEntry> artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(STORAGE_ID,
+                                                                                                                 REPOSITORY_ID,
+                                                                                                                 jarCoordinates.toPath()));
 
         assertTrue(artifactEntryOptional.isPresent());
 
         ArtifactEntry artifactEntry = artifactEntryOptional.get();
         assertThat(artifactEntry.getArtifactCoordinates(), CoreMatchers.notNullValue());
-        assertEquals("org.carlspring.strongbox.aest/coordinates-test123/1.2.3/jar",
-                     artifactEntry.getArtifactCoordinates().toPath());
+        assertEquals(jarCoordinates.toPath(), artifactEntry.getArtifactCoordinates().toPath());
 
         //Simple field update
-        artifactEntry.setRepositoryId(repositoryId + "abc");
+        artifactEntry.setRepositoryId(REPOSITORY_ID + "abc");
         artifactEntry = save(artifactEntry);
 
-        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId, repositoryId,
-                                                                                         "org.carlspring.strongbox.aest/coordinates-test123/1.2.3/jar"));
+        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(STORAGE_ID,
+                                                                                         REPOSITORY_ID,
+                                                                                         jarCoordinates.toPath()));
         assertFalse(artifactEntryOptional.isPresent());
 
-        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
-                                                                                         repositoryId + "abc",
-                                                                                         "org.carlspring.strongbox.aest/coordinates-test123/1.2.3/jar"));
+        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(STORAGE_ID,
+                                                                                         REPOSITORY_ID + "abc",
+                                                                                         jarCoordinates.toPath()));
         assertTrue(artifactEntryOptional.isPresent());
 
         //Cascade field update
         NullArtifactCoordinates nullArtifactCoordinates = (NullArtifactCoordinates)artifactEntry.getArtifactCoordinates();
-        nullArtifactCoordinates.setId("org.carlspring.strongbox.aest/coordinates-test123/1.2.3/pom");
+        nullArtifactCoordinates.setId(pomCoordinates.toPath());
         save(artifactEntry);
 
-        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
-                                                                                         repositoryId + "abc",
-                                                                                         "org.carlspring.strongbox.aest/coordinates-test123/1.2.3/jar"));
+        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(STORAGE_ID,
+                                                                                         REPOSITORY_ID + "abc",
+                                                                                         jarCoordinates.toPath()));
         assertFalse(artifactEntryOptional.isPresent());
 
-        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(storageId,
-                                                                                         repositoryId + "abc",
-                                                                                         "org.carlspring.strongbox.aest/coordinates-test123/1.2.3/pom"));
+        artifactEntryOptional = Optional.ofNullable(artifactEntryService.findOneArtifact(STORAGE_ID,
+                                                                                         REPOSITORY_ID + "abc",
+                                                                                         pomCoordinates.toPath()));
         assertTrue(artifactEntryOptional.isPresent());
 
     }
 
     private ArtifactEntry save(ArtifactEntry artifactEntry)
     {
-        ArtifactEntry result = artifactEntryService.save(artifactEntry);
-        
-        return result;
+        return artifactEntryService.save(artifactEntry);
     }
     
     @Test
-    public void searchBySizeShouldWork()
-            throws Exception
+    public void searchBySizeShouldWork(TestInfo testInfo)
     {
-        int all = count();
-        updateArtifactAttributes();
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        int all = count(groupId);
+        updateArtifactAttributes(groupId);
 
         List<ArtifactEntry> entries = artifactEntryService.findMatching(anArtifactEntrySearchCriteria()
-                                                                                                       .withMinSizeInBytes(500l)
-                                                                                                       .build(),
+                                                                                .withMinSizeInBytes(500L)
+                                                                                .build(),
                                                                         PagingCriteria.ALL)
                                                           .stream()
-                                                          .filter(e -> e.getRepositoryId().equals(repositoryId))
+                                                          .filter(e -> e.getArtifactCoordinates().getId().startsWith(
+                                                                  groupId))
                                                           .collect(Collectors.toList());
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
 
     @Test
-    public void searchByLastUsedShouldWork()
-            throws Exception
+    public void searchByLastUsedShouldWork(TestInfo testInfo)
     {
-        int all = count();
-        updateArtifactAttributes();
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        int all = count(groupId);
+        updateArtifactAttributes(groupId);
 
         List<ArtifactEntry> entries = artifactEntryService.findMatching(anArtifactEntrySearchCriteria()
-                                                                                                       .withLastAccessedTimeInDays(5)
-                                                                                                       .build(),
+                                                                                .withLastAccessedTimeInDays(5)
+                                                                                .build(),
                                                                         PagingCriteria.ALL)
                                                           .stream()
-                                                          .filter(e -> e.getRepositoryId().equals(repositoryId))
+                                                          .filter(e -> e.getArtifactCoordinates().getId().startsWith(
+                                                                  groupId))
                                                           .collect(Collectors.toList());
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
 
     @Test
-    public void deleteAllShouldWork()
-            throws Exception
+    public void deleteAllShouldWork(TestInfo testInfo)
     {
-        int all = count();
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        int all = count(groupId);
         assertThat(all, CoreMatchers.equalTo(3));
 
-        List<ArtifactEntry> artifactEntries = findAll();
+        List<ArtifactEntry> artifactEntries = findAll(groupId);
         int removed = artifactEntryService.delete(artifactEntries);
         assertThat(removed, CoreMatchers.equalTo(all));
 
-        int left = count();
+        int left = count(groupId);
         assertThat(left, CoreMatchers.equalTo(0));
-        assertTrue(findAll().isEmpty());
+        assertTrue(findAll(groupId).isEmpty());
     }
 
     @Test
-    public void deleteButNotAllShouldWork()
-            throws Exception
+    public void deleteButNotAllShouldWork(TestInfo testInfo)
     {
-        int all = count();
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        int all = count(groupId);
         assertThat(all, CoreMatchers.equalTo(3));
 
-        List<ArtifactEntry> artifactEntries = findAll();
+        List<ArtifactEntry> artifactEntries = findAll(groupId);
         artifactEntries.remove(0);
         int removed = artifactEntryService.delete(artifactEntries);
         assertThat(removed, CoreMatchers.equalTo(all - 1));
 
-        int left = count();
+        int left = count(groupId);
         assertThat(left, CoreMatchers.equalTo(1));
     }
 
     @Test
-    public void searchByLastUsedAndBySizeShouldWork()
-            throws Exception
+    public void searchByLastUsedAndBySizeShouldWork(TestInfo testInfo)
     {
-        int all = count();
-        updateArtifactAttributes();
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        int all = count(groupId);
+        updateArtifactAttributes(groupId);
 
         List<ArtifactEntry> entries = artifactEntryService.findMatching(anArtifactEntrySearchCriteria()
-                                                                                                       .withMinSizeInBytes(500l)
-                                                                                                       .withLastAccessedTimeInDays(5)
-                                                                                                       .build(),
+                                                                                .withMinSizeInBytes(500L)
+                                                                                .withLastAccessedTimeInDays(5)
+                                                                                .build(),
                                                                         PagingCriteria.ALL)
                                                           .stream()
-                                                          .filter(e -> e.getRepositoryId().equals(repositoryId))
+                                                          .filter(e -> e.getArtifactCoordinates().getId().startsWith(
+                                                                  groupId))
                                                           .collect(Collectors.toList());
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
@@ -267,18 +296,21 @@ public class ArtifactEntryServiceTest
     /**
      * Make sure that we are able to search artifacts by single coordinate.
      *
-     * @throws Exception
      */
     @Test
-    public void searchBySingleCoordinate()
-            throws Exception
+    public void searchBySingleCoordinate(TestInfo testInfo)
     {
-        logger.debug("There are a total of " + count() + " artifacts.");
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        logger.debug("There are a total of {} artifacts.", count(groupId));
 
         // prepare search query key (coordinates)
         NullArtifactCoordinates coordinates = new NullArtifactCoordinates(groupId + "/");
 
-        List<ArtifactEntry> artifactEntries = artifactEntryService.findArtifactList(storageId, repositoryId, coordinates.getCoordinates(), false);
+        List<ArtifactEntry> artifactEntries = artifactEntryService.findArtifactList(STORAGE_ID,
+                                                                                    REPOSITORY_ID,
+                                                                                    coordinates.getCoordinates(),
+                                                                                    false);
 
         assertNotNull(artifactEntries);
         assertFalse(artifactEntries.isEmpty());
@@ -286,8 +318,9 @@ public class ArtifactEntryServiceTest
 
         artifactEntries.forEach(artifactEntry ->
                                 {
-                                    logger.debug("Found artifact " + artifactEntry);
-                                    assertTrue(((NullArtifactCoordinates)artifactEntry.getArtifactCoordinates()).getPath().startsWith(groupId + "/"));
+                                    logger.debug("Found artifact {}", artifactEntry);
+                                    assertTrue(((NullArtifactCoordinates)artifactEntry.getArtifactCoordinates()).getPath().startsWith(
+                                            groupId + "/"));
                                 });
     }
 
@@ -295,15 +328,19 @@ public class ArtifactEntryServiceTest
      * Make sure that we are able to search artifacts by two coordinates that need to be joined with logical AND operator.
      */
     @Test
-    public void searchByTwoCoordinate()
-            throws Exception
+    public void searchByTwoCoordinate(TestInfo testInfo)
     {
-        logger.debug("There are a total of " + count() + " artifacts.");
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        logger.debug("There are a total of {} artifacts.", count(groupId));
 
         // prepare search query key (coordinates)
-        NullArtifactCoordinates c1 = new NullArtifactCoordinates(groupId + "/" + artifactId + "/");
+        NullArtifactCoordinates c1 = new NullArtifactCoordinates(groupId + "/" + ARTIFACT_ID + "/");
 
-        List<ArtifactEntry> result = artifactEntryService.findArtifactList(storageId, repositoryId, c1.getCoordinates(), false);
+        List<ArtifactEntry> result = artifactEntryService.findArtifactList(STORAGE_ID,
+                                                                           REPOSITORY_ID,
+                                                                           c1.getCoordinates(),
+                                                                           false);
         assertNotNull(result);
         assertFalse(result.isEmpty());
 
@@ -311,62 +348,70 @@ public class ArtifactEntryServiceTest
 
         result.forEach(artifactEntry ->
                        {
-                           logger.debug("Found artifact " + artifactEntry);
-                           assertTrue(((NullArtifactCoordinates)artifactEntry.getArtifactCoordinates()).getPath().startsWith(groupId + "/" + artifactId));
+                           logger.debug("Found artifact {}", artifactEntry);
+                           assertTrue(((NullArtifactCoordinates)artifactEntry.getArtifactCoordinates()).getPath().startsWith(
+                                   groupId + "/" + ARTIFACT_ID));
                        });
 
-        Long c = artifactEntryService.countArtifacts(storageId, repositoryId, c1.getCoordinates(), false);
+        Long c = artifactEntryService.countArtifacts(STORAGE_ID, REPOSITORY_ID, c1.getCoordinates(), false);
         assertEquals(Long.valueOf(1), c);
     }
 
-    public void displayAllEntries()
+    private void displayAllEntries(final String groupId)
     {
-        List<ArtifactEntry> result = findAll();
-        if (result == null || result.isEmpty())
+        List<ArtifactEntry> result = findAll(groupId);
+        if (CollectionUtils.isEmpty(result))
         {
             logger.debug("Artifact repository is empty");
         }
-
-        result.forEach(artifactEntry -> logger.debug("Found artifact " + "["
-                + artifactEntry.getArtifactCoordinates().getId() + "]" + artifactEntry));
+        else
+        {
+            result.forEach(artifactEntry -> logger.debug("Found artifact [{}] - {}",
+                                                        artifactEntry.getArtifactCoordinates().getId(),
+                                                        artifactEntry));
+        }
     }
 
-    public void createArtifacts(String groupId,
-                                String artifactId,
-                                String storageId,
-                                String repositoryId)
+    private void createArtifacts(String groupId,
+                                 String artifactId,
+                                 String storageId,
+                                 String repositoryId)
     {
         // create 3 artifacts, one will have coordinates that matches our query, one - not
-        ArtifactCoordinates coordinates1 = new NullArtifactCoordinates(String.format("%s/%s/%s/%s", groupId, artifactId + "123", "1.2.3", "jar"));
-        ArtifactCoordinates coordinates2 = new NullArtifactCoordinates(String.format("%s/%s/%s/%s", groupId, artifactId, "1.2.3", "jar"));
-        ArtifactCoordinates coordinates3 = new NullArtifactCoordinates(String.format("%s/%s/%s/%s", groupId  + "myId", artifactId + "321", "1.2.3", "jar"));
+        ArtifactCoordinates coordinates1 = createArtifactCoordinates(groupId, artifactId + "123", "1.2.3", "jar");
+        ArtifactCoordinates coordinates2 = createArtifactCoordinates(groupId, artifactId, "1.2.3", "jar");
+        ArtifactCoordinates coordinates3 = createArtifactCoordinates(groupId + "myId", artifactId + "321", "1.2.3",
+                                                                     "jar");
 
         createArtifactEntry(coordinates1, storageId, repositoryId);
         createArtifactEntry(coordinates2, storageId, repositoryId);
         createArtifactEntry(coordinates3, storageId, repositoryId);
     }
 
-    public ArtifactEntry createArtifactEntry(ArtifactCoordinates coordinates,
-                                             String storageId,
-                                             String repositoryId)
+    private ArtifactCoordinates createArtifactCoordinates(final String groupId,
+                                                          final String artifactId,
+                                                          final String version,
+                                                          final String extension)
+    {
+
+        return new NullArtifactCoordinates(String.format("%s/%s/%s/%s", groupId, artifactId, version, extension));
+    }
+
+    private void createArtifactEntry(ArtifactCoordinates coordinates,
+                                     String storageId,
+                                     String repositoryId)
     {
         ArtifactEntry artifactEntry = new ArtifactEntry();
         artifactEntry.setArtifactCoordinates(coordinates);
         artifactEntry.setStorageId(storageId);
         artifactEntry.setRepositoryId(repositoryId);
 
-        return save(artifactEntry);
+        save(artifactEntry);
     }
 
-    public ArtifactCoordinates createMavenArtifactCoordinates()
+    private void updateArtifactAttributes(final String groupId)
     {
-
-        return new NullArtifactCoordinates(String.format("%s/%s/%s/%s", "org.carlspring.strongbox.aest.another.package", "coordinates-test-super-test", "1.2.3", "jar"));
-    }
-
-    private void updateArtifactAttributes()
-    {
-        List<ArtifactEntry> artifactEntries = findAll();
+        List<ArtifactEntry> artifactEntries = findAll(groupId);
         for (int i = 0; i < artifactEntries.size(); i++)
         {
             final ArtifactEntry artifactEntry = artifactEntries.get(i);
@@ -374,13 +419,13 @@ public class ArtifactEntryServiceTest
             {
                 artifactEntry.setLastUsed(new Date());
                 artifactEntry.setLastUpdated(new Date());
-                artifactEntry.setSizeInBytes(1l);
+                artifactEntry.setSizeInBytes(1L);
             }
             else
             {
                 artifactEntry.setLastUsed(DateUtils.addDays(new Date(), -10));
                 artifactEntry.setLastUpdated(DateUtils.addDays(new Date(), -10));
-                artifactEntry.setSizeInBytes(100000l);
+                artifactEntry.setSizeInBytes(100000L);
             }
 
             save(artifactEntry);

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -217,9 +217,9 @@ public class ArtifactEntryServiceTest
                                                                   groupId))
                                                           .collect(Collectors.toList());
 
-        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
-                                             entry.getArtifactCoordinates().getId(),
-                                             entry));
+        entries.forEach(entry -> logger.debug("Found artifact after search: [{}] - {}",
+                                              entry.getArtifactCoordinates().getId(),
+                                              entry));
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
@@ -241,9 +241,9 @@ public class ArtifactEntryServiceTest
                                                                   groupId))
                                                           .collect(Collectors.toList());
 
-        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
-                                             entry.getArtifactCoordinates().getId(),
-                                             entry));
+        entries.forEach(entry -> logger.debug("Found artifact after search: [{}] - {}",
+                                              entry.getArtifactCoordinates().getId(),
+                                              entry));
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
@@ -300,9 +300,9 @@ public class ArtifactEntryServiceTest
                                                                   groupId))
                                                           .collect(Collectors.toList());
 
-        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
-                                             entry.getArtifactCoordinates().getId(),
-                                             entry));
+        entries.forEach(entry -> logger.debug("Found artifact after search: [{}] - {}",
+                                              entry.getArtifactCoordinates().getId(),
+                                              entry));
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
@@ -381,8 +381,8 @@ public class ArtifactEntryServiceTest
         else
         {
             result.forEach(artifactEntry -> logger.debug("Found artifact [{}] - {}",
-                                                        artifactEntry.getArtifactCoordinates().getId(),
-                                                        artifactEntry));
+                                                         artifactEntry.getArtifactCoordinates().getId(),
+                                                         artifactEntry));
         }
     }
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -217,6 +217,10 @@ public class ArtifactEntryServiceTest
                                                                   groupId))
                                                           .collect(Collectors.toList());
 
+        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
+                                             entry.getArtifactCoordinates().getId(),
+                                             entry));
+
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
 
@@ -236,6 +240,10 @@ public class ArtifactEntryServiceTest
                                                           .filter(e -> e.getArtifactCoordinates().getId().startsWith(
                                                                   groupId))
                                                           .collect(Collectors.toList());
+
+        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
+                                             entry.getArtifactCoordinates().getId(),
+                                             entry));
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }
@@ -291,6 +299,10 @@ public class ArtifactEntryServiceTest
                                                           .filter(e -> e.getArtifactCoordinates().getId().startsWith(
                                                                   groupId))
                                                           .collect(Collectors.toList());
+
+        entries.forEach(entry -> logger.info("Found artifact after search: [{}] - {}",
+                                             entry.getArtifactCoordinates().getId(),
+                                             entry));
 
         assertThat(entries.size(), CoreMatchers.equalTo(all - 1));
     }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -72,7 +72,8 @@ public class ArtifactEntryServiceTest
     private  ArtifactCoordinatesService artifactCoordinatesService;
 
     @BeforeEach
-    public void setup(TestInfo testInfo) {
+    public void setup(TestInfo testInfo)
+    {
 
         final String groupId = getGroupId(GROUP_ID, testInfo);
 
@@ -93,7 +94,8 @@ public class ArtifactEntryServiceTest
     }
     
     @AfterEach
-    public void cleanup(TestInfo testInfo) {
+    public void cleanup(TestInfo testInfo)
+    {
         final String groupId = getGroupId(GROUP_ID, testInfo);
 
         List<ArtifactEntry> artifactEntries = findAll(groupId);
@@ -113,7 +115,8 @@ public class ArtifactEntryServiceTest
         return artifactEntryService.findArtifactList(null, null, coordinates, false);
     }
     
-    protected int count(final String groupId) {
+    protected int count(final String groupId)
+    {
         return findAll(groupId).size();
     }
     
@@ -190,7 +193,6 @@ public class ArtifactEntryServiceTest
                                                                                          REPOSITORY_ID + "abc",
                                                                                          pomCoordinates.toPath()));
         assertTrue(artifactEntryOptional.isPresent());
-
     }
 
     private ArtifactEntry save(ArtifactEntry artifactEntry)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ConfigurationManagementServiceImplTest.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Execution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -42,7 +40,6 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@Execution(CONCURRENT)
 public class ConfigurationManagementServiceImplTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImplTest.java
@@ -1,19 +1,21 @@
 package org.carlspring.strongbox.services.impl;
 
-import javax.inject.Inject;
-
 import org.carlspring.strongbox.StorageApiTestConfig;
 import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
 import org.carlspring.strongbox.domain.RepositoryArtifactIdGroupEntry;
 import org.carlspring.strongbox.services.RepositoryArtifactIdGroupService;
+
+import javax.inject.Inject;
+
+import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-
-import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
@@ -22,6 +24,7 @@ import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@Execution(CONCURRENT)
 class RepositoryArtifactIdGroupServiceImplTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImplTest.java
@@ -10,12 +10,10 @@ import javax.inject.Inject;
 import com.orientechnologies.orient.core.storage.ORecordDuplicatedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
@@ -23,8 +21,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 class RepositoryArtifactIdGroupServiceImplTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/TrustStoreServiceTestIT.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/TrustStoreServiceTestIT.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.Resource;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,7 +19,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Przemyslaw Fusik
@@ -28,8 +26,8 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = StorageApiTestConfig.class)
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class TrustStoreServiceTestIT
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
@@ -27,20 +27,20 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = { StorageApiTestConfig.class })
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
 public class RepositoryManagementTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryManagementTest.java
@@ -1,22 +1,6 @@
 package org.carlspring.strongbox.storage.repository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.inject.Inject;
-
-import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.carlspring.strongbox.StorageApiTestConfig;
-import org.carlspring.strongbox.artifact.coordinates.NullArtifactCoordinates;
 import org.carlspring.strongbox.artifact.generator.NullArtifactGenerator;
 import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.configuration.ConfigurationManager;
@@ -25,9 +9,19 @@ import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.providers.io.RootRepositoryPath;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.carlspring.strongbox.testing.repository.NullRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository;
 import org.carlspring.strongbox.testing.storage.repository.TestRepositoryManagementApplicationContext;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -38,6 +32,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
@@ -68,12 +64,11 @@ public class RepositoryManagementTest
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testParametersShouldBeInjected(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt1") Repository r1,
-                                               @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt2") Repository r2,
+    public void testParametersShouldBeInjected(@NullRepository(repositoryId = "rmt1") Repository r1,
+                                               @NullRepository(repositoryId = "rmt2") Repository r2,
                                                @TestArtifact(resource = "artifact1.ext", generator = NullArtifactGenerator.class) Path standaloneArtifact,
                                                @TestArtifact(repositoryId = "rmt2", resource = "org/carlspring/test/artifact2.ext", generator = NullArtifactGenerator.class) Path repositoryArtifact,
                                                TestInfo testInfo)
-        throws IOException
     {
         assertNotNull(testInfo);
         parametersShouldBeCorrectlyResolvedAndUnique(r1, r2);
@@ -81,21 +76,20 @@ public class RepositoryManagementTest
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testGroupRepository(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt1") Repository r1,
-                                    @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt2") Repository r2,
+    public void testGroupRepository(@NullRepository(repositoryId = "rmt1") Repository r1,
+                                    @NullRepository(repositoryId = "rmt2") Repository r2,
                                     @TestRepository.Group(repositories = { "rmt1",
                                                                            "rmt2" })
-                                    @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmtg")
+                                    @NullRepository(repositoryId = "rmtg")
                                     Repository group)
-        throws IOException
     {
         parametersShouldBeCorrectlyResolvedAndUnique(r1, r2, group);
     }
     
     @ExtendWith({ RepositoryManagementTestExecutionListener.class, ArtifactManagementTestExecutionListener.class })
     @RepeatedTest(10)
-    public void testConcurrentRepositoryDirect(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt1") Repository r1,
-                                               @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt2") Repository r2,
+    public void testConcurrentRepositoryDirect(@NullRepository(repositoryId = "rmt1") Repository r1,
+                                               @NullRepository(repositoryId = "rmt2") Repository r2,
                                                @TestArtifact(resource = "artifact1.ext", generator = NullArtifactGenerator.class) Path standaloneArtifact,
                                                @TestArtifact(repositoryId = "rmt2", resource = "org/carlspring/test/artifact2.ext", generator = NullArtifactGenerator.class) Path repositoryArtifact)
         throws IOException
@@ -107,8 +101,8 @@ public class RepositoryManagementTest
 
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @RepeatedTest(10)
-    public void testConcurrentRepositoryReverse(@TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt2") Repository r2,
-                                                @TestRepository(layout = NullArtifactCoordinates.LAYOUT_NAME, repositoryId = "rmt1") Repository r1)
+    public void testConcurrentRepositoryReverse(@NullRepository(repositoryId = "rmt2") Repository r2,
+                                                @NullRepository(repositoryId = "rmt1") Repository r1)
     {
         parametersShouldBeCorrectlyResolvedAndUnique(r1, r2);
     }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/RepositoryTest.java
@@ -20,19 +20,19 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.collect.Sets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @ContextConfiguration(classes = { StorageApiTestConfig.class })
-@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class }, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(ExecutionMode.CONCURRENT)
+@TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 public class RepositoryTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
@@ -25,7 +24,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
@@ -35,7 +33,6 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
 public class ArtifactOperationsValidatorTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
@@ -8,13 +8,16 @@ import org.carlspring.strongbox.storage.ArtifactResolutionException;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
@@ -22,6 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author Kate Novik.
@@ -31,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@Execution(CONCURRENT)
 public class ArtifactOperationsValidatorTest
 {
 
@@ -39,8 +44,6 @@ public class ArtifactOperationsValidatorTest
     private static final String REPOSITORY_ID = "releases";
 
     private static MockMultipartFile multipartFile;
-
-    private static InputStream is;
 
     @Inject
     private ArtifactOperationsValidator artifactOperationsValidator;
@@ -54,14 +57,13 @@ public class ArtifactOperationsValidatorTest
     public void setUp()
             throws Exception
     {
-        File baseDir = new File(REPOSITORY_BASEDIR + "/" + REPOSITORY_ID);
-        if (!baseDir.exists())
+        Path basePath = Paths.get(REPOSITORY_BASEDIR, REPOSITORY_ID);
+        if (Files.notExists(basePath))
         {
-            //noinspection ResultOfMethodCallIgnored
-            baseDir.mkdirs();
+            Files.createDirectories(basePath);
         }
 
-        is = new RandomInputStream(20480000);
+        InputStream is = new RandomInputStream(20480000);
 
         multipartFile = new MockMultipartFile("artifact",
                                               "strongbox-validate-8.1.jar",
@@ -116,16 +118,14 @@ public class ArtifactOperationsValidatorTest
 
         }
 
-        File file = new File(REPOSITORY_BASEDIR + "validate-test.jar");
-        //noinspection ResultOfMethodCallIgnored
-        file.getParentFile().mkdirs();
-        //noinspection ResultOfMethodCallIgnored
-        file.createNewFile();
+        Path path = Paths.get(REPOSITORY_BASEDIR, "validate-test.jar");
+        Files.createDirectories(path.getParent());
+        Files.createFile(path);
 
         MockMultipartFile emptyFile = new MockMultipartFile("artifact",
                                                             "strongbox-validate-empty.jar",
                                                             "application/octet-stream",
-                                                            new FileInputStream(file));
+                                                            Files.newInputStream(path));
 
         try
         {

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericReleaseVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericReleaseVersionValidatorTest.java
@@ -12,14 +12,11 @@ import org.carlspring.strongbox.storage.validation.artifact.version.VersionValid
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-@Execution(CONCURRENT)
 public class GenericReleaseVersionValidatorTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericSnapshotVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericSnapshotVersionValidatorTest.java
@@ -12,12 +12,9 @@ import org.carlspring.strongbox.storage.validation.artifact.version.VersionValid
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-@Execution(CONCURRENT)
 public class GenericSnapshotVersionValidatorTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericSnapshotVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/GenericSnapshotVersionValidatorTest.java
@@ -1,26 +1,29 @@
 package org.carlspring.strongbox.storage.validation.version;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.carlspring.strongbox.artifact.coordinates.ArtifactCoordinates;
 import org.carlspring.strongbox.artifact.coordinates.MockedMavenArtifactCoordinates;
+import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryData;
 import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.repository.RepositoryPolicyEnum;
 import org.carlspring.strongbox.storage.validation.artifact.version.GenericSnapshotVersionValidator;
 import org.carlspring.strongbox.storage.validation.artifact.version.VersionValidationException;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
+@Execution(CONCURRENT)
 public class GenericSnapshotVersionValidatorTest
 {
 
-    Repository repository;
+    private Repository repository;
 
-    GenericSnapshotVersionValidator validator = new GenericSnapshotVersionValidator();
+    private GenericSnapshotVersionValidator validator = new GenericSnapshotVersionValidator();
 
 
     @BeforeEach
@@ -51,14 +54,11 @@ public class GenericSnapshotVersionValidatorTest
 
     @Test
     public void testInvalidArtifacts()
-            throws VersionValidationException
     {
         ArtifactCoordinates coordinates1 = new MockedMavenArtifactCoordinates();
         coordinates1.setVersion("1.0");
 
-        assertThrows(VersionValidationException.class, () -> {
-            validator.validate(repository, coordinates1);
-        });
+        assertThrows(VersionValidationException.class, () -> validator.validate(repository, coordinates1));
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
@@ -7,11 +7,13 @@ import org.carlspring.strongbox.services.VersionValidatorService;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@Execution(CONCURRENT)
 public class VersionValidatorServiceTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/version/VersionValidatorServiceTest.java
@@ -7,13 +7,11 @@ import org.carlspring.strongbox.services.VersionValidatorService;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**
  * @author mtodorov
@@ -23,7 +21,6 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ContextConfiguration(classes = StorageApiTestConfig.class)
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
                         mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
-@Execution(CONCURRENT)
 public class VersionValidatorServiceTest
 {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -1,5 +1,15 @@
 package org.carlspring.strongbox.testing.artifact;
 
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+import org.carlspring.strongbox.booters.PropertiesBooter;
+import org.carlspring.strongbox.providers.io.RepositoryFiles;
+import org.carlspring.strongbox.providers.io.RepositoryPath;
+import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
+import org.carlspring.strongbox.services.ArtifactManagementService;
+import org.carlspring.strongbox.util.ThrowingComparator;
+import org.carlspring.strongbox.util.ThrowingConsumer;
+
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.UndeclaredThrowableException;
@@ -16,16 +26,6 @@ import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
-import javax.annotation.PreDestroy;
-
-import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
-import org.carlspring.strongbox.booters.PropertiesBooter;
-import org.carlspring.strongbox.providers.io.RepositoryFiles;
-import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
-import org.carlspring.strongbox.services.ArtifactManagementService;
-import org.carlspring.strongbox.util.ThrowingComparator;
-import org.carlspring.strongbox.util.ThrowingConsumer;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -1,5 +1,25 @@
 package org.carlspring.strongbox.testing.storage.repository;
 
+import org.carlspring.strongbox.providers.io.RepositoryPath;
+import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
+import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
+import org.carlspring.strongbox.services.ConfigurationManagementService;
+import org.carlspring.strongbox.services.RepositoryManagementService;
+import org.carlspring.strongbox.services.StorageManagementService;
+import org.carlspring.strongbox.storage.Storage;
+import org.carlspring.strongbox.storage.StorageDto;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.storage.repository.RepositoryData;
+import org.carlspring.strongbox.storage.repository.RepositoryDto;
+import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
+import org.carlspring.strongbox.storage.repository.remote.RemoteRepositoryDto;
+import org.carlspring.strongbox.storage.routing.MutableRoutingRule;
+import org.carlspring.strongbox.storage.routing.MutableRoutingRuleRepository;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
+import org.carlspring.strongbox.util.ThrowingSupplier;
+
+import javax.annotation.PreDestroy;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.file.Files;
@@ -9,26 +29,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.PreDestroy;
-
-import org.carlspring.strongbox.providers.io.RepositoryPath;
-import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
-import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
-import org.carlspring.strongbox.services.ConfigurationManagementService;
-import org.carlspring.strongbox.services.RepositoryManagementService;
-import org.carlspring.strongbox.services.StorageManagementService;
-import org.carlspring.strongbox.storage.StorageDto;
-import org.carlspring.strongbox.storage.Storage;
-import org.carlspring.strongbox.storage.repository.RepositoryData;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.Repository;
-import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
-import org.carlspring.strongbox.storage.repository.remote.RemoteRepositoryDto;
-import org.carlspring.strongbox.storage.routing.MutableRoutingRule;
-import org.carlspring.strongbox.storage.routing.MutableRoutingRuleRepository;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
-import org.carlspring.strongbox.util.ThrowingSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -1,7 +1,10 @@
 package org.carlspring.strongbox.testing.storage.repository;
 
-import static org.carlspring.strongbox.testing.artifact.TestArtifactContext.id;
-import static org.carlspring.strongbox.testing.storage.repository.TestRepositoryContext.id;
+import org.carlspring.strongbox.configuration.ConfigurationUtils;
+import org.carlspring.strongbox.testing.artifact.TestArtifact;
+import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
+import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -20,11 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import org.carlspring.strongbox.configuration.ConfigurationUtils;
-import org.carlspring.strongbox.testing.artifact.TestArtifact;
-import org.carlspring.strongbox.testing.artifact.TestArtifactContext;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
-import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -38,6 +36,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.Assert;
+import static org.carlspring.strongbox.testing.artifact.TestArtifactContext.id;
+import static org.carlspring.strongbox.testing.storage.repository.TestRepositoryContext.id;
 
 /**
  * @author sbespalov

--- a/strongbox-storage/strongbox-storage-api/src/test/resources/junit-platform.properties
+++ b/strongbox-storage/strongbox-storage-api/src/test/resources/junit-platform.properties
@@ -1,1 +1,2 @@
 junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent


### PR DESCRIPTION
# Pull Request Description

This pull request closes #950 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
