### PR TITLE
issues/1423: NpmArtifactControllerTest fixed + Test repository management cleanup

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -183,15 +183,13 @@ public class NpmArtifactGenerator
     public Path generateArtifact(NpmArtifactCoordinates coordinates)
             throws IOException
     {
-        this.of(coordinates).buildPublishJson();
-        return getPackagePath();
+        return this.of(coordinates).buildPackage();
     }
 
     public Path generateArtifact(URI uri)
             throws IOException
     {
-        this.of(NpmArtifactCoordinates.parse(uri.toString())).buildPublishJson();
-        return getPackagePath();
+        return this.of(NpmArtifactCoordinates.parse(uri.toString())).buildPackage();
     }
 
     public Path generateArtifact(String id,
@@ -221,7 +219,7 @@ public class NpmArtifactGenerator
         return generateArtifact(id, version);
     }
 
-    private Path buildPublishJson()
+    public Path buildPublishJson()
             throws IOException
     {
         if (packagePath == null)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
@@ -6,6 +6,7 @@ import org.carlspring.strongbox.artifact.generator.NpmArtifactGenerator;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author Yuri Zaytsev
@@ -26,6 +27,15 @@ public class NpmArtifactGeneratorStrategy implements ArtifactGeneratorStrategy<N
                                                                         id,
                                                                         version,
                                                                         (String) attributesMap.get("extension"));
-        return artifactGenerator.generateArtifact(coordinates);
+        Path packagePath = artifactGenerator.generateArtifact(coordinates);
+        if (!Optional.ofNullable(attributesMap.get("repositoryId"))
+                     .filter(repositoryId -> ((String) repositoryId).trim().length() > 0)
+                     .isPresent())
+        {
+            // if package won't be deployed then `publish.json` will be generated
+            artifactGenerator.buildPublishJson();
+        }
+        
+        return packagePath;
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
@@ -62,4 +62,5 @@ public @interface NpmTestArtifact
      * The {@link org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates} scope.
      */
     String scope() default "";
+    
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -15,7 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpHeaders;
@@ -44,12 +43,9 @@ public class NpmArtifactControllerTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    @Disabled // disabled temporarily due to a fail
-    public void testViewPackage(@NpmRepository(storageId = STORAGE0,
-                                               repositoryId = REPOSITORY_RELEASES)
+    public void testViewPackage(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
                                 Repository repository,
-                                @NpmTestArtifact(storageId = STORAGE0,
-                                                 repositoryId = REPOSITORY_RELEASES,
+                                @NpmTestArtifact(repositoryId = REPOSITORY_RELEASES,
                                                  id = "npm-test-view",
                                                  versions = "1.0.0",
                                                  scope = "@carlspring")
@@ -83,8 +79,7 @@ public class NpmArtifactControllerTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testPackageCommonFlow(@NpmRepository(storageId = STORAGE0,
-                                                     repositoryId = REPOSITORY_RELEASES)
+    public void testPackageCommonFlow(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
                                       Repository repository,
                                       @NpmTestArtifact(id = "npm-test-release",
                                                        versions = "1.0.0",

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTestIT.java
@@ -56,8 +56,7 @@ public class NpmArtifactControllerTestIT
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
     public void testResolveArtifactViaProxy(@Remote(url = REMOTE_URL)
-                                            @NpmRepository(storageId = STORAGE0,
-                                                           repositoryId = REPOSITORY_PROXY)
+                                            @NpmRepository(repositoryId = REPOSITORY_PROXY)
                                             Repository proxyRepository)
             throws Exception
     {
@@ -77,12 +76,10 @@ public class NpmArtifactControllerTestIT
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
     public void testResolveArtifactViaGroupWithProxy(@Remote(url = REMOTE_URL)
-                                                     @NpmRepository(storageId = STORAGE0,
-                                                                    repositoryId = REPOSITORY_PROXY)
+                                                     @NpmRepository(repositoryId = REPOSITORY_PROXY)
                                                      Repository proxyRepository,
                                                      @Group(repositories = REPOSITORY_PROXY)
-                                                     @NpmRepository(storageId = STORAGE0,
-                                                                    repositoryId = REPOSITORY_GROUP)
+                                                     @NpmRepository(repositoryId = REPOSITORY_GROUP)
                                                      Repository groupRepository)
             throws Exception
     {
@@ -97,8 +94,7 @@ public class NpmArtifactControllerTestIT
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
     public void testViewArtifactViaProxy(@Remote(url = REMOTE_URL)
-                                         @NpmRepository(storageId = STORAGE0,
-                                                        repositoryId = REPOSITORY_PROXY)
+                                         @NpmRepository(repositoryId = REPOSITORY_PROXY)
                                          Repository proxyRepository)
     {
         final String storageId = proxyRepository.getStorage().getId();
@@ -127,8 +123,7 @@ public class NpmArtifactControllerTestIT
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
     public void testSearchArtifactViaProxy(@Remote(url = REMOTE_URL)
-                                           @NpmRepository(storageId = STORAGE0,
-                                                          repositoryId = REPOSITORY_PROXY)
+                                           @NpmRepository(repositoryId = REPOSITORY_PROXY)
                                            Repository proxyRepository)
     {
         final String storageId = proxyRepository.getStorage().getId();

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NpmRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NpmRestAssuredBaseTest.java
@@ -1,40 +1,33 @@
 package org.carlspring.strongbox.rest.common;
 
-import org.carlspring.commons.io.MultipleDigestOutputStream;
-import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
-import org.carlspring.strongbox.rest.client.RestAssuredArtifactClient;
-import org.carlspring.strongbox.storage.repository.NpmRepositoryFactory;
-import org.carlspring.strongbox.storage.repository.RepositoryDto;
-import org.carlspring.strongbox.storage.repository.RepositoryTypeEnum;
-import org.carlspring.strongbox.storage.repository.remote.MutableRemoteRepository;
-import org.carlspring.strongbox.testing.TestCaseWithRepositoryManagement;
-import org.carlspring.strongbox.users.domain.Privileges;
+import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.carlspring.strongbox.rest.client.RestAssuredArtifactClient.OK;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import javax.inject.Inject;
-import javax.xml.bind.JAXBException;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
 
+import javax.inject.Inject;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.carlspring.commons.io.MultipleDigestOutputStream;
+import org.carlspring.strongbox.rest.client.RestAssuredArtifactClient;
+import org.carlspring.strongbox.users.domain.Privileges;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.context.WebApplicationContext;
-import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.carlspring.strongbox.rest.client.RestAssuredArtifactClient.OK;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author carlspring
  */
 public abstract class NpmRestAssuredBaseTest
-        extends TestCaseWithRepositoryManagement
 {
 
     protected static final String TEST_RESOURCES = "target/test-resources";
@@ -49,9 +42,6 @@ public abstract class NpmRestAssuredBaseTest
 
     @Inject
     protected RestAssuredArtifactClient client;
-
-    @Inject
-    private NpmRepositoryFactory npmRepositoryFactory;
 
     @Value("${strongbox.url}")
     private String contextBaseUrl;
@@ -94,24 +84,6 @@ public abstract class NpmRestAssuredBaseTest
         assertTrue(pathExists(url), "Path " + url + " doesn't exist.");
     }
 
-    @Override
-    public void createProxyRepository(String storageId,
-                                      String repositoryId,
-                                      String remoteRepositoryUrl)
-            throws IOException,
-                   JAXBException,
-                   RepositoryManagementStrategyException
-    {
-        MutableRemoteRepository remoteRepository = new MutableRemoteRepository();
-        remoteRepository.setUrl(remoteRepositoryUrl);
-
-        RepositoryDto repository = npmRepositoryFactory.createRepository(repositoryId);
-        repository.setType(RepositoryTypeEnum.PROXY.getType());
-        repository.setRemoteRepository(remoteRepository);
-
-        createRepository(storageId, repository);
-    }
-
     protected void resolveArtifact(String artifactPath)
             throws NoSuchAlgorithmException, IOException
     {
@@ -125,29 +97,23 @@ public abstract class NpmRestAssuredBaseTest
             fail("Failed to resolve " + artifactPath + "!");
         }
 
-        File testResources = new File(TEST_RESOURCES, artifactPath);
-        if (!testResources.getParentFile().exists())
-        {
-            //noinspection ResultOfMethodCallIgnored
-            testResources.getParentFile().mkdirs();
-        }
-
-        FileOutputStream fos = new FileOutputStream(new File(TEST_RESOURCES, artifactPath));
-        MultipleDigestOutputStream mdos = new MultipleDigestOutputStream(fos);
-
         int total = 0;
-        int len;
-        final int size = 1024;
-        byte[] bytes = new byte[size];
-
-        while ((len = is.read(bytes, 0, size)) != -1)
+        try (OutputStream fos = new NullOutputStream();
+                MultipleDigestOutputStream mdos = new MultipleDigestOutputStream(fos))
         {
-            mdos.write(bytes, 0, len);
-            total += len;
-        }
 
-        mdos.flush();
-        mdos.close();
+            int len;
+            final int size = 1024;
+            byte[] bytes = new byte[size];
+
+            while ((len = is.read(bytes, 0, size)) != -1)
+            {
+                mdos.write(bytes, 0, len);
+                total += len;
+            }
+
+            mdos.flush();
+        }
 
         assertTrue(total > 0, "Resolved a zero-length artifact!");
     }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1423 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
