### PR TITLE
Move from delays to checksums on two tests to work around timestamp granularity on MacOS JRE

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
@@ -100,7 +100,7 @@ public class RepositoryHostedIndexCreatorTest
         RepositoryPath indexPath = repositoryIndexCreator.apply(repository);
         FileTime firstLastModifiedTime = Files.getLastModifiedTime(indexPath);
 
-        Thread.sleep(1);
+        Thread.sleep(1000);
 
         indexPath = repositoryIndexCreator.apply(repository);
         FileTime secondLastModifiedTime = Files.getLastModifiedTime(indexPath);

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
@@ -17,13 +17,13 @@ import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
+import org.carlspring.strongbox.util.MessageDigestUtils;
 
 import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 import io.restassured.http.Header;
@@ -132,20 +132,13 @@ public class MavenIndexControllerTest
                                                                                     classifiers = { "javadoc",
                                                                                                     "sources" })
                                                                  List<Path> artifactPaths)
-            throws IOException
+            throws IOException, NoSuchAlgorithmException
     {
         hostedRepositoryIndexCreator.apply(repository);
 
         RepositoryPath indexPath = repositoryLocalIndexDirectoryPathResolver.resolve(repository)
                                                                             .resolve("nexus-maven-repository-index.gz");
-
-        BasicFileAttributes attrs = Files.readAttributes(indexPath, BasicFileAttributes.class);
-        FileTime before = attrs.lastModifiedTime();
-
-        try
-        {
-            Thread.sleep(1000);
-        } catch (InterruptedException e ) {}
+        String beforeChecksum = MessageDigestUtils.calculateChecksum(indexPath, "SHA-1");
 
         String url = getContextBaseUrl() + "/api/maven/index/{storageId}/{repositoryId}";
 
@@ -159,11 +152,10 @@ public class MavenIndexControllerTest
 
         indexPath = repositoryLocalIndexDirectoryPathResolver.resolve(repository).resolve(
                 "nexus-maven-repository-index.gz");
-        attrs = Files.readAttributes(indexPath, BasicFileAttributes.class);
 
-        FileTime after = attrs.lastModifiedTime();
+        String afterChecksum = MessageDigestUtils.calculateChecksum(indexPath, "SHA-1");
 
-        assertThat(after).isGreaterThan(before);
+        assertThat(beforeChecksum).isNotEqualTo(afterChecksum);
     }
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
@@ -142,6 +142,11 @@ public class MavenIndexControllerTest
         BasicFileAttributes attrs = Files.readAttributes(indexPath, BasicFileAttributes.class);
         FileTime before = attrs.lastModifiedTime();
 
+        try
+        {
+            Thread.sleep(1000);
+        } catch (InterruptedException e ) {}
+
         String url = getContextBaseUrl() + "/api/maven/index/{storageId}/{repositoryId}";
 
         given().contentType(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
# Pull Request Description

This pull request closes # (N/A)

With commit 868626f3ec2f0616d5110d3c363780ebbcd67ada, `RepositoryHostedIndexCreatorTest` and `MavenIndexCreatorTest` both fail on my Mac due to successive operations on the filesystem which do not result in a change in the mtime on the file(s) in question.

For background, the HFS+ filesystem does not support sub-second granularity in the mtime on files.  However, my Mac is running APFS, which does offer improved granularity.  However there appears to be an issue in the JDK resulting in this information not being available in the Java nio APIs.  More information can be found at the following location:

http://mail.openjdk.java.net/pipermail/nio-dev/2017-December/004632.html

My suggested improvement is to sleep 1 second to ensure that the file(s) in question will have a different mtime.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
