### PR TITLE
Hotfix: Disable tests parallelization in strongbox-storage-api.

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/resources/junit-platform.properties
+++ b/strongbox-storage/strongbox-storage-api/src/test/resources/junit-platform.properties
@@ -1,2 +1,2 @@
-junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.enabled=false
 junit.jupiter.execution.parallel.mode.default=concurrent


### PR DESCRIPTION
# Pull Request Description

This pull request disables tests parallelization in `strongbox-storage-api` module, in order to solve unstability in `master` branch.
Relates to issue #950 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
