### PR TITLE
issue-1464 Improve PasswordEncoderController security

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/users/PasswordEncoderController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/users/PasswordEncoderController.java
@@ -1,38 +1,66 @@
 package org.carlspring.strongbox.controllers.users;
 
+import org.carlspring.strongbox.controllers.BaseController;
+import org.carlspring.strongbox.forms.users.PasswordEncodeForm;
+import org.carlspring.strongbox.validation.RequestBodyValidationException;
+
 import javax.inject.Inject;
+import java.util.Collections;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author Przemyslaw Fusik
  */
 @Controller
-@RequestMapping("/api/users/password-encoder")
-@Api(value = "/api/users/password-encoder")
+@RequestMapping("/api/users/encrypt/password")
+@Api(value = "/api/users/encrypt/encoder")
+@PreAuthorize("hasAuthority('ADMIN')")
 public class PasswordEncoderController
+        extends BaseController
 {
+
+    public static final String INVALID_FORM = "Form contains invalid data!";
 
     @Inject
     private PasswordEncoder passwordEncoder;
 
-    @ApiOperation(value = "Encodes provided raw password")
-    @ApiResponses(value = @ApiResponse(code = 200, message = "Returns encoded raw password"))
-    @GetMapping(value = "/{rawPassword}")
+    @ApiOperation(value = "Encodes submitted raw password")
+    @ApiResponses(value = @ApiResponse(code = 200, message = "Returns encoded password"))
+    @PostMapping(consumes = { MediaType.APPLICATION_JSON_VALUE },
+                 produces = { MediaType.APPLICATION_JSON_VALUE,
+                              MediaType.TEXT_PLAIN_VALUE })
     @ResponseBody
-    public ResponseEntity encode(@PathVariable String rawPassword)
+    public ResponseEntity encode(@RequestHeader(HttpHeaders.ACCEPT) String accept,
+                                 @Validated @RequestBody PasswordEncodeForm form,
+                                 BindingResult bindingResult)
     {
-        return ResponseEntity.ok(passwordEncoder.encode(rawPassword));
+        if (bindingResult.hasErrors())
+        {
+            throw new RequestBodyValidationException(INVALID_FORM, bindingResult);
+        }
+
+        String encoded = passwordEncoder.encode(form.getPassword());
+        Object response = encoded;
+
+        if (accept.equals(MediaType.APPLICATION_JSON_VALUE))
+        {
+            response = Collections.singletonMap("password", encoded);
+        }
+
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/PasswordEncoderControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/PasswordEncoderControllerTest.java
@@ -1,17 +1,24 @@
 package org.carlspring.strongbox.controllers.users;
 
 import org.carlspring.strongbox.config.IntegrationTest;
+import org.carlspring.strongbox.forms.users.PasswordEncodeForm;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
 
 import javax.inject.Inject;
 
+import io.restassured.module.mockmvc.response.ValidatableMockMvcResponse;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.transaction.annotation.Transactional;
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Przemyslaw Fusik
@@ -31,22 +38,69 @@ public class PasswordEncoderControllerTest
             throws Exception
     {
         super.init();
+        setContextBaseUrl(getContextBaseUrl() + "/api/users/encrypt/password");
+    }
+
+    @ParameterizedTest
+    @WithUserDetails("admin")
+    @ValueSource(strings = { MediaType.APPLICATION_JSON_VALUE,
+                             MediaType.TEXT_PLAIN_VALUE })
+    public void shouldEncodeProperly(String acceptedHeader)
+    {
+        final PasswordEncodeForm form = new PasswordEncodeForm("password");
+
+        ValidatableMockMvcResponse response = given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                                                     .accept(acceptedHeader)
+                                                     .body(form)
+                                                     .post(getContextBaseUrl())
+                                                     .peek()
+                                                     .then()
+                                                     .statusCode(HttpStatus.OK.value());
+
+
+        if (acceptedHeader.equals(MediaType.APPLICATION_JSON_VALUE))
+        {
+            response.body("password", CoreMatchers.not(form.getPassword()));
+        }
+        else
+        {
+            response.body(CoreMatchers.not(form.getPassword()));
+        }
     }
 
     @Test
-    public void shouldEncodeProperly()
+    @WithAnonymousUser
+    public void shouldRequireAuthenticationAccess()
     {
+        final PasswordEncodeForm form = new PasswordEncodeForm("password");
 
-        final String encodedPassword = given().when()
-                                              .get("/api/users/password-encoder/password")
-                                              .peek()
-                                              .then()
-                                              .statusCode(200)
-                                              .extract()
-                                              .asString();
-
-        assertTrue(passwordEncoder.matches("password", encodedPassword));
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
+               .body(form)
+               .when()
+               .post(getContextBaseUrl())
+               .peek()
+               .then()
+               .body("error", CoreMatchers.containsString("Full authentication is required"))
+               .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
+
+    @Test
+    @WithUserDetails("deployer")
+    public void shouldAllowOnlyAdminAccess()
+    {
+        final PasswordEncodeForm form = new PasswordEncodeForm("password");
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
+               .body(form)
+               .when()
+               .post(getContextBaseUrl())
+               .peek()
+               .then()
+               .body("error", CoreMatchers.containsString("forbidden"))
+               .statusCode(HttpStatus.FORBIDDEN.value());
+    }
 
 }

--- a/strongbox-web-forms/src/main/java/org/carlspring/strongbox/forms/users/PasswordEncodeForm.java
+++ b/strongbox-web-forms/src/main/java/org/carlspring/strongbox/forms/users/PasswordEncodeForm.java
@@ -1,0 +1,36 @@
+package org.carlspring.strongbox.forms.users;
+
+import org.carlspring.strongbox.validation.users.Password;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PasswordEncodeForm
+        implements Serializable
+{
+
+    @Password(min = 8)
+    @JsonProperty("password")
+    private String password;
+
+    @JsonCreator
+    public PasswordEncodeForm(@JsonProperty("password") String password)
+    {
+        this.password = password;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public void setPassword(String password)
+    {
+        this.password = password;
+    }
+
+}


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1464 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
