### PR TITLE
Issue-1466: Language-related error for shouldRequireAuthenticationAccess method in PasswordEncoderControllerTest

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/PasswordEncoderControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/PasswordEncoderControllerTest.java
@@ -86,13 +86,13 @@ public class PasswordEncoderControllerTest
         final PasswordEncodeForm form = new PasswordEncodeForm("password");
 
         String defaultErrorMessage = messages.getMessage(UNAUTHORIZED_MESSAGE_CODE,
-                Locale.ENGLISH);
+                                                         Locale.ENGLISH);
 
         String errorMessage = messages.getMessage(UNAUTHORIZED_MESSAGE_CODE,
-                defaultErrorMessage);
+                                                  defaultErrorMessage);
 
         String decodedErrorMessage = new String(errorMessage.getBytes(ISO_8859_1),
-                Charset.defaultCharset());
+                                                Charset.defaultCharset());
 
         given().contentType(MediaType.APPLICATION_JSON_VALUE)
                .accept(MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1466 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
