### PR TITLE
Fix 'Fail to lock' issue which prevents to run tests

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/group/RepositoryGroupIndexCreatorSearchTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/group/RepositoryGroupIndexCreatorSearchTest.java
@@ -50,59 +50,59 @@ public class RepositoryGroupIndexCreatorSearchTest
         extends BaseRepositoryIndexCreatorTest
 {
 
-    private static final String REPOSITORY_RELEASES_0 = "injector-releases-0";
+    private static final String REPOSITORY_RELEASES_0 = "injector-releases-0-rgicst";
 
-    private static final String REPOSITORY_RELEASES_0_1 = "injector-releases-0-1";
+    private static final String REPOSITORY_RELEASES_0_1 = "injector-releases-0-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_0_1_GROUP = "injector-releases-0-1-group";
+    private static final String REPOSITORY_RELEASES_0_1_GROUP = "injector-releases-0-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_1 = "injector-releases-1";
+    private static final String REPOSITORY_RELEASES_1 = "injector-releases-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_1_1 = "injector-releases-1-1";
+    private static final String REPOSITORY_RELEASES_1_1 = "injector-releases-1-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_1_1_GROUP = "injector-releases-1-1-group";
+    private static final String REPOSITORY_RELEASES_1_1_GROUP = "injector-releases-1-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_2 = "injector-releases-2";
+    private static final String REPOSITORY_RELEASES_2 = "injector-releases-2-rgicst";
 
-    private static final String REPOSITORY_RELEASES_2_1 = "injector-releases-2-1";
+    private static final String REPOSITORY_RELEASES_2_1 = "injector-releases-2-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_2_1_GROUP = "injector-releases-2-1-group";
+    private static final String REPOSITORY_RELEASES_2_1_GROUP = "injector-releases-2-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_3 = "injector-releases-3";
+    private static final String REPOSITORY_RELEASES_3 = "injector-releases-3-rgicst";
 
-    private static final String REPOSITORY_RELEASES_3_1 = "injector-releases-3-1";
+    private static final String REPOSITORY_RELEASES_3_1 = "injector-releases-3-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_3_1_GROUP = "injector-releases-3-1-group";
+    private static final String REPOSITORY_RELEASES_3_1_GROUP = "injector-releases-3-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_4 = "injector-releases-4";
+    private static final String REPOSITORY_RELEASES_4 = "injector-releases-4-rgicst";
 
-    private static final String REPOSITORY_RELEASES_4_1 = "injector-releases-4-1";
+    private static final String REPOSITORY_RELEASES_4_1 = "injector-releases-4-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_4_1_GROUP = "injector-releases-4-1-group";
+    private static final String REPOSITORY_RELEASES_4_1_GROUP = "injector-releases-4-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_5 = "injector-releases-5";
+    private static final String REPOSITORY_RELEASES_5 = "injector-releases-5-rgicst";
 
-    private static final String REPOSITORY_RELEASES_5_1 = "injector-releases-5-1";
+    private static final String REPOSITORY_RELEASES_5_1 = "injector-releases-5-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_5_1_GROUP = "injector-releases-5-1-group";
+    private static final String REPOSITORY_RELEASES_5_1_GROUP = "injector-releases-5-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_6 = "injector-releases-6";
+    private static final String REPOSITORY_RELEASES_6 = "injector-releases-6-rgicst";
 
-    private static final String REPOSITORY_RELEASES_6_1 = "injector-releases-6-1";
+    private static final String REPOSITORY_RELEASES_6_1 = "injector-releases-6-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_6_1_GROUP = "injector-releases-6-1-group";
+    private static final String REPOSITORY_RELEASES_6_1_GROUP = "injector-releases-6-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_7 = "injector-releases-7";
+    private static final String REPOSITORY_RELEASES_7 = "injector-releases-7-rgicst";
 
-    private static final String REPOSITORY_RELEASES_7_1 = "injector-releases-7-1";
+    private static final String REPOSITORY_RELEASES_7_1 = "injector-releases-7-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_7_1_GROUP = "injector-releases-7-1-group";
+    private static final String REPOSITORY_RELEASES_7_1_GROUP = "injector-releases-7-1-group-rgicst";
 
-    private static final String REPOSITORY_RELEASES_8 = "injector-releases-8";
+    private static final String REPOSITORY_RELEASES_8 = "injector-releases-8-rgicst";
 
-    private static final String REPOSITORY_RELEASES_8_1 = "injector-releases-8-1";
+    private static final String REPOSITORY_RELEASES_8_1 = "injector-releases-8-1-rgicst";
 
-    private static final String REPOSITORY_RELEASES_8_1_GROUP = "injector-releases-8-1-group";
+    private static final String REPOSITORY_RELEASES_8_1_GROUP = "injector-releases-8-1-group-rgicst";
 
     private static final String PROPERTIES_INJECTOR_GROUP_ID = "org.carlspring";
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorSearchTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorSearchTest.java
@@ -48,21 +48,21 @@ public class RepositoryHostedIndexCreatorSearchTest
         extends BaseRepositoryIndexCreatorTest
 {
 
-    private static final String REPOSITORY_RELEASES_1 = "injector-releases-1";
+    private static final String REPOSITORY_RELEASES_1 = "injector-releases-1-rhicst";
 
-    private static final String REPOSITORY_RELEASES_2 = "injector-releases-2";
+    private static final String REPOSITORY_RELEASES_2 = "injector-releases-2-rhicst";
 
-    private static final String REPOSITORY_RELEASES_3 = "injector-releases-3";
+    private static final String REPOSITORY_RELEASES_3 = "injector-releases-3-rhicst";
 
-    private static final String REPOSITORY_RELEASES_4 = "injector-releases-4";
+    private static final String REPOSITORY_RELEASES_4 = "injector-releases-4-rhicst";
 
-    private static final String REPOSITORY_RELEASES_5 = "injector-releases-5";
+    private static final String REPOSITORY_RELEASES_5 = "injector-releases-5-rhicst";
 
-    private static final String REPOSITORY_RELEASES_6 = "injector-releases-6";
+    private static final String REPOSITORY_RELEASES_6 = "injector-releases-6-rhicst";
 
-    private static final String REPOSITORY_RELEASES_7 = "injector-releases-7";
+    private static final String REPOSITORY_RELEASES_7 = "injector-releases-7-rhicst";
 
-    private static final String REPOSITORY_RELEASES_8 = "injector-releases-8";
+    private static final String REPOSITORY_RELEASES_8 = "injector-releases-8-rhicst";
 
     private static final String GROUP_ID = "org.carlspring";
 
@@ -77,6 +77,7 @@ public class RepositoryHostedIndexCreatorSearchTest
     private Resource jarArtifact = new ClassPathResource("artifacts/properties-injector-1.7.jar");
 
     /**
+     *
      * org/carlspring/ioc/PropertyValueInjector
      * org/carlspring/ioc/InjectionException
      * org/carlspring/ioc/PropertyValue

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
@@ -43,7 +43,7 @@ public class RepositoryHostedIndexCreatorTest
         extends BaseRepositoryIndexCreatorTest
 {
 
-    private static final String REPOSITORY_RELEASES = "ri-releases";
+    private static final String REPOSITORY_RELEASES = "ri-releases-rhicst";
     private static final String GROUP_ID = "org.carlspring.strongbox";
     private static final String ARTIFACT_ID = "strongbox-commons";
 


### PR DESCRIPTION
# Pull Request Description

This pull request reference to #1389.
Can be connected with #949, #950. 
Fixes:

> Failed to lock [storage0/xxxxx] after [8] seconds. Consider to use unique resource ID for your test."

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [x] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
