### PR TITLE
Apply one separate repository for each test

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -52,7 +52,8 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
         extends BaseCronJobWithMavenIndexingTestCase
 {
 
-    private static final String REPOSITORY_SNAPSHOTS = "rtmscj-snapshots";
+    private static final String REPOSITORY_SNAPSHOTS_1 = "rtmscj-snapshots-1";
+    private static final String REPOSITORY_SNAPSHOTS_2 = "rtmscj-snapshots-2";
 
     private static final String ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_FIRST = "org/carlspring/strongbox/strongbox-timestamped-first";
     private static final String ARTIFACT_BASE_PATH_STRONGBOX_TIMESTAMPED_SECOND = "org/carlspring/strongbox/strongbox-timestamped-second";
@@ -80,8 +81,8 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     public void testRemoveTimestampedSnapshot(
-            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS, policy = SNAPSHOT) Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_1, policy = SNAPSHOT) Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_1, id = GROUP_ID + ":" +
                                                                          ARTIFACT_ID1, versions = { "2.0-20190701.202015-1",
                                                                                                     "2.0-20190701.202101-2",
                                                                                                     "2.0-20190701.202203-3" })
@@ -141,8 +142,8 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     public void testRemoveTimestampedSnapshotInRepository(
-            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS, policy = SNAPSHOT) Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS, id = GROUP_ID + ":" +
+            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_2, policy = SNAPSHOT) Repository repository,
+            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_2, id = GROUP_ID + ":" +
                                                                          ARTIFACT_ID2, versions = { "2.0-20190701.202015-1",
                                                                                                     "2.0-20190701.202101-2" })
                     List<Path> artifact)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/cron/jobs/RemoveTimestampedMavenSnapshotCronJobTestIT.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @SpringBootTest
 @ActiveProfiles(profiles = "test")
 @TestExecutionListeners(listeners = { CacheManagerTestExecutionListener.class },
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+                        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @Execution(CONCURRENT)
 public class RemoveTimestampedMavenSnapshotCronJobTestIT
         extends BaseCronJobWithMavenIndexingTestCase
@@ -80,13 +80,15 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void testRemoveTimestampedSnapshot(
-            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_1, policy = SNAPSHOT) Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_1, id = GROUP_ID + ":" +
-                                                                         ARTIFACT_ID1, versions = { "2.0-20190701.202015-1",
-                                                                                                    "2.0-20190701.202101-2",
-                                                                                                    "2.0-20190701.202203-3" })
-                    List<Path> artifact)
+    public void testRemoveTimestampedSnapshot(@MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_1,
+                                                               policy = SNAPSHOT)
+                                              Repository repository,
+                                              @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_1,
+                                                                 id = GROUP_ID + ":" + ARTIFACT_ID1,
+                                                                 versions = { "2.0-20190701.202015-1",
+                                                                              "2.0-20190701.202101-2",
+                                                                              "2.0-20190701.202203-3" })
+                                              List<Path> artifact)
             throws Exception
     {
         final String storageId = repository.getStorage().getId();
@@ -141,12 +143,14 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
     @Test
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
-    public void testRemoveTimestampedSnapshotInRepository(
-            @MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_2, policy = SNAPSHOT) Repository repository,
-            @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_2, id = GROUP_ID + ":" +
-                                                                         ARTIFACT_ID2, versions = { "2.0-20190701.202015-1",
-                                                                                                    "2.0-20190701.202101-2" })
-                    List<Path> artifact)
+    public void testRemoveTimestampedSnapshotInRepository(@MavenRepository(repositoryId = REPOSITORY_SNAPSHOTS_2,
+                                                                           policy = SNAPSHOT)
+                                                          Repository repository,
+                                                          @MavenTestArtifact(repositoryId = REPOSITORY_SNAPSHOTS_2,
+                                                                             id = GROUP_ID + ":" + ARTIFACT_ID2,
+                                                                             versions = { "2.0-20190701.202015-1",
+                                                                                          "2.0-20190701.202101-2" })
+                                                          List<Path> artifact)
             throws Exception
     {
         final String storageId = repository.getStorage().getId();
@@ -168,10 +172,9 @@ public class RemoveTimestampedMavenSnapshotCronJobTestIT
                 {
                     try (Stream<Path> pathStream = Files.walk(artifactPath))
                     {
-
                         long timestampedSnapshots = pathStream.filter(path -> path.toString().endsWith(".jar")).count();
+                        
                         assertEquals(1, timestampedSnapshots, "Amount of timestamped snapshots doesn't equal 1.");
-
                     }
 
                     assertTrue(getSnapshotArtifactVersion(artifactPath).endsWith("-2"));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/local/RepositoryHostedIndexCreatorTest.java
@@ -43,7 +43,9 @@ public class RepositoryHostedIndexCreatorTest
         extends BaseRepositoryIndexCreatorTest
 {
 
-    private static final String REPOSITORY_RELEASES = "ri-releases-rhicst";
+    private static final String REPOSITORY_RELEASES_0 = "ri-releases-rhicst0";
+    private static final String REPOSITORY_RELEASES_1 = "ri-releases-rhicst1";
+    private static final String REPOSITORY_RELEASES_2 = "ri-releases-rhicst2";
     private static final String GROUP_ID = "org.carlspring.strongbox";
     private static final String ARTIFACT_ID = "strongbox-commons";
 
@@ -54,10 +56,10 @@ public class RepositoryHostedIndexCreatorTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void packedIndexShouldBeGenerated(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+    public void packedIndexShouldBeGenerated(@MavenRepository(repositoryId = REPOSITORY_RELEASES_0,
                                                               setup = MavenIndexedRepositorySetup.class)
                                              Repository repository,
-                                             @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                             @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_0,
                                                                 id = GROUP_ID + ":" + ARTIFACT_ID,
                                                                 versions = { "1.0",
                                                                              "1.1",
@@ -87,10 +89,10 @@ public class RepositoryHostedIndexCreatorTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void packedIndexShouldBeOverridable(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+    public void packedIndexShouldBeOverridable(@MavenRepository(repositoryId = REPOSITORY_RELEASES_1,
                                                                 setup = MavenIndexedRepositorySetup.class)
                                                Repository repository,
-                                               @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                               @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_1,
                                                                   id = GROUP_ID + ":" + ARTIFACT_ID,
                                                                   versions = { "1.0",
                                                                                "1.1",
@@ -110,10 +112,10 @@ public class RepositoryHostedIndexCreatorTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void packedRepositoryIndexGeneratorShouldBeThreadSafe(@MavenRepository(repositoryId = REPOSITORY_RELEASES,
+    public void packedRepositoryIndexGeneratorShouldBeThreadSafe(@MavenRepository(repositoryId = REPOSITORY_RELEASES_2,
                                                                                   setup = MavenIndexedRepositorySetup.class)
                                                                  Repository repository,
-                                                                 @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                                 @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES_2,
                                                                                     id = GROUP_ID + ":" + ARTIFACT_ID,
                                                                                     versions = { "1.0",
                                                                                                  "1.1",

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidatorTest.java
@@ -37,7 +37,9 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 public class MavenSnapshotVersionValidatorTest
 {
 
-    private static final String REPOSITORY_ID = "test-repository-for-maven-snapshot-validation";
+    private static final String REPOSITORY_ID_1 = "test-repository-for-maven-snapshot-validation-1";
+    private static final String REPOSITORY_ID_2 = "test-repository-for-maven-snapshot-validation-2";
+    private static final String REPOSITORY_ID_3 = "test-repository-for-maven-snapshot-validation-3";
     private static final String GROUP_ID = "org.carlspring.maven";
     private static final String ARTIFACT_ID = "my-maven-plugin";
 
@@ -45,7 +47,7 @@ public class MavenSnapshotVersionValidatorTest
 
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void shouldSupportRepository(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT)
+    public void shouldSupportRepository(@MavenRepository(repositoryId = REPOSITORY_ID_1, policy = SNAPSHOT)
                                         Repository repository)
     {
         assertTrue(validator.supports(repository));
@@ -54,9 +56,9 @@ public class MavenSnapshotVersionValidatorTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testSnapshotValidation(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT)
+    public void testSnapshotValidation(@MavenRepository(repositoryId = REPOSITORY_ID_2, policy = SNAPSHOT)
                                        Repository repository,
-                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_ID_2,
                                                           id = GROUP_ID + ":" + ARTIFACT_ID,
                                                           versions = { "1.0-SNAPSHOT",
                                                                        "1.0-20131004.115330-1",
@@ -78,9 +80,9 @@ public class MavenSnapshotVersionValidatorTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testInvalidArtifacts(@MavenRepository(repositoryId = REPOSITORY_ID, policy = SNAPSHOT)
+    public void testInvalidArtifacts(@MavenRepository(repositoryId = REPOSITORY_ID_3, policy = SNAPSHOT)
                                      Repository repository,
-                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID,
+                                     @MavenTestArtifact(repositoryId = REPOSITORY_ID_3,
                                                         id = GROUP_ID + ":" + ARTIFACT_ID,
                                                         versions = { "1",
                                                                      "1.0",

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/BrowseControllerTest.java
@@ -40,7 +40,8 @@ public class BrowseControllerTest
         extends MavenRestAssuredBaseTest
 {
 
-    private static final String REPOSITORY = "browsing-test-repository";
+    private static final String REPOSITORY_1 = "browsing-test-repository-1";
+    private static final String REPOSITORY_2 = "browsing-test-repository-2";
 
     @Override
     @BeforeEach
@@ -89,7 +90,7 @@ public class BrowseControllerTest
 
     @ExtendWith(RepositoryManagementTestExecutionListener.class)
     @Test
-    public void testGetRepositories(@MavenRepository(repositoryId = REPOSITORY)
+    public void testGetRepositories(@MavenRepository(repositoryId = REPOSITORY_1)
                                     Repository repository)
     {
         final String storageId = repository.getStorage().getId();
@@ -153,9 +154,9 @@ public class BrowseControllerTest
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
                   ArtifactManagementTestExecutionListener.class })
     @Test
-    public void testRepositoryContents(@MavenRepository(repositoryId = REPOSITORY)
+    public void testRepositoryContents(@MavenRepository(repositoryId = REPOSITORY_2)
                                        Repository repository,
-                                       @MavenTestArtifact(repositoryId = REPOSITORY,
+                                       @MavenTestArtifact(repositoryId = REPOSITORY_2,
                                                           id = "org.carlspring.strongbox.browsing:test-browsing",
                                                           versions = { "1.1",
                                                                        "3.2" })


### PR DESCRIPTION
# Pull Request Description

This pull request reference to #1389.
It is another fix connected with #1470.
 
Fixes:

> Failed to lock [storage0/xxxxx] after [8] seconds. Consider to use unique resource ID for your test."

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [x] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
