### PR TITLE
Issue 1169: Simplify ConfigurationResourceResolver and YamlFileManager

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/booters/PropertiesBooter.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/booters/PropertiesBooter.java
@@ -1,12 +1,6 @@
 package org.carlspring.strongbox.booters;
 
-import javax.annotation.PostConstruct;
-
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
-import org.springframework.beans.factory.config.BeanPostProcessor;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -18,7 +12,6 @@ import org.springframework.stereotype.Component;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class PropertiesBooter
 {
-
     @Value("${strongbox.home}")
     private String homeDirectory;
 
@@ -51,34 +44,6 @@ public class PropertiesBooter
 
     @Value("${strongbox.revision}")
     private String strongboxRevision;
-
-    /**
-     * Initialization method that sets default system properties, if none are set.
-     */
-    @PostConstruct
-    public void init()
-    {
-        if (System.getProperty("logging.dir") == null)
-        {
-            System.setProperty("logging.dir", getVaultDirectory() + "/logs");
-        }
-
-        if (System.getProperty("logging.config.file") == null)
-        {
-            System.setProperty("logging.config.file", getHomeDirectory() + "/etc/logback-spring.xml");
-        }
-
-
-        if (System.getProperty("ehcache.disk.store.dir") == null)
-        {
-            System.setProperty("ehcache.disk.store.dir", getHomeDirectory() + "/cache");
-        }
-
-        if (System.getProperty("strongbox.storage.booter.basedir") == null)
-        {
-            System.setProperty("strongbox.storage.booter.basedir", getStorageBooterBasedir());
-        }
-    }
 
     public String getHomeDirectory()
     {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/StrongboxSpringBootApplication.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/StrongboxSpringBootApplication.java
@@ -1,11 +1,7 @@
 package org.carlspring.strongbox.app;
 
-import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.config.WebConfig;
 import org.carlspring.strongbox.config.orientdb.OrientDbProfile;
-
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +11,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -23,8 +18,7 @@ import org.springframework.context.annotation.Import;
  */
 @SpringBootApplication(exclude = { DataSourceAutoConfiguration.class,
                                    HibernateJpaAutoConfiguration.class })
-@Import({ WebConfig.class,
-          StrongboxSpringBootApplication.InitializationConfig.class })
+@Import(WebConfig.class)
 public class StrongboxSpringBootApplication
 {
 
@@ -58,19 +52,4 @@ public class StrongboxSpringBootApplication
         thread.setDaemon(false);
         thread.start();
     }
-
-    @Configuration
-    static class InitializationConfig
-    {
-
-        @Inject
-        private PropertiesBooter propertiesBooter;
-
-        @PostConstruct
-        void init()
-        {
-            System.setProperty("strongbox.storage.booter.basedir", propertiesBooter.getStorageBooterBasedir());
-        }
-    }
-
 }


### PR DESCRIPTION
# Pull Request Description

This is a 1st step in #1169 - moving the system property setting to an ApplicationContextInitializer instead of in `@PostConstruct`.
 
- Moved the system property setting from PropertiesBooter to a new ApplicationContextInitializer
- Removed redundant setting of storage booter basedir in StrongboxSpringBootApplication
- Removed redundant setting of tmpdir in TempDirBooter


# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
