### PR TITLE
SB-1475: test that ArtifactEntry.created stores both date and time

### DIFF
--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/net/MediaType.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/net/MediaType.java
@@ -11,6 +11,8 @@ public final class MediaType
 
     public static final String APPLICATION_YAML_VALUE = "application/yaml";
 
+    public static final String APPLICATION_X_GZIP_VALUE = "application/x-gzip";
+
     private MediaType()
     {
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -31,7 +31,6 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.util.CollectionUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.carlspring.strongbox.services.support.ArtifactEntrySearchCriteria.Builder.anArtifactEntrySearchCriteria;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Functional test and usage example scenarios for {@link ArtifactEntryService}.
@@ -120,8 +119,8 @@ public class ArtifactEntryServiceTest
 
         final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
 
-        assertNull(artifactEntry.getCreated());
-        assertNull(artifactEntry.getLastUpdated());
+        assertThat(artifactEntry.getCreated()).isNotNull();
+        assertThat(artifactEntry.getLastUpdated()).isNotNull();
 
         final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
         final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
@@ -130,8 +129,8 @@ public class ArtifactEntryServiceTest
         final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
                 .orElse(null);
 
-        assertNotNull(firstTimeReadFromDatabase);
-        assertEquals(firstTimeReadFromDatabase.getCreated(), creationDate);
+        assertThat(firstTimeReadFromDatabase).isNotNull();
+        assertThat(firstTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
 
         artifactEntry.setDownloadCount(1);
         save(firstTimeReadFromDatabase);
@@ -139,8 +138,8 @@ public class ArtifactEntryServiceTest
         final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
                 .orElse(null);
 
-        assertNotNull(secondTimeReadFromDatabase);
-        assertEquals(secondTimeReadFromDatabase.getCreated(), creationDate);
+        assertThat(secondTimeReadFromDatabase).isNotNull();
+        assertThat(secondTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
     }
 
     @Test
@@ -155,13 +154,13 @@ public class ArtifactEntryServiceTest
         final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
         final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
         final Date creationDate = firstTimeSavedArtifactEntry.getCreated();
-        assertEquals(now, creationDate);
+        assertThat(creationDate).isEqualTo(now);
 
         final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
                 .orElse(null);
 
-        assertNotNull(firstTimeReadFromDatabase);
-        assertEquals(now, creationDate);
+        assertThat(firstTimeReadFromDatabase).isNotNull();
+        assertThat(creationDate).isEqualTo(now);
     }
 
     private ArtifactEntry createArtifactEntry(String groupId)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -119,8 +119,8 @@ public class ArtifactEntryServiceTest
 
         final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
 
-        assertThat(artifactEntry.getCreated()).isNotNull();
-        assertThat(artifactEntry.getLastUpdated()).isNotNull();
+        assertThat(artifactEntry.getCreated()).isNull();
+        assertThat(artifactEntry.getLastUpdated()).isNull();
 
         final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
         final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -10,6 +10,8 @@ import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.services.ArtifactEntryService;
 
 import javax.inject.Inject;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -143,24 +145,36 @@ public class ArtifactEntryServiceTest
     }
 
     @Test
-    public void saveEntityCreatedPropertyShouldRetainDateAndTime(TestInfo testInfo)
-    {
+    public void saveEntityCreatedLastUsedLastUpdatedPropertiesShouldRetainTime(TestInfo testInfo) throws ParseException {
         final String groupId = getGroupId(GROUP_ID, testInfo);
 
         final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
-        final Date now = new Date();
-        artifactEntry.setCreated(now);
-
         final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
         final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
-        final Date creationDate = firstTimeSavedArtifactEntry.getCreated();
-        assertThat(creationDate).isEqualTo(now);
 
         final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
                 .orElse(null);
-
         assertThat(firstTimeReadFromDatabase).isNotNull();
-        assertThat(creationDate).isEqualTo(now);
+
+        final Date sampleDate = createSampleDate();
+
+        firstTimeReadFromDatabase.setCreated(sampleDate);
+        firstTimeReadFromDatabase.setLastUpdated(sampleDate);
+        firstTimeReadFromDatabase.setLastUsed(sampleDate);
+
+        save(firstTimeReadFromDatabase);
+        final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
+                .orElse(null);
+
+        assertThat(secondTimeReadFromDatabase).isNotNull();
+
+        assertThat(secondTimeReadFromDatabase.getCreated()).isEqualTo(sampleDate);
+        assertThat(secondTimeReadFromDatabase.getLastUpdated()).isEqualTo(sampleDate);
+        assertThat(secondTimeReadFromDatabase.getLastUsed()).isEqualTo(sampleDate);
+    }
+
+    private Date createSampleDate() throws ParseException {
+        return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2019-10-31 13:15:50");
     }
 
     private ArtifactEntry createArtifactEntry(String groupId)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
@@ -1,12 +1,5 @@
 package org.carlspring.strongbox.storage.validation.resource;
 
-import org.carlspring.commons.io.RandomInputStream;
-import org.carlspring.strongbox.StorageApiTestConfig;
-import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
-import org.carlspring.strongbox.services.ConfigurationManagementService;
-import org.carlspring.strongbox.storage.ArtifactResolutionException;
-
-import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,16 +7,26 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import javax.inject.Inject;
+
+import org.carlspring.commons.io.RandomInputStream;
+import org.carlspring.strongbox.StorageApiTestConfig;
+import org.carlspring.strongbox.data.CacheManagerTestExecutionListener;
+import org.carlspring.strongbox.services.ConfigurationManagementService;
+import org.carlspring.strongbox.storage.ArtifactResolutionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
-import static org.assertj.core.api.Assertions.fail;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Kate Novik.
@@ -64,7 +67,7 @@ public class ArtifactOperationsValidatorTest
 
         multipartFile = new MockMultipartFile("artifact",
                                               "strongbox-validate-8.1.jar",
-                                              "application/octet-stream",
+                                              MediaType.APPLICATION_OCTET_STREAM_VALUE,
                                               is);
     }
 
@@ -121,7 +124,7 @@ public class ArtifactOperationsValidatorTest
 
         MockMultipartFile emptyFile = new MockMultipartFile("artifact",
                                                             "strongbox-validate-empty.jar",
-                                                            "application/octet-stream",
+                                                            MediaType.APPLICATION_OCTET_STREAM_VALUE,
                                                             Files.newInputStream(path));
 
         try

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -1,5 +1,38 @@
 package org.carlspring.strongbox.controllers.layout.npm;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.IOUtils;
 import org.carlspring.strongbox.artifact.ArtifactTag;
 import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
 import org.carlspring.strongbox.config.NpmLayoutProviderConfig.NpmObjectMapper;
@@ -9,7 +42,12 @@ import org.carlspring.strongbox.data.criteria.Paginator;
 import org.carlspring.strongbox.data.criteria.Predicate;
 import org.carlspring.strongbox.npm.NpmSearchRequest;
 import org.carlspring.strongbox.npm.NpmViewRequest;
-import org.carlspring.strongbox.npm.metadata.*;
+import org.carlspring.strongbox.npm.metadata.DistTags;
+import org.carlspring.strongbox.npm.metadata.PackageFeed;
+import org.carlspring.strongbox.npm.metadata.PackageVersion;
+import org.carlspring.strongbox.npm.metadata.SearchResults;
+import org.carlspring.strongbox.npm.metadata.Time;
+import org.carlspring.strongbox.npm.metadata.Versions;
 import org.carlspring.strongbox.providers.ProviderImplementationException;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.layout.NpmPackageDesc;
@@ -23,40 +61,22 @@ import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.storage.validation.artifact.ArtifactCoordinatesValidationException;
 import org.carlspring.strongbox.web.LayoutRequestMapping;
 import org.carlspring.strongbox.web.RepositoryMapping;
-
-import javax.inject.Inject;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
-import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.io.IOUtils;
 import org.javatuples.Pair;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.Assert;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This Controller used to handle npm requests.
@@ -150,7 +170,7 @@ public class NpmArtifactController
         SimpleDateFormat format = new SimpleDateFormat(NpmSearchResultSupplier.SEARCH_DATE_FORMAT);
         searchResults.setTime(format.format(new Date()));
         
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getOutputStream().write(npmJacksonMapper.writeValueAsBytes(searchResults));
     }
 
@@ -186,7 +206,7 @@ public class NpmArtifactController
         NpmPackageDesc packageDesc = npmPackageSupplier.apply(repositoryPath);
         PackageVersion npmPackage = packageDesc.getNpmPackage();
         
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getOutputStream().write(npmJacksonMapper.writeValueAsBytes(npmPackage));
     }
     
@@ -250,7 +270,7 @@ public class NpmArtifactController
 
         });
 
-        response.setContentType(MediaType.APPLICATION_JSON);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getOutputStream().write(npmJacksonMapper.writeValueAsBytes(packageFeed));
     }
 
@@ -343,7 +363,7 @@ public class NpmArtifactController
     }
 
     @PreAuthorize("hasAuthority('ARTIFACTS_DEPLOY')")
-    @PutMapping(path = "{storageId}/{repositoryId}/{name:.+}", consumes = MediaType.APPLICATION_JSON)
+    @PutMapping(path = "{storageId}/{repositoryId}/{name:.+}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity publish(@RepositoryMapping Repository repository,
                                   @PathVariable(name = "name") String name,
                                   HttpServletRequest request)
@@ -406,7 +426,7 @@ public class NpmArtifactController
         String packageFileName = repositoryPath.getFileName().toString();
         RepositoryPath checksumPath = repositoryPath.resolveSibling(packageFileName + ".sha1");
         artifactManagementService.validateAndStore(checksumPath,
-                                                      new ByteArrayInputStream(shasum.getBytes("UTF-8")));
+                                                      new ByteArrayInputStream(shasum.getBytes(StandardCharsets.UTF_8)));
 
         Files.delete(packageTgzTmp);
         Files.delete(packageJsonTmp);
@@ -509,7 +529,7 @@ public class NpmArtifactController
             packageJsonSource = extrectPackageJson(packageTgzIn);
         }
         Path packageJsonTmp = Files.createTempFile("package", "json");
-        Files.write(packageJsonTmp, packageJsonSource.getBytes("UTF-8"), StandardOpenOption.TRUNCATE_EXISTING);
+        Files.write(packageJsonTmp, packageJsonSource.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
 
         return packageJsonTmp;
     }
@@ -524,7 +544,7 @@ public class NpmArtifactController
 
         jp.nextToken();
         String contentType = jp.nextTextValue();
-        Assert.isTrue("application/octet-stream".equals(contentType),
+        Assert.isTrue(MediaType.APPLICATION_OCTET_STREAM_VALUE.equals(contentType),
                       String.format("Failed to parse npm package source for [%s], unknown content type [%s]",
                                     packageAttachmentName, contentType));
 
@@ -571,7 +591,7 @@ public class NpmArtifactController
                     continue;
                 }
                 StringWriter writer = new StringWriter();
-                IOUtils.copy(tarIn, writer, "UTF-8");
+                IOUtils.copy(tarIn, writer, StandardCharsets.UTF_8);
                 return writer.toString();
             }
             

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
@@ -1,5 +1,14 @@
 package org.carlspring.strongbox.controllers.layout.maven;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import io.restassured.http.Header;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.rest.common.MavenRestAssuredBaseTest;
@@ -18,24 +27,17 @@ import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementT
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Group;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.carlspring.strongbox.util.MessageDigestUtils;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-
-import io.restassured.http.Header;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import static com.google.common.base.Predicates.not;
 
+import static com.google.common.base.Predicates.not;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.carlspring.strongbox.net.MediaType.APPLICATION_X_GZIP_VALUE;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
@@ -294,7 +296,7 @@ public class MavenIndexControllerTest
                .peek()
                .then()
                .statusCode(HttpStatus.OK.value())
-               .contentType("application/x-gzip")
+               .contentType(APPLICATION_X_GZIP_VALUE)
                .body(CoreMatchers.notNullValue());
     }
 
@@ -327,7 +329,7 @@ public class MavenIndexControllerTest
                .peek()
                .then()
                .statusCode(HttpStatus.OK.value())
-               .contentType("text/plain")
+               .contentType(MediaType.TEXT_PLAIN_VALUE)
                .body(CoreMatchers.notNullValue());
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
@@ -1,5 +1,20 @@
 package org.carlspring.strongbox.controllers.layout.nuget;
 
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.module.mockmvc.config.RestAssuredMockMvcConfig;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.carlspring.strongbox.artifact.coordinates.NugetArtifactCoordinates;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.domain.ArtifactEntry;
@@ -14,26 +29,13 @@ import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecution
 import org.carlspring.strongbox.testing.artifact.NugetTestArtifact;
 import org.carlspring.strongbox.testing.repository.NugetRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
-
-import javax.inject.Inject;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
-import io.restassured.http.Headers;
-import io.restassured.module.mockmvc.config.RestAssuredMockMvcConfig;
-import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -417,7 +419,7 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     {
         return mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                       .header("X-NuGet-ApiKey", API_KEY)
-                      .contentType("multipart/form-data; boundary=---------------------------123qwe")
+                      .contentType(MediaType.MULTIPART_FORM_DATA_VALUE.concat("; boundary=---------------------------123qwe"))
                       .body(packageContent);
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/login/LoginControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/login/LoginControllerTest.java
@@ -1,10 +1,9 @@
 package org.carlspring.strongbox.controllers.login;
 
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-
 import javax.inject.Inject;
 
+import com.google.common.collect.ImmutableSet;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.forms.users.UserForm;
 import org.carlspring.strongbox.rest.common.RestAssuredBaseTest;
@@ -16,14 +15,14 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 
-import com.google.common.collect.ImmutableSet;
-
-import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * @author Przemyslaw Fusik
@@ -63,8 +62,8 @@ public class LoginControllerTest
         loginInput.setUsername("admin");
         loginInput.setPassword("password");
 
-        mockMvc.contentType("application/json")
-               .header("Accept", "application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
                .body(loginInput)
                .when()
                .post("/api/login")
@@ -83,8 +82,8 @@ public class LoginControllerTest
         loginInput.setUsername("przemyslaw_fusik");
         loginInput.setPassword("password");
 
-        mockMvc.contentType("application/json")
-               .header("Accept", "application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
                .body(loginInput)
                .when()
                .post("/api/login")
@@ -108,8 +107,8 @@ public class LoginControllerTest
         loginInput.setUsername("test-disabled-user-login");
         loginInput.setPassword("1234");
 
-        mockMvc.contentType("application/json")
-               .header("Accept", "application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
                .body(loginInput)
                .when()
                .post("/api/login")
@@ -136,8 +135,8 @@ public class LoginControllerTest
         loginInput.setUsername("admin-cache-eviction-test");
         loginInput.setPassword("password");
 
-        mockMvc.contentType("application/json")
-               .header("Accept", "application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
                .body(loginInput)
                .when()
                .post("/api/login")
@@ -160,8 +159,8 @@ public class LoginControllerTest
                .then()
                .statusCode(HttpStatus.OK.value());
 
-        mockMvc.contentType("application/json")
-               .header("Accept", "application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .accept(MediaType.APPLICATION_JSON_VALUE)
                .body(loginInput)
                .when()
                .post("/api/login")

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/security/CustomAccessDeniedHandlerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/security/CustomAccessDeniedHandlerTest.java
@@ -62,14 +62,14 @@ public class CustomAccessDeniedHandlerTest
     @WithMockUser(username = "unauthorizedUser")
     public void unauthorizedUserShouldReceiveExpectedUnauthorizedResponse()
     {
-        mockMvc.contentType("application/json")
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                .accept(ContentType.JSON)
                .when()
                .get("/api/configuration/strongbox")
                .peek()
                .then()
                .statusCode(HttpStatus.FORBIDDEN.value())
-               .contentType("application/json")
+               .contentType(MediaType.APPLICATION_JSON_VALUE)
                .body("error", equalTo("forbidden"));
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/security/authentication/suppliers/CustomLoginSupplierTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/security/authentication/suppliers/CustomLoginSupplierTest.java
@@ -1,15 +1,17 @@
 package org.carlspring.strongbox.security.authentication.suppliers;
 
-import org.carlspring.strongbox.config.IntegrationTest;
-import org.carlspring.strongbox.controllers.login.LoginInput;
-
 import javax.inject.Inject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.carlspring.strongbox.config.IntegrationTest;
+import org.carlspring.strongbox.controllers.login.LoginInput;
 import org.junit.jupiter.api.Test;
+
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -30,7 +32,7 @@ public class CustomLoginSupplierTest
             throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest("post", "/api/login");
-        request.setContentType("application/json");
+        request.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         assertThat(customLoginSupplier.supports(request)).isTrue();
     }
@@ -40,7 +42,7 @@ public class CustomLoginSupplierTest
             throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest("get", "/api/login");
-        request.setContentType("application/json");
+        request.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         assertThat(customLoginSupplier.supports(request)).isFalse();
     }
@@ -50,7 +52,7 @@ public class CustomLoginSupplierTest
             throws Exception
     {
         MockHttpServletRequest request = new MockHttpServletRequest("post", "/api/login");
-        request.setContentType("application/xml");
+        request.setContentType(MediaType.APPLICATION_XML_VALUE);
 
         assertThat(customLoginSupplier.supports(request)).isFalse();
     }


### PR DESCRIPTION
# Pull Request Description

This pull request is 3 of 3 needed to close #1475.
1 of 3 is https://github.com/strongbox/liquibase-orientdb/pull/2
2 of 3 is https://github.com/strongbox/strongbox-db/pull/16

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [X] Yes, please see: this pull request description
  * [ ] No