### PR TITLE
Issue-1475: Test that ArtifactEntity properties created, lastUpdated, lastUsed retain time when saved and read to/from db

### DIFF
--- a/strongbox-data-service/pom.xml
+++ b/strongbox-data-service/pom.xml
@@ -76,17 +76,17 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-server</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-PR-16-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-liquibase</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-PR-16-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-import</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-PR-16-SNAPSHOT</version>
             <classifier>schema</classifier>
         </dependency>
         

--- a/strongbox-data-service/pom.xml
+++ b/strongbox-data-service/pom.xml
@@ -76,17 +76,17 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-server</artifactId>
-            <version>1.0-PR-16-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-liquibase</artifactId>
-            <version>1.0-PR-16-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-db-import</artifactId>
-            <version>1.0-PR-16-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>
             <classifier>schema</classifier>
         </dependency>
         

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -10,6 +10,8 @@ import org.carlspring.strongbox.domain.ArtifactEntry;
 import org.carlspring.strongbox.services.ArtifactEntryService;
 
 import javax.inject.Inject;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -360,6 +362,80 @@ public class ArtifactEntryServiceTest
 
         Long c = artifactEntryService.countArtifacts(STORAGE_ID, REPOSITORY_ID, c1.getCoordinates(), false);
         assertThat(c).isEqualTo(Long.valueOf(1));
+    }
+
+    @Test
+    public void saveEntityCreationDateShouldBeGeneratedAutomaticallyAndRemainUnchanged(TestInfo testInfo)
+    {
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
+
+        assertThat(artifactEntry.getCreated()).isNull();
+        assertThat(artifactEntry.getLastUpdated()).isNull();
+
+        final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
+        final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
+        final Date creationDate = firstTimeSavedArtifactEntry.getCreated();
+
+        final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
+                .orElse(null);
+
+        assertThat(firstTimeReadFromDatabase).isNotNull();
+        assertThat(firstTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
+
+        artifactEntry.setDownloadCount(1);
+        save(firstTimeReadFromDatabase);
+
+        final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
+                .orElse(null);
+
+        assertThat(secondTimeReadFromDatabase).isNotNull();
+        assertThat(secondTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
+    }
+
+    @Test
+    public void saveEntityCreatedLastUsedLastUpdatedPropertiesShouldRetainTime(TestInfo testInfo) throws ParseException {
+        final String groupId = getGroupId(GROUP_ID, testInfo);
+
+        final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
+        final ArtifactEntry firstTimeSavedArtifactEntry = save(artifactEntry);
+        final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
+
+        final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
+                .orElse(null);
+        assertThat(firstTimeReadFromDatabase).isNotNull();
+
+        final Date sampleDate = createSampleDate();
+
+        firstTimeReadFromDatabase.setCreated(sampleDate);
+        firstTimeReadFromDatabase.setLastUpdated(sampleDate);
+        firstTimeReadFromDatabase.setLastUsed(sampleDate);
+
+        save(firstTimeReadFromDatabase);
+        final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
+                .orElse(null);
+
+        assertThat(secondTimeReadFromDatabase).isNotNull();
+
+        assertThat(secondTimeReadFromDatabase.getCreated()).isEqualTo(sampleDate);
+        assertThat(secondTimeReadFromDatabase.getLastUpdated()).isEqualTo(sampleDate);
+        assertThat(secondTimeReadFromDatabase.getLastUsed()).isEqualTo(sampleDate);
+    }
+
+    private Date createSampleDate() throws ParseException {
+        return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2019-10-31 13:15:50");
+    }
+
+    private ArtifactEntry createArtifactEntry(String groupId)
+    {
+        final ArtifactEntry artifactEntry = new ArtifactEntry();
+
+        artifactEntry.setStorageId(STORAGE_ID);
+        artifactEntry.setRepositoryId(REPOSITORY_ID);
+        artifactEntry.setArtifactCoordinates(createArtifactCoordinates(groupId, ARTIFACT_ID + "1234", "1.2.3", "jar"));
+
+        return artifactEntry;
     }
 
     private void displayAllEntries(final String groupId)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceTest.java
@@ -379,7 +379,7 @@ public class ArtifactEntryServiceTest
         final Date creationDate = firstTimeSavedArtifactEntry.getCreated();
 
         final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
-                .orElse(null);
+                                                                            .orElse(null);
 
         assertThat(firstTimeReadFromDatabase).isNotNull();
         assertThat(firstTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
@@ -388,14 +388,16 @@ public class ArtifactEntryServiceTest
         save(firstTimeReadFromDatabase);
 
         final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
-                .orElse(null);
+                                                                             .orElse(null);
 
         assertThat(secondTimeReadFromDatabase).isNotNull();
         assertThat(secondTimeReadFromDatabase.getCreated()).isEqualTo(creationDate);
     }
 
     @Test
-    public void saveEntityCreatedLastUsedLastUpdatedPropertiesShouldRetainTime(TestInfo testInfo) throws ParseException {
+    public void saveEntityCreatedLastUsedLastUpdatedPropertiesShouldRetainTime(TestInfo testInfo)
+            throws ParseException
+    {
         final String groupId = getGroupId(GROUP_ID, testInfo);
 
         final ArtifactEntry artifactEntry = createArtifactEntry(groupId);
@@ -403,7 +405,7 @@ public class ArtifactEntryServiceTest
         final String artifactEntryId = firstTimeSavedArtifactEntry.getObjectId();
 
         final ArtifactEntry firstTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
-                .orElse(null);
+                                                                            .orElse(null);
         assertThat(firstTimeReadFromDatabase).isNotNull();
 
         final Date sampleDate = createSampleDate();
@@ -414,7 +416,7 @@ public class ArtifactEntryServiceTest
 
         save(firstTimeReadFromDatabase);
         final ArtifactEntry secondTimeReadFromDatabase = artifactEntryService.findOne(artifactEntryId)
-                .orElse(null);
+                                                                             .orElse(null);
 
         assertThat(secondTimeReadFromDatabase).isNotNull();
 
@@ -423,7 +425,9 @@ public class ArtifactEntryServiceTest
         assertThat(secondTimeReadFromDatabase.getLastUsed()).isEqualTo(sampleDate);
     }
 
-    private Date createSampleDate() throws ParseException {
+    private Date createSampleDate()
+            throws ParseException
+    {
         return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2019-10-31 13:15:50");
     }
 


### PR DESCRIPTION
# Pull Request Description

Adds tests for ArtifactEntry properties that used to have a type of 'date' but now should have a type of 'datetime' and thus store not only date, but also retain time information.

This pull request closes #1475.

# Acceptance Test

* [X] Building the code with `mvn clean install -Dintegration.tests` still works.
* [X] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [X] Yes, please see:
https://github.com/strongbox/strongbox-db/pull/16

  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [X] No
