### PR TITLE
issue-1169: Use SpringBoot "@Value + Resource" to load YAML resources.

### DIFF
--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -202,10 +202,13 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
         </dependency>
     </dependencies>
 

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/config/CommonConfig.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/config/CommonConfig.java
@@ -2,6 +2,7 @@ package org.carlspring.strongbox.config;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan({ "org.carlspring.strongbox.booters",
@@ -15,6 +16,7 @@ import org.springframework.context.annotation.Configuration;
                  "org.carlspring.strongbox.url",
                  "org.carlspring.strongbox.util",
                  "org.carlspring.strongbox.yaml" })
+@Import(PropertiesPathResolverConfig.class)
 public class CommonConfig
 {
 }

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/config/PropertiesPathResolverConfig.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/config/PropertiesPathResolverConfig.java
@@ -1,0 +1,106 @@
+package org.carlspring.strongbox.config;
+
+import java.nio.file.Paths;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
+
+/**
+ * Configures a {@link PropertiesPathResolver} under the name "propertiesPathResolver" - it can then be used in SpEL
+ * expressions to resolve properties lookup path's such as {@code @Value("#{propertiesPathResolver.resolve('customPropName','defaultPropPath')}")}.
+ *
+ * @author cbono
+ */
+@Configuration
+class PropertiesPathResolverConfig
+{
+    @Bean(name = "propertiesPathResolver")
+    PropertiesPathResolver propertiesPathResolver(Environment environment)
+    {
+        return new PropertiesPathResolver(environment);
+    }
+
+    /**
+     * Resolves a final path to use to lookup a properties resource.
+     */
+    static class PropertiesPathResolver
+    {
+        static final String PREFIX_OVERRIDE_PROPERTY = "strongbox.props.default-location-prefix";
+        private static final Logger logger = LoggerFactory.getLogger(PropertiesPathResolver.class);
+        private final Environment environment;
+
+        PropertiesPathResolver(final Environment environment)
+        {
+            this.environment = environment;
+        }
+
+        /**
+         * Resolves a final path to use to lookup a properties resource.
+         * <p>
+         * If there is a user-specified path set in the {@code customPathPropertyName} property then it will used and
+         * prefixed with 'file://' (unless it is already prefixed with 'classpath:' - which should be a rare case).
+         * <p>
+         * Otherwise, the specified {@code defaultPath} will be used and will be prefixed with
+         * {@code 'file:${strongbox.home}'} (unless there is a default path prefix override specified in the
+         * {@link #PREFIX_OVERRIDE_PROPERTY} property).
+         *
+         * @param customPathPropertyName the name of the property that may hold a user specified path
+         * @param defaultPath default path to use if no user specified path is set in the custom path property
+         * @return final path to use to lookup the properties resource - including the proper prefix ('file://' or 'classpath:')
+         */
+        public String resolve(final String customPathPropertyName, final String defaultPath)
+        {
+            final String customPathPropertyValue = environment.getProperty(customPathPropertyName);
+            if (!StringUtils.isEmpty(customPathPropertyValue))
+            {
+                final String resolved = customPathPropertyValue.startsWith("classpath:") || customPathPropertyValue.startsWith("file:") ?
+                                        customPathPropertyValue : "file://" + ensureParentOrCurrentDirAbsolute(customPathPropertyValue);
+                logger.debug("Resolved to path '{}' using custom property '{}'.", resolved, customPathPropertyName);
+                return resolved;
+            }
+
+            // Use 'file://${strongbox.home}' as prefix unless an override has been set
+            final String pathPrefix;
+            final String defaultPathPrefixOverride = environment.getProperty(PREFIX_OVERRIDE_PROPERTY);
+            if (StringUtils.isEmpty(defaultPathPrefixOverride))
+            {
+                pathPrefix = "file://" + getStrongboxHome();
+            }
+            else
+            {
+                pathPrefix = defaultPathPrefixOverride;
+            }
+            logger.debug("Using pathPrefix '{}'.", pathPrefix);
+
+            final String resolved = pathPrefix + defaultPath;
+            logger.debug("Resolved to path '{}' using default '{}' - no custom path set in '{}'.", resolved, defaultPath, customPathPropertyName);
+            return resolved;
+        }
+
+        private String getStrongboxHome() {
+            final String strongboxHome = ensureParentOrCurrentDirAbsolute(environment.getRequiredProperty("strongbox.home"));
+            return strongboxHome.endsWith("/") ? strongboxHome : strongboxHome + "/";
+        }
+
+        private String ensureParentOrCurrentDirAbsolute(final String path) {
+
+            if (path.startsWith("..") ) {
+                final String currentDirAbs = Paths.get(".").toAbsolutePath().normalize().toString();
+                logger.debug("Path started with relative parent dir '..'  - converted to absolute path '{}/..'.", currentDirAbs);
+                return currentDirAbs + "/.." + (path.length() > 2 ? path.substring(2) : "");
+            }
+
+            if (path.startsWith(".")) {
+                final String currentDirAbs = Paths.get(".").toAbsolutePath().normalize().toString();
+                logger.debug("Path started with relative current dir '.'  - converted to absolute path '{}'.", currentDirAbs);
+                return currentDirAbs + (path.length() > 1 ? path.substring(1) : "");
+            }
+
+            return path;
+        }
+    }
+}

--- a/strongbox-commons/src/test/java/org/carlspring/strongbox/config/PropertiesPathResolverConfigTest.java
+++ b/strongbox-commons/src/test/java/org/carlspring/strongbox/config/PropertiesPathResolverConfigTest.java
@@ -1,0 +1,112 @@
+package org.carlspring.strongbox.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.carlspring.strongbox.config.PropertiesPathResolverConfig.PropertiesPathResolver;
+import static org.carlspring.strongbox.config.PropertiesPathResolverConfig.PropertiesPathResolver.PREFIX_OVERRIDE_PROPERTY;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PropertiesPathResolverConfigTest
+{
+    private static final String CURRENT_DIR = System.getProperty("user.dir");
+    private static final String CUSTOM_PATH_PROP = "strongbox.scary-t.file";
+    private static final String STRONGBOX_HOME_PROP = "strongbox.home";
+    private static final String STRONGBOX_HOME_DEFAULT = "/Users/keyboard-kitty/work/sbox";
+    private static final String DEFAULT_PATH = "etc/configzzz.yaml";
+
+    private Environment env;
+    private PropertiesPathResolver resolver;
+
+    @BeforeEach
+    public void setUp()
+    {
+        env = mock(Environment.class);
+        resolver = new PropertiesPathResolver(env);
+    }
+
+    @Test
+    public void testCustomAbsolutePath()
+    {
+        final String customPropValue = "/Users/sleepy/one/conf.yaml";
+        prepareProps(STRONGBOX_HOME_DEFAULT, customPropValue, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + customPropValue);
+    }
+
+    @Test
+    public void testCustomAbsolutePathAlreadyPrefixedWithClasspathScheme()
+    {
+        final String customPropValue = "classpath:conf.yaml";
+        prepareProps(STRONGBOX_HOME_DEFAULT, customPropValue, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo(customPropValue);
+    }
+
+    @Test
+    public void testCustomAbsolutePathAlreadyPrefixedWithFileScheme()
+    {
+        final String customPropValue = "file:conf.yaml";
+        prepareProps(STRONGBOX_HOME_DEFAULT, customPropValue, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo(customPropValue);
+    }
+
+    @Test
+    public void testCustomRelativePathToCurrentDir()
+    {
+        final String customPropValue = "./conf.yaml";
+        prepareProps(STRONGBOX_HOME_DEFAULT, customPropValue, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + CURRENT_DIR + "/conf.yaml");
+    }
+
+    @Test
+    public void testCustomRelativePathToParentDir()
+    {
+        final String customPropValue = "../conf.yaml";
+        prepareProps(STRONGBOX_HOME_DEFAULT, customPropValue, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + CURRENT_DIR + "/../conf.yaml");
+    }
+
+    @Test
+    public void testDefaultPathWithOverridePrefix()
+    {
+        final String defaultPrefixOverride = "classpath:";
+        prepareProps(STRONGBOX_HOME_DEFAULT, null, defaultPrefixOverride);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo(defaultPrefixOverride + DEFAULT_PATH);
+    }
+
+    @Test
+    public void testDefaultPathWithAbsoluteStrongboxHomeNoEndingSlash()
+    {
+        prepareProps(STRONGBOX_HOME_DEFAULT, null, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + STRONGBOX_HOME_DEFAULT + "/" + DEFAULT_PATH);
+    }
+
+    @Test
+    public void testDefaultPathWithAbsoluteStrongboxHomeWithEndingSlash()
+    {
+        prepareProps(STRONGBOX_HOME_DEFAULT + "/", null, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + STRONGBOX_HOME_DEFAULT + "/" + DEFAULT_PATH);
+    }
+
+    @Test
+    public void testDefaultPathWithRelativeCurrentDirStrongboxHome()
+    {
+        prepareProps(".", null, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + CURRENT_DIR + "/" + DEFAULT_PATH);
+    }
+
+    @Test
+    public void testDefaultPathWithRelativeParentDirStrongboxHome()
+    {
+        prepareProps("..", null, null);
+        assertThat(resolver.resolve(CUSTOM_PATH_PROP, DEFAULT_PATH)).isEqualTo("file://" + CURRENT_DIR + "/../" + DEFAULT_PATH);
+    }
+
+    private void prepareProps(final String strongboxHome, final String customPropValue, final String defaultPrefixOverride)
+    {
+        when(env.getRequiredProperty(STRONGBOX_HOME_PROP)).thenReturn(strongboxHome);
+        when(env.getProperty(CUSTOM_PATH_PROP)).thenReturn(customPropValue);
+        when(env.getProperty(PREFIX_OVERRIDE_PROPERTY)).thenReturn(defaultPrefixOverride);
+    }
+}

--- a/strongbox-configuration/src/main/java/org/carlspring/strongbox/yaml/YamlFileManager.java
+++ b/strongbox-configuration/src/main/java/org/carlspring/strongbox/yaml/YamlFileManager.java
@@ -2,14 +2,13 @@ package org.carlspring.strongbox.yaml;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Objects;
 
-import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.util.ServiceLoaderUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,45 +21,36 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 /**
  * @author Przemyslaw Fusik
  * @author Pablo Tirado
+ * @author cbono
  */
 public abstract class YamlFileManager<T>
 {
-
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final Class<T> myClazz;
 
     private final YAMLMapper yamlMapper;
 
-    public YamlFileManager(YAMLMapperFactory yamlMapperFactory)
+    protected YamlFileManager(YAMLMapperFactory yamlMapperFactory)
     {
         this(yamlMapperFactory, new Class[0]);
     }
 
     @SuppressWarnings("unchecked")
-    public YamlFileManager(YAMLMapperFactory yamlMapperFactory,
-                           Class<?>... classes)
+    protected YamlFileManager(YAMLMapperFactory yamlMapperFactory, Class<?>... classes)
     {
         myClazz = (Class<T>) GenericTypeResolver.resolveTypeArgument(getClass(), YamlFileManager.class);
         yamlMapper = yamlMapperFactory.create(ServiceLoaderUtils.load(classes));
     }
 
-    public abstract String getPropertyKey();
-
-    public abstract String getDefaultLocation();
-
-    public abstract ConfigurationResourceResolver getConfigurationResourceResolver();
-
-    public Resource getResource()
-    {
-        return getConfigurationResourceResolver().getConfigurationResource(getPropertyKey(), getDefaultLocation());
-    }
+    protected abstract Resource getResource();
 
     public synchronized void store(final T configuration) throws IOException
     {
         Objects.nonNull(configuration);
-        
+
         Resource resource = getResource();
+
         //Check that target resource stored on FS and not under classpath for example
         if (!resource.isFile() || resource instanceof ClassPathResource)
         {
@@ -68,7 +58,8 @@ public abstract class YamlFileManager<T>
             return;
         }
 
-        try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(Paths.get(resource.getURI()))))
+        // Write the content - we know its a file at this point - use resource.getFile to work w/ Windows
+        try (OutputStream os = new BufferedOutputStream(Files.newOutputStream(resource.getFile().toPath())))
         {
             yamlMapper.writeValue(os, configuration);
         }
@@ -82,10 +73,12 @@ public abstract class YamlFileManager<T>
             return null;
         }
 
-        try (InputStream inputStream = new BufferedInputStream(resource.getInputStream()))
+        // Read the content - use FileInputStream for file resources to work w/ Windows
+        try (InputStream inputStream = new BufferedInputStream(resource.isFile() ?
+                                                               new FileInputStream(resource.getFile()) :
+                                                               resource.getInputStream()))
         {
             return yamlMapper.readValue(inputStream, myClazz);
         }
     }
-
 }

--- a/strongbox-cron/strongbox-cron-api/pom.xml
+++ b/strongbox-cron/strongbox-cron-api/pom.xml
@@ -99,6 +99,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>strongbox-testing-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.mchange</groupId>

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/config/CronTasksConfigurationFileManager.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/config/CronTasksConfigurationFileManager.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.cron.config;
 
 import org.carlspring.strongbox.cron.domain.CronTasksConfigurationDto;
-import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.yaml.YAMLMapperFactory;
 import org.carlspring.strongbox.yaml.YamlFileManager;
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,9 +18,8 @@ import org.springframework.stereotype.Component;
 public class CronTasksConfigurationFileManager
         extends YamlFileManager<CronTasksConfigurationDto>
 {
-
-    @Inject
-    private ConfigurationResourceResolver configurationResourceResolver;
+    @Value("#{@propertiesPathResolver.resolve('strongbox.cron.tasks.yaml','etc/conf/strongbox-cron-tasks.yaml')}")
+    private Resource resource;
 
     @Inject
     public CronTasksConfigurationFileManager(YAMLMapperFactory yamlMapperFactory)
@@ -28,21 +28,8 @@ public class CronTasksConfigurationFileManager
     }
 
     @Override
-    public String getPropertyKey()
+    protected Resource getResource()
     {
-        return "strongbox.cron.tasks.yaml";
+        return resource;
     }
-
-    @Override
-    public String getDefaultLocation()
-    {
-        return "etc/conf/strongbox-cron-tasks.yaml";
-    }
-
-    @Override
-    public ConfigurationResourceResolver getConfigurationResourceResolver()
-    {
-        return configurationResourceResolver;
-    }
-
 }

--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
@@ -73,14 +73,6 @@
         </dependency>
 
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>strongbox-authentication-support</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-ldap</artifactId>
         </dependency>
@@ -101,6 +93,22 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>strongbox-authentication-support</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>strongbox-testing-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/strongbox-security/strongbox-authentication-registry/pom.xml
+++ b/strongbox-security/strongbox-authentication-registry/pom.xml
@@ -109,6 +109,13 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>strongbox-testing-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/AuthorizationConfigFileManager.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/authorization/AuthorizationConfigFileManager.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.authorization;
 
 import org.carlspring.strongbox.authorization.dto.AuthorizationConfigDto;
-import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.yaml.YAMLMapperFactory;
 import org.carlspring.strongbox.yaml.YamlFileManager;
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,9 +18,8 @@ import org.springframework.stereotype.Component;
 public class AuthorizationConfigFileManager
         extends YamlFileManager<AuthorizationConfigDto>
 {
-
-    @Inject
-    private ConfigurationResourceResolver configurationResourceResolver;
+    @Value("#{@propertiesPathResolver.resolve('strongbox.authorization.config.yaml','etc/conf/strongbox-authorization.yaml')}")
+    private Resource resource;
 
     @Inject
     public AuthorizationConfigFileManager(YAMLMapperFactory yamlMapperFactory)
@@ -28,21 +28,8 @@ public class AuthorizationConfigFileManager
     }
 
     @Override
-    public String getPropertyKey()
+    protected Resource getResource()
     {
-        return "strongbox.authorization.config.yaml";
+        return resource;
     }
-
-    @Override
-    public String getDefaultLocation()
-    {
-        return "etc/conf/strongbox-authorization.yaml";
-    }
-
-    @Override
-    public ConfigurationResourceResolver getConfigurationResourceResolver()
-    {
-        return configurationResourceResolver;
-    }
-
 }

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/UsersFileManager.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/UsersFileManager.java
@@ -1,12 +1,13 @@
 package org.carlspring.strongbox.users;
 
-import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.users.dto.UsersDto;
 import org.carlspring.strongbox.yaml.YAMLMapperFactory;
 import org.carlspring.strongbox.yaml.YamlFileManager;
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,9 +18,8 @@ import org.springframework.stereotype.Component;
 public class UsersFileManager
         extends YamlFileManager<UsersDto>
 {
-
-    @Inject
-    private ConfigurationResourceResolver configurationResourceResolver;
+    @Value("#{@propertiesPathResolver.resolve('strongbox.users.config.yaml','etc/conf/strongbox-security-users.yaml')}")
+    private Resource resource;
 
     @Inject
     public UsersFileManager(YAMLMapperFactory yamlMapperFactory)
@@ -27,23 +27,9 @@ public class UsersFileManager
         super(yamlMapperFactory);
     }
 
-
     @Override
-    public String getPropertyKey()
+    protected Resource getResource()
     {
-        return "strongbox.users.config.yaml";
+        return resource;
     }
-
-    @Override
-    public String getDefaultLocation()
-    {
-        return "etc/conf/strongbox-security-users.yaml";
-    }
-
-    @Override
-    public ConfigurationResourceResolver getConfigurationResourceResolver()
-    {
-        return configurationResourceResolver;
-    }
-
 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/ConfigurationFileManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/configuration/ConfigurationFileManager.java
@@ -1,6 +1,5 @@
 package org.carlspring.strongbox.configuration;
 
-import org.carlspring.strongbox.resource.ConfigurationResourceResolver;
 import org.carlspring.strongbox.yaml.YAMLMapperFactory;
 import org.carlspring.strongbox.yaml.YamlFileManager;
 import org.carlspring.strongbox.yaml.repository.CustomRepositoryConfigurationDto;
@@ -8,6 +7,8 @@ import org.carlspring.strongbox.yaml.repository.remote.RemoteRepositoryConfigura
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
 /**
@@ -17,9 +18,8 @@ import org.springframework.stereotype.Component;
 public class ConfigurationFileManager
         extends YamlFileManager<MutableConfiguration>
 {
-
-    @Inject
-    private ConfigurationResourceResolver configurationResourceResolver;
+    @Value("#{@propertiesPathResolver.resolve('strongbox.config.file','etc/conf/strongbox.yaml')}")
+    private Resource resource;
 
     @Inject
     public ConfigurationFileManager(YAMLMapperFactory yamlMapperFactory)
@@ -28,21 +28,8 @@ public class ConfigurationFileManager
     }
 
     @Override
-    public String getPropertyKey()
+    protected Resource getResource()
     {
-        return "strongbox.config.file";
+        return resource;
     }
-
-    @Override
-    public String getDefaultLocation()
-    {
-        return "etc/conf/strongbox.yaml";
-    }
-
-    @Override
-    public ConfigurationResourceResolver getConfigurationResourceResolver()
-    {
-        return configurationResourceResolver;
-    }
-
 }

--- a/strongbox-testing/strongbox-testing-core/pom.xml
+++ b/strongbox-testing/strongbox-testing-core/pom.xml
@@ -111,8 +111,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
         <!-- Logging -->

--- a/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/config/AutomaticTestPropertiesEnvironmentPostProcessor.java
+++ b/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/config/AutomaticTestPropertiesEnvironmentPostProcessor.java
@@ -1,0 +1,37 @@
+package org.carlspring.strongbox.config;
+
+import org.carlspring.strongbox.config.PropertiesPathResolverConfig.PropertiesPathResolver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * Initializes the Environment with a set of default values for the following properties:
+ * <pre>
+ *  <ul>
+ *      <li>{@link PropertiesPathResolver#PREFIX_OVERRIDE_PROPERTY}='classpath:'</li>
+ *  </ul>
+ */
+@Order(100) // No signficance other than to preserve consistent load order
+class AutomaticTestPropertiesEnvironmentPostProcessor implements EnvironmentPostProcessor
+{
+    private static final String PROPERTY_SOURCE_NAME = "strongboxAutomaticTestProperties";
+
+    @Override
+    public void postProcessEnvironment(final ConfigurableEnvironment environment,
+                                       final SpringApplication application)
+    {
+        final Map<String, Object> properties = new HashMap<>();
+
+        // Force all resolved paths to be prefixed with 'classpath:' during tests
+        properties.put(PropertiesPathResolver.PREFIX_OVERRIDE_PROPERTY, "classpath:");
+
+        environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+    }
+}

--- a/strongbox-testing/strongbox-testing-core/src/main/resources/META-INF/spring.factories
+++ b/strongbox-testing/strongbox-testing-core/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.carlspring.strongbox.config.AutomaticTestPropertiesEnvironmentPostProcessor


### PR DESCRIPTION
# Pull Request Description

This is a proposed fix for #1169 

## Technical details

* Uses built-in SpringBoot `@Value + Resource` instead of custom ResourceLoader
* In order for the above to work - defined a function to be used in `SpEL` of the `@Value` to resolve path properly
* Override the path resolve in test env by setting an override property prefixed to `classpath:`

**Concerns:**
* Although we now leverage the built-in Spring Boot reosurce loading, some of the complexity around the path resolving is still present - albeit pushed under the surface a bit. I was hoping to not have to "pretty up" the paths like this but I wanted to follow through w/ the solution, get it in front of everyone as a working PR, and then we can decide what we want to do w/ it.

### TODOs
* [ ] Group to decide to move forward or not w/ these changes
* [ ] If group consensus is to move forward - create a unit test for `YamlPropertyPathResolver`.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
