### PR TITLE
Issue 1500 Use built-in formatting in logging methods

### DIFF
--- a/strongbox-aql/src/test/java/org/carlspring/strongbox/aql/AqlParserTest.java
+++ b/strongbox-aql/src/test/java/org/carlspring/strongbox/aql/AqlParserTest.java
@@ -33,7 +33,7 @@ public class AqlParserTest
 
         AqlQueryParser aqlParser = new AqlQueryParser(query);
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         Selector<ArtifactEntry> selector = aqlParser.parseQuery();
         Predicate predicate = selector.getPredicate();
@@ -47,7 +47,7 @@ public class AqlParserTest
 
         aqlParser = new AqlQueryParser(query);
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         Map<Pair<Integer, Integer>, String> errorMap = null;
         try
@@ -59,7 +59,7 @@ public class AqlParserTest
             errorMap = aqlParser.getErrors();
         }
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isTrue();
         assertThat(errorMap).isNotNull();
@@ -80,7 +80,7 @@ public class AqlParserTest
 
         aqlParser.parseQuery();
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isFalse();
     }
@@ -94,7 +94,7 @@ public class AqlParserTest
 
         aqlParser.parseQuery();
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isFalse();
     }
@@ -115,7 +115,7 @@ public class AqlParserTest
             errorMap = aqlParser.getErrors();
         }
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isTrue();
         assertThat(errorMap).isNotNull();
@@ -135,7 +135,7 @@ public class AqlParserTest
 
         aqlParser.parseQuery();
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isFalse();
     }
@@ -149,7 +149,7 @@ public class AqlParserTest
 
         AqlQueryParser aqlParser = new AqlQueryParser(query);
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         Selector<ArtifactEntry> selector = aqlParser.parseQuery();
         Predicate predicate = selector.getPredicate();
@@ -162,7 +162,7 @@ public class AqlParserTest
 
         String sqlQuery = queryTemplate.calculateQueryString(selector);
 
-        logger.debug(String.format("Query [%s] parse result:\n[%s]", query, sqlQuery));
+        logger.debug("Query [{}] parse result:\n[{}]", query, sqlQuery);
 
         assertThat(sqlQuery)
                 .isEqualTo("SELECT * " +
@@ -181,7 +181,7 @@ public class AqlParserTest
 
         Map<String, Object> parameterMap = queryTemplate.exposeParameterMap(predicate);
 
-        logger.debug(String.format("Query [%s] parse parameters:\n[%s]", query, parameterMap));
+        logger.debug("Query [{}] parse parameters:\n[{}]", query, parameterMap);
 
         assertThat(parameterMap)
                 .isEqualTo(ImmutableMap.of("storageId_0",
@@ -213,7 +213,7 @@ public class AqlParserTest
             errorMap = aqlParser.getErrors();
         }
 
-        logger.debug(String.format("Query [%s] parse tree:\n[%s]", query, aqlParser));
+        logger.debug("Query [{}] parse tree:\n[{}]", query, aqlParser);
 
         assertThat(aqlParser.hasErrors()).isTrue();
         assertThat(errorMap).isNotNull();

--- a/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
@@ -373,7 +373,7 @@ public class ArtifactClient
     {
         if (username != null && password != null)
         {
-            logger.trace("[setupAuthentication] {}@{}", username, password);
+            logger.trace("[setupAuthentication] {}", username);
             target.register(HttpAuthenticationFeature.basic(username, password));
             return target;
         }

--- a/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/client/ArtifactClient.java
@@ -165,7 +165,7 @@ public class ArtifactClient
     {
         String url = getContextBaseUrl() + (!path.startsWith("/") ? "/" : "") + path;
 
-        logger.debug("Getting " + url + "...");
+        logger.debug("Getting {}...", url);
 
         WebTarget resource = getClientInstance().target(url);
         setupAuthentication(resource);
@@ -204,7 +204,7 @@ public class ArtifactClient
     {
         String url = getContextBaseUrl() + (!path.startsWith("/") ? "/" : "") + path;
 
-        logger.debug("Getting " + url + "...");
+        logger.debug("Getting {}...", url);
 
         WebTarget resource = getClientInstance().target(url);
         setupAuthentication(resource);
@@ -229,7 +229,7 @@ public class ArtifactClient
         String url = getContextBaseUrl() + "/storages/" + storageId + "/" + repositoryId + "/" + path +
                      (force ? "?force=" + force : "");
 
-        logger.info("Getting " + url + "...");
+        logger.info("Getting {}...", url);
         
         WebTarget resource = getClientInstance().target(url);
         setupAuthentication(resource);
@@ -320,7 +320,7 @@ public class ArtifactClient
     {
         String url = escapeUrl(path);
 
-        logger.debug("Path to artifact: " + url);
+        logger.debug("Path to artifact: {}", url);
 
         WebTarget resource = getClientInstance().target(url);
         setupAuthentication(resource);
@@ -373,7 +373,7 @@ public class ArtifactClient
     {
         if (username != null && password != null)
         {
-            logger.trace("[setupAuthentication] " + username + "@" + password);
+            logger.trace("[setupAuthentication] {}@{}", username, password);
             target.register(HttpAuthenticationFeature.basic(username, password));
             return target;
         }

--- a/strongbox-client/src/main/java/org/carlspring/strongbox/client/RestArtifactResolver.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/client/RestArtifactResolver.java
@@ -73,7 +73,7 @@ public class RestArtifactResolver
     {
         String url = escapeUrl(path);
 
-        logger.debug("Getting " + url + "...");
+        logger.debug("Getting {}...", url);
 
         WebTarget resource = new WebTargetBuilder(url).withAuthentication()
                                                       .customRequestConfig()
@@ -98,7 +98,7 @@ public class RestArtifactResolver
     {
         String url = escapeUrl(path);
 
-        logger.debug("Heading " + url + "...");
+        logger.debug("Heading {}...", url);
 
         WebTarget resource = new WebTargetBuilder(url)
                                      .withAuthentication()

--- a/strongbox-client/src/main/java/org/carlspring/strongbox/service/impl/ProxyRepositoryConnectionPoolConfigurationServiceImpl.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/service/impl/ProxyRepositoryConnectionPoolConfigurationServiceImpl.java
@@ -36,7 +36,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
         implements ProxyRepositoryConnectionPoolConfigurationService
 {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(
+    private static final Logger logger = LoggerFactory.getLogger(
             ProxyRepositoryConnectionPoolConfigurationServiceImpl.class);
 
     private PoolingHttpClientConnectionManager poolingHttpClientConnectionManager;
@@ -129,7 +129,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
         }
         else
         {
-            LOGGER.warn("Not setting max repository connections to {} as it is no positive value", max);
+            logger.warn("Not setting max repository connections to {} as it is no positive value", max);
         }
     }
 
@@ -175,7 +175,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
             }
             else
             {
-                LOGGER.warn("Unknown port of uri {}", repository);
+                logger.warn("Unknown port of uri {}", repository);
             }
 
             HttpHost httpHost = new HttpHost(uri.getHost(), port, uri.getScheme());
@@ -184,7 +184,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
         }
         catch (URISyntaxException e)
         {
-            LOGGER.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
         }
 
         // default http route creation

--- a/strongbox-client/src/main/java/org/carlspring/strongbox/service/impl/ProxyRepositoryConnectionPoolConfigurationServiceImpl.java
+++ b/strongbox-client/src/main/java/org/carlspring/strongbox/service/impl/ProxyRepositoryConnectionPoolConfigurationServiceImpl.java
@@ -129,7 +129,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
         }
         else
         {
-            LOGGER.warn("Not setting max repository connections to %s as it is no positive value", max);
+            LOGGER.warn("Not setting max repository connections to {} as it is no positive value", max);
         }
     }
 
@@ -175,7 +175,7 @@ public class ProxyRepositoryConnectionPoolConfigurationServiceImpl
             }
             else
             {
-                LOGGER.warn("Unknown port of uri %s", repository);
+                LOGGER.warn("Unknown port of uri {}", repository);
             }
 
             HttpHost httpHost = new HttpHost(uri.getHost(), port, uri.getScheme());

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/booters/TempDirBooter.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/booters/TempDirBooter.java
@@ -54,17 +54,17 @@ public class TempDirBooter
             Files.createDirectories(tempDirPath);
         }
 
-        logger.debug("Temporary directory: " + tempDirPath.toString() + ".");
+        logger.debug("Temporary directory: {}.", tempDirPath);
 
         if (System.getProperty("java.io.tmpdir") == null)
         {
             System.setProperty("java.io.tmpdir", tempDirPath.toString());
 
-            logger.debug("Set java.io.tmpdir to " + tempDirPath.toString() + ".");
+            logger.debug("Set java.io.tmpdir to {}.", tempDirPath);
         }
         else
         {
-            logger.debug("The java.io.tmpdir is already set to " + System.getProperty("java.io.tmpdir") + ".");
+            logger.debug("The java.io.tmpdir is already set to {}.", System.getProperty("java.io.tmpdir"));
         }
     }
     
@@ -75,14 +75,14 @@ public class TempDirBooter
         Files.createDirectories(lockFile.getParent());
         Files.createFile(lockFile);
 
-        logger.debug(" -> Created lock file '" + lockFile.toAbsolutePath().toString() + "'...");
+        logger.debug(" -> Created lock file '{}'...", lockFile.toAbsolutePath());
     }
     
     private boolean lockExists()
     {
         if (Files.exists(lockFile))
         {
-            logger.debug(" -> Lock found: '" + propertiesBooter.getVaultDirectory() + "'!");
+            logger.debug(" -> Lock found: '{}'!", propertiesBooter.getVaultDirectory());
 
             return true;
         }
@@ -100,7 +100,7 @@ public class TempDirBooter
     {
         Files.deleteIfExists(lockFile);
 
-        logger.debug("Removed lock file '" + lockFile.toAbsolutePath().toString() + "'.");
+        logger.debug("Removed lock file '{}'.", lockFile.toAbsolutePath());
     }
 
 }

--- a/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ConfigurationResourceResolver.java
+++ b/strongbox-commons/src/main/java/org/carlspring/strongbox/resource/ConfigurationResourceResolver.java
@@ -74,31 +74,31 @@ public class ConfigurationResourceResolver
         String filename;
         if ((filename = getProperty(propertyKey)) != null)
         {
-            logger.debug(String.format("Using configured resource path [%s]", filename));
+            logger.debug("Using configured resource path [{}]", filename);
 
             return resourceLoader.getResource(filename);
         }
 
-        logger.debug(String.format("Try to fetch configuration resource path [%s]", configurationPath));
+        logger.debug("Try to fetch configuration resource path [{}]", configurationPath);
 
         if (configurationPath != null &&
             (!configurationPath.startsWith("classpath") && !(Files.exists(Paths.get(configurationPath)))))
         {
-            logger.info(String.format("Configuration resource [%s] does not exist, will try to resolve with configured location [%s].",
-                                      configurationPath, propertyKey));
+            logger.info("Configuration resource [{}] does not exist, will try to resolve with configured location [{}].",
+                        configurationPath, propertyKey);
 
             configurationPath = null;
         }
 
         if (configurationPath != null)
         {
-            logger.debug(String.format("Using provided resource path [%s]", configurationPath));
+            logger.debug("Using provided resource path [{}]", configurationPath);
 
             return resourceLoader.getResource(configurationPath);
         }
         else
         {
-            logger.debug(String.format("Using default resource path [%s]", propertyDefaultValue));
+            logger.debug("Using default resource path [{}]", propertyDefaultValue);
 
             return resourceLoader.getResource(propertyDefaultValue);
         }

--- a/strongbox-configuration/src/main/java/org/carlspring/strongbox/yaml/YamlFileManager.java
+++ b/strongbox-configuration/src/main/java/org/carlspring/strongbox/yaml/YamlFileManager.java
@@ -64,7 +64,7 @@ public abstract class YamlFileManager<T>
         //Check that target resource stored on FS and not under classpath for example
         if (!resource.isFile() || resource instanceof ClassPathResource)
         {
-            logger.warn(String.format("Skip resource store [%s]", resource));
+            logger.warn("Skip resource store [{}]", resource);
             return;
         }
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/jobs/AbstractCronJob.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/jobs/AbstractCronJob.java
@@ -87,7 +87,7 @@ public abstract class AbstractCronJob
         }
         catch (Throwable e)
         {
-            logger.error(String.format("Failed to execute cron job task [%s].", configuration.getName()), e);
+            logger.error("Failed to execute cron job task [{}].", configuration.getName(), e);
         }
         manager.addExecutedJob(configuration.getUuid().toString(), true);
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
@@ -109,7 +109,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (SchedulerException e)
         {
-            logger.error("Failed to schedule Cron Job:\n [{}]", cronTaskConfiguration, e);
+            logger.error("Failed to schedule Cron Job: [{}]", cronTaskConfiguration, e);
 
             return;
         }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
@@ -109,7 +109,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (SchedulerException e)
         {
-            logger.error("Failed to schedule Cron Job:%n [{}]", cronTaskConfiguration, e);
+            logger.error("Failed to schedule Cron Job:\n [{}]", cronTaskConfiguration, e);
 
             return;
         }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronJobSchedulerServiceImpl.java
@@ -40,7 +40,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (ClassNotFoundException e)
         {
-            logger.error(String.format("Failed to schedule cron job [%s]", jobClassName), e);
+            logger.error("Failed to schedule cron job [{}]", jobClassName, e);
 
             return;
         }
@@ -65,7 +65,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (SchedulerException e)
         {
-            logger.error(String.format("Failed to add Cron Job [%s] to the Scheduler", cronTaskConfiguration), e);
+            logger.error("Failed to add Cron Job [{}] to the Scheduler", cronTaskConfiguration, e);
             return;
         }
 
@@ -80,8 +80,7 @@ public class CronJobSchedulerServiceImpl
             }
             catch (SchedulerException e)
             {
-                logger.error(String.format("Failed to trigger Cron Job [%s] by the Scheduler", cronTaskConfiguration),
-                             e);
+                logger.error("Failed to trigger Cron Job [{}] by the Scheduler", cronTaskConfiguration, e);
                 return;
             }
 
@@ -110,7 +109,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (SchedulerException e)
         {
-            logger.error(String.format("Failed to schedule Cron Job:%n [%s]", cronTaskConfiguration), e);
+            logger.error("Failed to schedule Cron Job:%n [{}]", cronTaskConfiguration, e);
 
             return;
         }
@@ -128,7 +127,7 @@ public class CronJobSchedulerServiceImpl
         }
         catch (SchedulerException e)
         {
-            logger.error(String.format("Failed to delete cron job [%s]", jobKey));
+            logger.error("Failed to delete cron job [{}]", jobKey);
         }
     }
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskDataServiceImpl.java
@@ -82,7 +82,7 @@ public class CronTaskDataServiceImpl
                 }
                 catch (ClassNotFoundException e)
                 {
-                    logger.warn(String.format("Skip configuration, job class not found [%s].", jobClass));
+                    logger.warn("Skip configuration, job class not found [{}].", jobClass);
                     iterator.remove();
                 }
             }

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskExecutor.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskExecutor.java
@@ -23,7 +23,7 @@ import org.springframework.util.ReflectionUtils;
 public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBean
 {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CronTaskExecutor.class);
+    private static final Logger logger = LoggerFactory.getLogger(CronTaskExecutor.class);
 
     public CronTaskExecutor(int corePoolSize,
                             int maximumPoolSize,
@@ -83,7 +83,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error("Before execute failed for [{}]", r, e);
+            logger.error("Before execute failed for [{}]", r, e);
         }
     }
 
@@ -91,7 +91,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
     {
         Class<? extends Job> jobClass = jd.getJobClass();
         String jobClassName = jobClass.getSimpleName();
-        LOGGER.debug("Bootstrap Cron Job [{}]", jobClassName);
+        logger.debug("Bootstrap Cron Job [{}]", jobClassName);
         MDC.put(CronTaskContextAcceptFilter.STRONGBOX_CRON_CONTEXT_NAME, LoggingUtils.caclucateCronContextName(jobClass));
     }
 
@@ -106,7 +106,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error("Failed to expose Cron Job details for [{}] class",
+            logger.error("Failed to expose Cron Job details for [{}] class",
                          r.getClass().getSimpleName(), e);
         }
         return null;
@@ -123,7 +123,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error("After execute failed for [{}]", r, e);
+            logger.error("After execute failed for [{}]", r, e);
         }
     }
 

--- a/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskExecutor.java
+++ b/strongbox-cron/strongbox-cron-api/src/main/java/org/carlspring/strongbox/cron/services/impl/CronTaskExecutor.java
@@ -83,7 +83,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error(String.format("Before execute failed for [%s]", r), e);
+            LOGGER.error("Before execute failed for [{}]", r, e);
         }
     }
 
@@ -91,7 +91,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
     {
         Class<? extends Job> jobClass = jd.getJobClass();
         String jobClassName = jobClass.getSimpleName();
-        LOGGER.debug(String.format("Bootstrap Cron Job [%s]", jobClassName));
+        LOGGER.debug("Bootstrap Cron Job [{}]", jobClassName);
         MDC.put(CronTaskContextAcceptFilter.STRONGBOX_CRON_CONTEXT_NAME, LoggingUtils.caclucateCronContextName(jobClass));
     }
 
@@ -106,9 +106,8 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error(String.format("Failed to expose Cron Job details for [%s] class",
-                                       r.getClass().getSimpleName()),
-                         e);
+            LOGGER.error("Failed to expose Cron Job details for [{}] class",
+                         r.getClass().getSimpleName(), e);
         }
         return null;
     }
@@ -124,7 +123,7 @@ public class CronTaskExecutor extends ThreadPoolExecutor implements DisposableBe
         }
         catch (Exception e)
         {
-            LOGGER.error(String.format("After execute failed for [%s]", r), e);
+            LOGGER.error("After execute failed for [{}]", r, e);
         }
     }
 

--- a/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
@@ -57,7 +57,7 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJob
             }
             catch (NumberFormatException ex)
             {
-                logger.error("Invalid Long value [{}] of 'minSizeInBytes' property. Cron job won't be fired.",
+                logger.error("Invalid long value [{}] of 'minSizeInBytes' property. Cron job won't be fired.",
                              minSizeInBytesText, ex);
                 return;
             }

--- a/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
@@ -43,8 +43,9 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJob
         }
         catch (NumberFormatException ex)
         {
-            logger.error("Invalid integer value [" + lastAccessedTimeInDaysText +
-                         "] of 'lastAccessedTimeInDays' property. Cron job won't be fired.", ex);
+            logger.error("Invalid integer value [{}] of 'lastAccessedTimeInDays' property. Cron job won't be fired.",
+                         lastAccessedTimeInDaysText,
+                         ex);
             return;
         }
 
@@ -57,8 +58,8 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJob
             }
             catch (NumberFormatException ex)
             {
-                logger.error("Invalid Long value [" + minSizeInBytesText +
-                             "] of 'minSizeInBytes' property. Cron job won't be fired.", ex);
+                logger.error("Invalid Long value [{}] of 'minSizeInBytes' property. Cron job won't be fired.",
+                             minSizeInBytesText, ex);
                 return;
             }
         }

--- a/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/main/java/org/carlspring/strongbox/cron/jobs/CleanupExpiredArtifactsFromProxyRepositoriesCronJob.java
@@ -44,8 +44,7 @@ public class CleanupExpiredArtifactsFromProxyRepositoriesCronJob
         catch (NumberFormatException ex)
         {
             logger.error("Invalid integer value [{}] of 'lastAccessedTimeInDays' property. Cron job won't be fired.",
-                         lastAccessedTimeInDaysText,
-                         ex);
+                         lastAccessedTimeInDaysText, ex);
             return;
         }
 

--- a/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronTestCase.java
+++ b/strongbox-cron/strongbox-cron-tasks/src/test/java/org/carlspring/strongbox/cron/jobs/BaseCronTestCase.java
@@ -84,7 +84,7 @@ abstract class BaseCronTestCase implements ApplicationListener<CronTaskEvent>, A
             receivedExpectedEvent = true;
             receivedEvent = event;
 
-            logger.debug("Received expected event: " + expectedEventType);
+            logger.debug("Received expected event: {}", expectedEventType);
         }
     }
 
@@ -104,7 +104,7 @@ abstract class BaseCronTestCase implements ApplicationListener<CronTaskEvent>, A
                                long checkInterval)
             throws InterruptedException
     {
-        logger.debug("Expecting event type " + expectedEventType + " for '" + expectedCronTaskName + "'...");
+        logger.debug("Expecting event type {} for '{}'...", expectedEventType, expectedCronTaskName);
 
         int totalWait = 0;
         while (!receivedExpectedEvent &&

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/EmbeddedOrientDbConfig.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/EmbeddedOrientDbConfig.java
@@ -60,11 +60,11 @@ public class EmbeddedOrientDbConfig
         String database = serverProperties.getDatabase();
         if (orientDB.exists(database))
         {
-            logger.info("Re-using existing database " + database + ".");
+            logger.info("Re-using existing database {}.", database);
             
             return orientDB;
         }
-        logger.info(String.format("Database does not exist. Copying fresh database snapshot from classpath..."));
+        logger.info("Database does not exist. Copying fresh database snapshot from classpath...");
 
         try (JarFile jar = getDbSchemaClasspathLocation())
         {

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/InMemoryOrientDbConfig.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/InMemoryOrientDbConfig.java
@@ -39,7 +39,7 @@ public class InMemoryOrientDbConfig
     OrientDB orientDB(OrientDbServerConfiguration serverProperties)
     {
         String database = serverProperties.getDatabase();
-        logger.info(String.format("Initialize In-Memory OrientDB server for [%s]", database));
+        logger.info("Initialize In-Memory OrientDB server for [{}]", database);
 
         OrientDB orientDB = new OrientDB(StringUtils.substringBeforeLast(serverProperties.getUrl(), "/"),
                                          serverProperties.getUsername(),
@@ -47,7 +47,7 @@ public class InMemoryOrientDbConfig
                                          getOrientDBConfig());
         if (!orientDB.exists(database))
         {
-            logger.info(String.format("Creating database [%s]...", database));
+            logger.info("Creating database [{}]...", database);
             orientDB.create(database, ODatabaseType.MEMORY);
 
             try (ODatabaseSession session = orientDB.open(database, ORIENTDB_DEFAULT_USERNAME,

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/OrientDbProfile.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/config/orientdb/OrientDbProfile.java
@@ -49,7 +49,7 @@ public class OrientDbProfile
     {
         String profile = System.getProperty(PROPERTY_PROFILE, PROFILE_MEMORY);
         
-        logger.info(String.format("Bootstrap OrientDB connection properties with profile [%s].", profile));
+        logger.info("Bootstrap OrientDB connection properties with profile [{}].", profile);
 
         try (InputStream is = OrientDbProfile.class.getResourceAsStream(String.format("/META-INF/properties/%s.properties",
                                                                                       profile)))
@@ -65,7 +65,7 @@ public class OrientDbProfile
                               return;
                           }
 
-                          logger.debug(String.format("Using default value for OrientDB connection property [%s].", p));
+                          logger.debug("Using default value for OrientDB connection property [{}].", p);
 
                           System.setProperty((String) p, properties.getProperty((String) p));
                       });

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/criteria/OQueryTemplate.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/criteria/OQueryTemplate.java
@@ -50,7 +50,7 @@ public class OQueryTemplate<R, T extends GenericEntity> implements QueryTemplate
         OSQLSynchQuery<T> oQuery = new OSQLSynchQuery<>(sQuery);
         Map<String, Object> parameterMap = exposeParameterMap(s.getPredicate());
 
-        logger.debug(String.format("Executing SQL query:%n\t[%s]%nWith parameters:%n\t[%s]", sQuery, parameterMap));
+        logger.debug("Executing SQL query:%n\t[{}]%nWith parameters:%n\t[{}]", sQuery, parameterMap);
 
         Object result = getEmDelegate().command(oQuery)
                                        .execute(parameterMap);

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/criteria/OQueryTemplate.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/criteria/OQueryTemplate.java
@@ -50,7 +50,11 @@ public class OQueryTemplate<R, T extends GenericEntity> implements QueryTemplate
         OSQLSynchQuery<T> oQuery = new OSQLSynchQuery<>(sQuery);
         Map<String, Object> parameterMap = exposeParameterMap(s.getPredicate());
 
-        logger.debug("Executing SQL query:%n\t[{}]%nWith parameters:%n\t[{}]", sQuery, parameterMap);
+        logger.debug("Executing SQL query:\n" +
+                     "\t[{}]\n" +
+                     "With parameters:\n" +
+                     "\t[{}]",
+                     sQuery, parameterMap);
 
         Object result = getEmDelegate().command(oQuery)
                                        .execute(parameterMap);

--- a/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/service/CommonCrudService.java
+++ b/strongbox-data-service/src/main/java/org/carlspring/strongbox/data/service/CommonCrudService.java
@@ -315,7 +315,7 @@ public abstract class CommonCrudService<T extends GenericEntity>
         // now query should looks like
         // SELECT * FROM Foo WHERE blah = :blah AND moreBlah = :moreBlah
 
-        logger.debug("Executing SQL query> " + query);
+        logger.debug("Executing SQL query> {}", query);
 
         return query;
     }

--- a/strongbox-event-api/src/main/java/org/carlspring/strongbox/event/EventExecutorFactoryBean.java
+++ b/strongbox-event-api/src/main/java/org/carlspring/strongbox/event/EventExecutorFactoryBean.java
@@ -30,7 +30,7 @@ public class EventExecutorFactoryBean implements FactoryBean<Executor>
                                     .flatMap(c -> Optional.ofNullable(lookupExecutor()))
                                     .orElse(new SyncTaskExecutor());
         
-        logger.info(String.format("Using [%s] executor for Async events.", executor.getClass()));
+        logger.info("Using [{}] executor for Async events.", executor.getClass());
         
         return executor;
     }

--- a/strongbox-event-api/src/main/java/org/carlspring/strongbox/event/artifact/ArtifactEventListenerRegistry.java
+++ b/strongbox-event-api/src/main/java/org/carlspring/strongbox/event/artifact/ArtifactEventListenerRegistry.java
@@ -22,7 +22,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPLOADING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPLOADING event for " + path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPLOADING event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -32,8 +32,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPDATED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPDATED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_UPDATED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -43,8 +42,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_STORED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_STORED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_STORED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -54,8 +52,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADING event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADING event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -65,8 +62,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_DOWNLOADED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -78,9 +74,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
                                                 dstPath,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPYING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPYING event for " +
-                     srcPath + " to " + dstPath +
-                     "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPYING event for {} to {}...", srcPath, dstPath);
 
         dispatchEvent(event);
     }
@@ -92,9 +86,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
                                                 dstPath,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPIED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPIED event for " +
-                     srcPath + " to " + dstPath +
-                     "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_COPIED event for {} to {}...", srcPath, dstPath);
 
         dispatchEvent(event);
     }
@@ -106,9 +98,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
                                                 dstPath,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVING event for " +
-                     srcPath + " to " + dstPath +
-                     "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVING event for {} to {}...", srcPath, dstPath);
 
         dispatchEvent(event);
     }
@@ -120,9 +110,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
                                                 dstPath,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVED event for " +
-                     srcPath + " to " + dstPath +
-                     "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVED event for {} to {}...", srcPath, dstPath);
 
         dispatchEvent(event);
     }
@@ -132,8 +120,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_PATH_DELETED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_PATH_DELETED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_PATH_DELETED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -143,8 +130,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_ARCHIVING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_MOVED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -154,8 +140,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_ARCHIVED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_ARCHIVED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_ARCHIVED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -165,8 +150,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -176,8 +160,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADING event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_METADATA_DOWNLOADING event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -187,8 +170,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADED event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -198,8 +180,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADING.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADING event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_CHECKSUM_DOWNLOADING event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -209,8 +190,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_FETCHED_FROM_REMOTE.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_FETCHED_FROM_REMOTE event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_FETCHED_FROM_REMOTE event for {}...", path);
 
         dispatchEvent(event);
     }
@@ -220,8 +200,7 @@ public class ArtifactEventListenerRegistry extends AbstractEventListenerRegistry
         ArtifactEvent event = new ArtifactEvent(path,
                                                 ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_STORED.getType());
 
-        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_STORED event for " +
-                      path + "...");
+        logger.debug("Dispatching ArtifactEventTypeEnum.EVENT_ARTIFACT_FILE_STORED event for {}...", path);
 
         dispatchEvent(event);
     }

--- a/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
+++ b/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
@@ -149,7 +149,7 @@ public class RestClient
             }
             catch (Exception ex)
             {
-                logger.error("Exception occurred {} ...", ExceptionUtils.getStackTrace(ex));
+                logger.error("Exception occurred ", ex);
                 throw ex;
             }
         }

--- a/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
+++ b/strongbox-rest-client/src/main/java/org/carlspring/strongbox/client/RestClient.java
@@ -89,9 +89,9 @@ public class RestClient
 
     public static void displayResponseError(Response response)
     {
-        logger.error("Status code " + response.getStatus());
-        logger.error("Status info " + response.getStatusInfo().getReasonPhrase());
-        logger.error("Response message " + response.readEntity(String.class));
+        logger.error("Status code {}", response.getStatus());
+        logger.error("Status info {}", response.getStatusInfo().getReasonPhrase());
+        logger.error("Response message {}", response.readEntity(String.class));
         logger.error(response.toString());
     }
 
@@ -570,7 +570,7 @@ public class RestClient
     {
         String url = getContextBaseUrl() + arg;
 
-        logger.debug("Prepare target URL " + url);
+        logger.debug("Prepare target URL {}", url);
 
         return getClientInstance().target(url);
     }

--- a/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
+++ b/strongbox-rest-client/src/test/java/org/carlspring/strongbox/rest/client/RestAssuredArtifactClient.java
@@ -66,7 +66,7 @@ public class RestAssuredArtifactClient
     {
         String url = escapeUrl(path);
 
-        logger.debug("Path to artifact: " + url);
+        logger.debug("Path to artifact: {}", url);
 
         return givenLocal().contentType(ContentType.TEXT)
                            .when()
@@ -116,7 +116,7 @@ public class RestAssuredArtifactClient
             throw new ArtifactOperationException("Unable to convert to byte array", e);
         }
 
-        logger.debug("Deploying " + url);
+        logger.debug("Deploying {}", url);
 
         givenLocal().contentType(mediaType)
                     .header("Content-Disposition", contentDisposition)
@@ -194,15 +194,15 @@ public class RestAssuredArtifactClient
             statusCode = PARTIAL_CONTENT;
         }
 
-        logger.debug("[getArtifactAsByteArray] URL " + url);
+        logger.debug("[getArtifactAsByteArray] URL {}", url);
 
         MockMvcResponse response = o.when().get(url);
         Headers allHeaders = response.getHeaders();
 
-        logger.debug("HTTP GET " + url);
+        logger.debug("HTTP GET {}", url);
         logger.debug("Response headers:");
 
-        allHeaders.forEach(header -> logger.debug("\t" + header.getName() + " = " + header.getValue()));
+        allHeaders.forEach(header -> logger.debug("\t{} = {}", header.getName(), header.getValue()));
 
         if (validate)
         {
@@ -212,12 +212,12 @@ public class RestAssuredArtifactClient
         if (response.getStatusCode() == OK || response.getStatusCode() == PARTIAL_CONTENT)
         {
             byte[] result = response.getMockHttpServletResponse().getContentAsByteArray();
-            logger.debug("Received " + result.length + " bytes.");
+            logger.debug("Received {} bytes.", result.length);
             return result;
         }
         else
         {
-            logger.warn("[getArtifactAsByteArray] response " + response.getStatusCode());
+            logger.warn("[getArtifactAsByteArray] response {}", response.getStatusCode());
             return null;
         }
     }
@@ -367,10 +367,10 @@ public class RestAssuredArtifactClient
         MockMvcResponse response = o.when().head(url);
         Headers allHeaders = response.getHeaders();
 
-        logger.debug("HTTP HEAD " + url);
+        logger.debug("HTTP HEAD {}", url);
         logger.debug("Response headers:");
 
-        allHeaders.forEach(header -> logger.debug("\t" + header.getName() + " = " + header.getValue()));
+        allHeaders.forEach(header -> logger.debug("\t{} = {}", header.getName(), header.getValue()));
 
         if (response.getStatusCode() == OK || response.getStatusCode() == PARTIAL_CONTENT)
         {
@@ -379,7 +379,7 @@ public class RestAssuredArtifactClient
         }
         else
         {
-            logger.warn("[getArtifactAsByteArray] response " + response.getStatusCode());
+            logger.warn("[getArtifactAsByteArray] response {}", response.getStatusCode());
             return null;
         }
     }
@@ -391,10 +391,10 @@ public class RestAssuredArtifactClient
         MockMvcResponse response = o.when().get(url);
         Headers allHeaders = response.getHeaders();
 
-        logger.debug("HTTP GET " + url);
+        logger.debug("HTTP GET {}", url);
         logger.debug("Response headers:");
 
-        allHeaders.forEach(header -> logger.debug("\t" + header.getName() + " = " + header.getValue()));
+        allHeaders.forEach(header -> logger.debug("\t{} = {}", header.getName(), header.getValue()));
 
         if (response.getStatusCode() == OK || response.getStatusCode() == PARTIAL_CONTENT)
         {
@@ -403,7 +403,7 @@ public class RestAssuredArtifactClient
         }
         else
         {
-            logger.warn("[getArtifactAsByteArray] response " + response.getStatusCode());
+            logger.warn("[getArtifactAsByteArray] response {}", response.getStatusCode());
             return null;
         }
     }

--- a/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/src/main/java/org/carlspring/strongbox/authentication/api/password/PasswordAuthenticationProvider.java
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/src/main/java/org/carlspring/strongbox/authentication/api/password/PasswordAuthenticationProvider.java
@@ -78,8 +78,7 @@ public class PasswordAuthenticationProvider extends DaoAuthenticationProvider
                     .isPresent())
 
         {
-            logger.debug(String.format("Found cached authentication for [%s]",
-                                       userDetails.getUsername()));
+            logger.debug("Found cached authentication for [{}]", userDetails.getUsername());
             return;
         }
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/AuthenticationResourceManager.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/AuthenticationResourceManager.java
@@ -80,7 +80,7 @@ public class AuthenticationResourceManager
     {
         if (!(resource instanceof WritableResource))
         {
-            logger.warn(String.format("Could not store read-only resource [%s].", resource));
+            logger.warn("Could not store read-only resource [{}].", resource);
 
             return;
         }

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
@@ -61,12 +61,12 @@ public class ExternalAuthenticatorsHelper
         }
         if (!Files.exists(authenticatorsDirectory))
         {
-            logger.debug(authenticatorsDirectory + " does not exist.");
+            logger.debug("{} does not exist.", authenticatorsDirectory);
             return parent;
         }
         if (!Files.isDirectory(authenticatorsDirectory))
         {
-            logger.error(authenticatorsDirectory + " is not a directory.");
+            logger.error("{} is not a directory.", authenticatorsDirectory);
             return parent;
         }
 
@@ -74,7 +74,7 @@ public class ExternalAuthenticatorsHelper
 
         if (CollectionUtils.isEmpty(authenticatorsJarPaths))
         {
-            logger.debug(authenticatorsDirectory + " contains 0 authenticators jar files.");
+            logger.debug("{} contains 0 authenticators jar files.", authenticatorsDirectory);
             return parent;
         }
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
@@ -74,7 +74,7 @@ public class ExternalAuthenticatorsHelper
 
         if (CollectionUtils.isEmpty(authenticatorsJarPaths))
         {
-            logger.debug("{} contains 0 authenticators jar files.", authenticatorsDirectory);
+            logger.debug("no authenticator jar files.");
             return parent;
         }
 

--- a/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
+++ b/strongbox-security/strongbox-authentication-registry/src/main/java/org/carlspring/strongbox/authentication/registry/support/ExternalAuthenticatorsHelper.java
@@ -74,7 +74,7 @@ public class ExternalAuthenticatorsHelper
 
         if (CollectionUtils.isEmpty(authenticatorsJarPaths))
         {
-            logger.debug("no authenticator jar files.");
+            logger.debug("{} does not contain any authenticator jar files.", authenticatorsDirectory);
             return parent;
         }
 

--- a/strongbox-security/strongbox-authentication-support/src/main/java/org/carlspring/strongbox/authentication/support/AuthoritiesExternalToInternalMapper.java
+++ b/strongbox-security/strongbox-authentication-support/src/main/java/org/carlspring/strongbox/authentication/support/AuthoritiesExternalToInternalMapper.java
@@ -30,14 +30,14 @@ public class AuthoritiesExternalToInternalMapper
     @Override
     public Collection<? extends GrantedAuthority> mapAuthorities(Collection<? extends GrantedAuthority> externalAuthorities)
     {
-        logger.debug(String.format("Map authorities [%s]", externalAuthorities));
+        logger.debug("Map authorities [{}]", externalAuthorities);
         Collection<? extends GrantedAuthority> result = externalAuthorities.stream()
                                                                            .map(GrantedAuthority::getAuthority)
                                                                            .map(a -> getRolesMapping().get(a))
                                                                            .filter(Objects::nonNull)
                                                                            .map(SimpleGrantedAuthority::new)
                                                                            .collect(Collectors.toSet());
-        logger.debug(String.format("Authorities mapped [%s]", result));
+        logger.debug("Authorities mapped [{}]", result);
         return result;
     }
 

--- a/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
+++ b/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
@@ -199,7 +199,6 @@ public class YamlUserServiceTest
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
         logger.debug("Found stored user\n\t{}\n", addedEntity);
-
         logger.debug("Updating user...");
 
         UserDto userUpdate = new UserDto();
@@ -281,7 +280,6 @@ public class YamlUserServiceTest
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Delete operation failed!").isNotNull();
 
         logger.debug("Found stored user\n\t{}\n", addedEntity);
-
         logger.debug("Deleting user...");
 
         userService.deleteByUsername(testUserName);

--- a/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
+++ b/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
@@ -146,7 +146,7 @@ public class YamlUserServiceTest
         User addedEntity = userService.findByUsername(testUserName);
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
-        logger.debug("Found stored initial user\n\t{}\n",addedEntity);
+        logger.debug("Found stored initial user\n\t{}\n", addedEntity);
 
         // 2. Update the user with empty/null password
         logger.debug("Updating user with empty/null pass...");

--- a/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
+++ b/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
@@ -73,7 +73,7 @@ public class YamlUserServiceTest
 
         assertThat(foundEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
-        logger.debug("Found stored user\n\t" + foundEntity + "\n");
+        logger.debug("Found stored user\n\t{}\n", foundEntity);
 
         assertThat(foundEntity.getUsername()).isEqualTo(testUserName);
         assertThat(foundEntity.getPassword())
@@ -101,7 +101,7 @@ public class YamlUserServiceTest
         User addedEntity = userService.findByUsername(testUserName);
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
-        logger.debug("Found stored user\n\t" + addedEntity + "\n");
+        logger.debug("Found stored user\n\t{}\n", addedEntity);
 
         logger.debug("Updating user...");
 
@@ -116,7 +116,7 @@ public class YamlUserServiceTest
         User updatedEntity = userService.findByUsername(testUserName);
         assertThat(updatedEntity).as("Unable to locate updated user " + testUserName + ". Update operation failed!").isNotNull();
 
-        logger.debug("Found stored updated user\n\t" + updatedEntity + "\n");
+        logger.debug("Found stored updated user\n\t{}\n", updatedEntity);
 
         assertThat(updatedEntity.getUsername()).isEqualTo(testUserName);
         assertThat(updatedEntity.getPassword())
@@ -146,7 +146,7 @@ public class YamlUserServiceTest
         User addedEntity = userService.findByUsername(testUserName);
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
-        logger.debug("Found stored initial user\n\t" + addedEntity + "\n");
+        logger.debug("Found stored initial user\n\t{}\n",addedEntity);
 
         // 2. Update the user with empty/null password
         logger.debug("Updating user with empty/null pass...");
@@ -160,7 +160,7 @@ public class YamlUserServiceTest
         User updatedEntity = userService.findByUsername(testUserName);
         assertThat(updatedEntity).as("Unable to locate updated user " + testUserName + ". Update operation failed!").isNotNull();
 
-        logger.debug("Found stored updated with empty pass user\n\t" + updatedEntity + "\n");
+        logger.debug("Found stored updated with empty pass user\n\t{}\n", updatedEntity);
 
         assertThat(updatedEntity.getPassword()).as("User password has changed!").isEqualTo(addedEntity.getPassword());
 
@@ -176,7 +176,7 @@ public class YamlUserServiceTest
         updatedEntity = userService.findByUsername(testUserName);
         assertThat(updatedEntity).as("Unable to locate updated user " + testUserName + ". Update operation failed!").isNotNull();
 
-        logger.debug("Found stored updated with empty pass user\n\t" + updatedEntity + "\n");
+        logger.debug("Found stored updated with empty pass user\n\t{}\n", updatedEntity);
 
         assertThat(updatedEntity.getPassword()).as("User password has changed!").isEqualTo(addedEntity.getPassword());
     }
@@ -198,7 +198,7 @@ public class YamlUserServiceTest
         User addedEntity = userService.findByUsername(testUserName);
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Save operation failed!").isNotNull();
 
-        logger.debug("Found stored user\n\t" + addedEntity + "\n");
+        logger.debug("Found stored user\n\t{}\n", addedEntity);
 
         logger.debug("Updating user...");
 
@@ -214,7 +214,7 @@ public class YamlUserServiceTest
         User updatedEntity = userService.findByUsername(testUserName);
         assertThat(updatedEntity).as("Unable to locate updated user " + testUserName + ". Update operation failed!").isNotNull();
 
-        logger.debug("Updated user found: \n\t" + updatedEntity + "\n");
+        logger.debug("Updated user found: \n\t{}\n", updatedEntity);
 
         assertThat(updatedEntity.getPassword())
                 .as("User password should have been encrypted!")
@@ -280,7 +280,7 @@ public class YamlUserServiceTest
         User addedEntity = userService.findByUsername(testUserName);
         assertThat(addedEntity).as("Unable to locate user " + testUserName + ". Delete operation failed!").isNotNull();
 
-        logger.debug("Found stored user\n\t" + addedEntity + "\n");
+        logger.debug("Found stored user\n\t{}\n", addedEntity);
 
         logger.debug("Deleting user...");
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/AsyncArtifactEntryHandler.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/AsyncArtifactEntryHandler.java
@@ -71,8 +71,8 @@ public abstract class AsyncArtifactEntryHandler
             }
             catch (Exception e)
             {
-                logger.error(String.format("Failed to handle async event [%s]",
-                                           AsyncArtifactEntryHandler.this.getClass().getSimpleName()),
+                logger.error("Failed to handle async event [{}]",
+                             AsyncArtifactEntryHandler.this.getClass().getSimpleName(),
                              e);
             }
         });
@@ -126,8 +126,7 @@ public abstract class AsyncArtifactEntryHandler
             }
             catch (ONeedRetryException e)
             {
-                logger.debug(String.format("Retry event [%s] for path [%s]", this.getClass().getSimpleName(),
-                                           repositoryPath));
+                logger.debug("Retry event [{}] for path [{}]", this.getClass().getSimpleName(), repositoryPath);
                 propogateIfNeeded(i, repositoryPath, e);
             }
 
@@ -157,10 +156,10 @@ public abstract class AsyncArtifactEntryHandler
                 ArtifactEntry result = handleEvent(repositoryPath);
                 if (result == null)
                 {
-                    logger.debug(String.format("No [%s] result for event [%s] and path [%s].",
-                                               ArtifactEntry.class.getSimpleName(),
-                                               AsyncArtifactEntryHandler.this.getClass().getSimpleName(),
-                                               repositoryPath));
+                    logger.debug("No [{}] result for event [{}] and path [{}].",
+                                 ArtifactEntry.class.getSimpleName(),
+                                 AsyncArtifactEntryHandler.this.getClass().getSimpleName(),
+                                 repositoryPath);
 
                     return null;
                 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/coordinates/ArtifactLayoutLocator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/coordinates/ArtifactLayoutLocator.java
@@ -49,9 +49,9 @@ public class ArtifactLayoutLocator
             ArtifactCoordinatesLayout artifactLayout = artifactCoordinatesClass.getAnnotation(ArtifactCoordinatesLayout.class);
             if (artifactLayout == null)
             {
-                logger.warn(String.format("[%s] should be provided for [%s] class",
-                                          ArtifactCoordinatesLayout.class.getSimpleName(),
-                                          artifactCoordinatesClass.getSimpleName()));
+                logger.warn("[{}] should be provided for [{}] class",
+                            ArtifactCoordinatesLayout.class.getSimpleName(),
+                            artifactCoordinatesClass.getSimpleName());
                 continue;
             }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/ArtifactDirectoryLocator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/ArtifactDirectoryLocator.java
@@ -46,8 +46,8 @@ public class ArtifactDirectoryLocator
 
         long endTime = System.currentTimeMillis();
 
-        logger.debug("Executed (cache: " + -operation.getVisitedRootPaths().size() + ")" +
-                     " visits in " + (endTime - startTime) + " ms.");
+        logger.debug("Executed (cache: {}) visits in {} ms.",
+                     -operation.getVisitedRootPaths().size(), (endTime - startTime));
 
         getOperation().getVisitedRootPaths().clear();
     }
@@ -63,7 +63,7 @@ public class ArtifactDirectoryLocator
         }
         rootPath = rootPath.normalize();
 
-        logger.debug(String.format("ArtifactDirectoryLocator started in: path-[%s]", rootPath));
+        logger.debug("ArtifactDirectoryLocator started in: path-[{}]", rootPath);
 
         return Files.isDirectory(rootPath) ? rootPath : rootPath.getParent();
     }
@@ -96,7 +96,7 @@ public class ArtifactDirectoryLocator
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to execute operation [%s]", operation.getClass().getSimpleName()), e);
+            logger.error("Failed to execute operation [{}]", operation.getClass().getSimpleName(), e);
         }
     }
     

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/AbstractArtifactLocationHandler.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/AbstractArtifactLocationHandler.java
@@ -59,7 +59,7 @@ public abstract class AbstractArtifactLocationHandler
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to read Path attributes for [%s]", path), e);
+            logger.error("Failed to read Path attributes for [{}]", path, e);
             return false;
         }
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/ArtifactLocationGenerateChecksumOperation.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/ArtifactLocationGenerateChecksumOperation.java
@@ -38,15 +38,15 @@ public class ArtifactLocationGenerateChecksumOperation
                 }
                 catch (IOException e)
                 {
-                    logger.error(String.format("Failed to read attributes for [%s]", p),
+                    logger.error("Failed to read attributes for [{}]", p,
                                  e);
                 }
                 return false;
             });
             if (!containsMetadata)
             {
-                logger.debug(String.format("Target path [%s] does not contains any metadata, so we don't need to execute any operations.",
-                                           path));
+                logger.debug("Target path [{}] does not contains any metadata, so we don't need to execute any operations.",
+                             path);
                 return;
             }
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/ArtifactLocationGenerateChecksumOperation.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/artifact/locator/handlers/ArtifactLocationGenerateChecksumOperation.java
@@ -38,8 +38,7 @@ public class ArtifactLocationGenerateChecksumOperation
                 }
                 catch (IOException e)
                 {
-                    logger.error("Failed to read attributes for [{}]", p,
-                                 e);
+                    logger.error("Failed to read attributes for [{}]", p, e);
                 }
                 return false;
             });

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/ResourcesBooter.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/ResourcesBooter.java
@@ -78,7 +78,7 @@ public class ResourcesBooter implements ApplicationContextInitializer<Configurab
 
             if (Files.exists(destFile))
             {
-                logger.info(String.format("Resource already exists, skip [%s].", destFile));
+                logger.info("Resource already exists, skip [{}].", destFile);
                 continue;
             }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/booters/StorageBooter.java
@@ -104,19 +104,19 @@ public class StorageBooter
     private void initializeStorage(Storage storage)
             throws IOException
     {
-        logger.info("  * Initializing " + storage.getId() + "...");
+        logger.info("  * Initializing {}...", storage.getId());
     }
 
     private void initializeRepository(Repository repository)
             throws IOException, RepositoryManagementStrategyException
     {
-        logger.info("  * Initializing " + repository.getStorage().getId() + ":" + repository.getId() + "...");
+        logger.info("  * Initializing {}:{}...", repository.getStorage().getId(), repository.getId());
 
         if (layoutProviderRegistry.getProvider(repository.getLayout()) == null)
         {
-            logger.error(String.format("Failed to resolve layout [%s] for repository [%s].",
-                                       repository.getLayout(),
-                                       repository.getId()));
+            logger.error("Failed to resolve layout [{}] for repository [{}].",
+                         repository.getLayout(),
+                         repository.getId());
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/AbstractRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/AbstractRepositoryProvider.java
@@ -137,7 +137,7 @@ public abstract class AbstractRepositoryProvider implements RepositoryProvider, 
     public void onBeforeWrite(RepositoryStreamWriteContext ctx) throws IOException
     {
         RepositoryPath repositoryPath = (RepositoryPath) ctx.getPath();
-        logger.debug(String.format("Writing [%s]", repositoryPath));
+        logger.debug("Writing [{}]", repositoryPath);
         
         if (!RepositoryFiles.isArtifact(repositoryPath))
         {
@@ -172,7 +172,7 @@ public abstract class AbstractRepositoryProvider implements RepositoryProvider, 
     public void onAfterWrite(RepositoryStreamWriteContext ctx) throws IOException
     {
         RepositoryPath repositoryPath = (RepositoryPath) ctx.getPath();
-        logger.debug(String.format("Complete writing [%s]", repositoryPath));             
+        logger.debug("Complete writing [{}]", repositoryPath);
     }
 
     @Override
@@ -180,7 +180,7 @@ public abstract class AbstractRepositoryProvider implements RepositoryProvider, 
         throws IOException
     {
         RepositoryPath repositoryPath = (RepositoryPath) ctx.getPath();
-        logger.debug(String.format("Reading %s", repositoryPath));
+        logger.debug("Reading {}", repositoryPath);
 
         if (!RepositoryFiles.isArtifact(repositoryPath))
         {
@@ -201,7 +201,7 @@ public abstract class AbstractRepositoryProvider implements RepositoryProvider, 
     public void onAfterRead(RepositoryStreamReadContext ctx)
     {
         RepositoryPath repositoryPath = (RepositoryPath) ctx.getPath();
-        logger.debug(String.format("Complete reading [%s]", repositoryPath));
+        logger.debug("Complete reading [{}]", repositoryPath);
         
         artifactEventListenerRegistry.dispatchArtifactDownloadedEvent(repositoryPath);
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryPathLock.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryPathLock.java
@@ -48,7 +48,7 @@ public class RepositoryPathLock
         String lockName = Optional.ofNullable(id)
                                   .map(p -> String.format("%s?%s", lock, p))
                                   .orElseGet(() -> lock.toString());
-        logger.debug(String.format("Get lock for [%s]", lock));
+        logger.debug("Get lock for [{}]", lock);
         
         return lockService.getReentrantReadWriteLock(lockName);
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryStreamSupport.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/RepositoryStreamSupport.java
@@ -72,13 +72,13 @@ public class RepositoryStreamSupport
 
         RepositoryPath path = (RepositoryPath) ctx.getPath();
         
-        logger.debug(String.format("Locking [%s].", path));
+        logger.debug("Locking [{}].", path);
         
         Lock lock = ctx instanceof RepositoryStreamWriteContext ? lockSource.writeLock() : lockSource.readLock();
         ctx.setLock(lock);
         lock.lock();
 
-        logger.debug(String.format("Locked [%s].", path));
+        logger.debug("Locked [{}].", path);
         
         ctx.setOpened(true);
     }
@@ -94,7 +94,7 @@ public class RepositoryStreamSupport
 
         ctx.getLock().unlock();
         
-        logger.debug(String.format("Unlocked [%s].", ctx.getPath()));
+        logger.debug("Unlocked [{}].", ctx.getPath());
         
         clearContext();
     }
@@ -144,15 +144,15 @@ public class RepositoryStreamSupport
         public void flush()
             throws IOException
         {
-            logger.debug(String.format("Flushing [%s]", getContext().getPath()));
+            logger.debug("Flushing [{}]", getContext().getPath());
             
             super.flush();
             
-            logger.debug(String.format("Flushed [%s]", getContext().getPath()));
+            logger.debug("Flushed [{}]", getContext().getPath());
             
             RepositoryStreamSupport.this.commit();
             
-            logger.debug(String.format("Commited [%s]", getContext().getPath()));
+            logger.debug("Commited [{}]", getContext().getPath());
         }
 
         @Override
@@ -169,7 +169,7 @@ public class RepositoryStreamSupport
             }
             catch (Exception e) 
             {
-                logger.error(String.format("Failed to close [%s].", getContext().getPath()), e);
+                logger.error("Failed to close [{}].", getContext().getPath(), e);
                 
                 throw e;
             }
@@ -202,7 +202,7 @@ public class RepositoryStreamSupport
                 //Check that artifact exists.
                 if (!RepositoryFiles.artifactExists((RepositoryPath) path)) 
                 {
-                    logger.debug(String.format("The path [%s] does not exist!", path));
+                    logger.debug("The path [{}] does not exist!", path);
                     
                     throw new ArtifactNotFoundException(path.toUri());
                 }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
@@ -209,13 +209,13 @@ public abstract class StorageFileSystemProvider
             return;
         }
         
-        logger.debug(String.format("Deleting hidden folders for [%s]", path));
+        logger.debug("Deleting hidden folders for [{}]", path);
         
         FileSystemUtils.deleteRecursively(unwrap(root).resolve(LayoutFileSystem.TEMP));
         FileSystemUtils.deleteRecursively(unwrap(root).resolve(LayoutFileSystem.TRASH));
         Files.delete(unwrap(root));
         
-        logger.debug(String.format("Hidden folders deleted [%s]", path));
+        logger.debug("Hidden folders deleted [{}]", path);
 
     }
 
@@ -357,12 +357,12 @@ public abstract class StorageFileSystemProvider
     public RepositoryPath moveFromTemporaryDirectory(TempRepositoryPath tempPath)
         throws IOException
     {
-        logger.debug(String.format("Moving [%s]", tempPath.getTarget()));
+        logger.debug("Moving [{}]", tempPath.getTarget());
         RepositoryPath path = tempPath.getTempTarget();
 
         if (!Files.exists(tempPath.getTarget()))
         {
-            throw new IOException(String.format("[%s] target for [%s] don't exists!", TempRepositoryPath.class.getSimpleName(), tempPath));
+            throw new IOException(String.format("[{}] target for [{}] don't exists!", TempRepositoryPath.class.getSimpleName(), tempPath));
         }
 
         if (!Files.exists(unwrap(path).getParent()))
@@ -414,7 +414,7 @@ public abstract class StorageFileSystemProvider
 
         if (!Files.exists(trashPath.getParent().getTarget()))
         {
-            logger.debug(String.format("Creating: dir-[%s]", trashPath.getParent()));
+            logger.debug("Creating: dir-[{}]", trashPath.getParent());
 
             Files.createDirectories(trashPath.getParent().getTarget());
         }
@@ -507,7 +507,7 @@ public abstract class StorageFileSystemProvider
     {
         if (RepositoryFileAttributes.class.isAssignableFrom(type) && !RepositoryPath.class.isInstance(path))
         {
-            throw new IOException(String.format("Requested path is not [%s].", RepositoryPath.class.getSimpleName()));
+            throw new IOException(String.format("Requested path is not [{}].", RepositoryPath.class.getSimpleName()));
         }
 
         BasicFileAttributes targetAttributes = getTarget().readAttributes(unwrap(path),

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
@@ -414,7 +414,7 @@ public abstract class StorageFileSystemProvider
 
         if (!Files.exists(trashPath.getParent().getTarget()))
         {
-            logger.debug("Creating: dir-[{}]", trashPath.getParent());
+            logger.debug("Creating: [{}]", trashPath.getParent());
 
             Files.createDirectories(trashPath.getParent().getTarget());
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/io/StorageFileSystemProvider.java
@@ -362,7 +362,7 @@ public abstract class StorageFileSystemProvider
 
         if (!Files.exists(tempPath.getTarget()))
         {
-            throw new IOException(String.format("[{}] target for [{}] don't exists!", TempRepositoryPath.class.getSimpleName(), tempPath));
+            throw new IOException(String.format("[%s] target for [%s] don't exists!", TempRepositoryPath.class.getSimpleName(), tempPath));
         }
 
         if (!Files.exists(unwrap(path).getParent()))
@@ -507,7 +507,7 @@ public abstract class StorageFileSystemProvider
     {
         if (RepositoryFileAttributes.class.isAssignableFrom(type) && !RepositoryPath.class.isInstance(path))
         {
-            throw new IOException(String.format("Requested path is not [{}].", RepositoryPath.class.getSimpleName()));
+            throw new IOException(String.format("Requested path is not [%s].", RepositoryPath.class.getSimpleName()));
         }
 
         BasicFileAttributes targetAttributes = getTarget().readAttributes(unwrap(path),

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/AbstractLayoutProvider.java
@@ -218,8 +218,8 @@ public abstract class AbstractLayoutProvider<T extends ArtifactCoordinates>
             }
             catch (IOException e)
             {
-                logger.warn(String.format("Unable to list filenames in archive path %s using %s", repositoryPath,
-                                           ARCHIVE_LISTING_FUNCTION), e);
+                logger.warn("Unable to list filenames in archive path {} using {}",
+                            repositoryPath, ARCHIVE_LISTING_FUNCTION, e);
             }
         }
         return Collections.emptySet();

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutFileSystemProvider.java
@@ -331,7 +331,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
         Repository repository = path.getRepository();
         Storage storage = repository.getStorage();
 
-        logger.debug("Attempting to restore: path-[{}]; ", path);
+        logger.debug("Attempting to restore: [{}]; ", path);
         
         super.undelete(path);
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutFileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/layout/LayoutFileSystemProvider.java
@@ -168,7 +168,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
                               }
                               catch (NoSuchAlgorithmException t)
                               {
-                                  logger.error(String.format("Digest algorithm not supported: alg-[%s]", e), t);
+                                  logger.error("Digest algorithm not supported: alg-[{}]", e, t);
                               }
                           });
         return result;
@@ -187,7 +187,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
                  }
                  catch (IOException e)
                  {
-                     logger.error(String.format("Failed to read attributes for [%s]", p), e);
+                     logger.error("Failed to read attributes for [{}]", p, e);
                  }
                  return false;
              })
@@ -198,7 +198,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
                  }
                  catch (IOException e)
                  {
-                     logger.error(String.format("Failed to write checksum for [%s]", p), e);
+                     logger.error("Failed to write checksum for [{}]", p, e);
                  }
              });
     }
@@ -232,8 +232,8 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
                                            }
                                            catch (IOException e)
                                            {
-                                               logger.error(String.format("Failed to write checksum for [%s]",
-                                                                          checksumPath.toString()), e);
+                                               logger.error("Failed to write checksum for [{}]",
+                                                            checksumPath.toString(), e);
                                            }
                                        });
         }
@@ -244,7 +244,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
                        boolean force)
             throws IOException
     {
-        logger.debug("Deleting in (" + path + ")...");
+        logger.debug("Deleting in ({})...", path);
 
 
         RepositoryPath repositoryPath = (RepositoryPath) path;
@@ -252,7 +252,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
 
         if (!Files.exists(path))
         {
-            logger.warn(String.format("Path not found: path-[%s]", path));
+            logger.warn("Path not found: path-[{}]", path);
             
             return;
         }
@@ -264,9 +264,8 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
             artifactEventListenerRegistry.dispatchArtifactPathDeletedEvent(path);
         }
 
-        logger.debug(String.format("Deleted [%s]", path));
+        logger.debug("Deleted [{}]", path);
     }
-    
     @Override
     protected void doDeletePath(RepositoryPath repositoryPath,
                                 boolean force)
@@ -298,7 +297,7 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to fetch ArtifactEntry for [%s]", repositoryPath), e);
+            logger.error("Failed to fetch ArtifactEntry for [{}]", repositoryPath, e);
             return null;
         }
 
@@ -314,13 +313,13 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
         Repository repository = path.getRepository();
         Storage storage = repository.getStorage();
 
-        logger.debug("Emptying trash for " + storage.getId() + ":" + repository.getId() + "...");
+        logger.debug("Emptying trash for {}:{}...", storage.getId(), repository.getId());
 
         super.deleteTrash(path);
 
         repositoryEventListenerRegistry.dispatchEmptyTrashEvent(storage.getId(), repository.getId());
 
-        logger.debug("Trash for " + storage.getId() + ":" + repository.getId() + " removed.");
+        logger.debug("Trash for {}:{} removed.", storage.getId(), repository.getId());
     }
 
     
@@ -332,13 +331,13 @@ public abstract class LayoutFileSystemProvider extends StorageFileSystemProvider
         Repository repository = path.getRepository();
         Storage storage = repository.getStorage();
 
-        logger.debug(String.format("Attempting to restore: path-[%s]; ", path));
+        logger.debug("Attempting to restore: path-[{}]; ", path);
         
         super.undelete(path);
 
         repositoryEventListenerRegistry.dispatchUndeleteTrashEvent(storage.getId(), repository.getId());
 
-        logger.debug("The trash for " + storage.getId() + ":" + repository.getId() + " has been undeleted.");
+        logger.debug("The trash for {}:{} has been undeleted.", storage.getId(), repository.getId());
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/GroupRepositoryProvider.java
@@ -122,7 +122,7 @@ public class GroupRepositoryProvider
                 continue;
             }
 
-            logger.debug(String.format("Located artifact: [%s]", subRepositoryPath));
+            logger.debug("Located artifact: [{}]", subRepositoryPath);
 
             return subRepositoryPath;
         }
@@ -182,7 +182,7 @@ public class GroupRepositoryProvider
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to resolve path [%s]", repositoryPath));
+            logger.error("Failed to resolve path [{}]", repositoryPath);
             return null;
         }
     }
@@ -203,7 +203,7 @@ public class GroupRepositoryProvider
                              Predicate predicate,
                              Paginator paginator)
     {
-        logger.debug(String.format("Search in [%s]:[%s] ...", storageId, repositoryId));
+        logger.debug("Search in [{}]:[{}] ...", storageId, repositoryId);
 
         Map<ArtifactCoordinates, Path> resultMap = new LinkedHashMap<>();
 
@@ -290,7 +290,7 @@ public class GroupRepositoryProvider
                       String repositoryId,
                       Predicate predicate)
     {
-        logger.debug(String.format("Count in [%s]:[%s] ...", storageId, repositoryId));
+        logger.debug("Count in [{}]:[{}] ...", storageId, repositoryId);
 
         Storage storage = getConfiguration().getStorage(storageId);
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
@@ -63,13 +63,13 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
         }
         catch (ArtifactNotFoundException e) 
         {
-            logger.debug(String.format("The path [%s] does not exist!%n*\t[%s]", repositoryPath, e.getMessage()));
+            logger.debug("The path [{}] does not exist!%n*\t[{}]", repositoryPath, e.getMessage());
 
             return null;
         }
         catch (IOException ex)
         {
-            logger.error(String.format("Failed to decorate InputStream for [%s]", repositoryPath), ex);
+            logger.error("Failed to decorate InputStream for [{}]", repositoryPath, ex);
             
             throw ex;
         }
@@ -108,7 +108,7 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
             }
             catch (Exception e)
             {
-                logger.error(String.format("Failed to resolve Artifact [%s]", artifactEntry.getArtifactCoordinates()),
+                logger.error("Failed to resolve Artifact [{}]", artifactEntry.getArtifactCoordinates(),
                              e);
                 continue;
             }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/HostedRepositoryProvider.java
@@ -63,7 +63,7 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
         }
         catch (ArtifactNotFoundException e) 
         {
-            logger.debug("The path [{}] does not exist!%n*\t[{}]", repositoryPath, e.getMessage());
+            logger.debug("The path [{}] does not exist!\n*\t[{}]", repositoryPath, e.getMessage());
 
             return null;
         }
@@ -108,8 +108,8 @@ public class HostedRepositoryProvider extends AbstractRepositoryProvider
             }
             catch (Exception e)
             {
-                logger.error("Failed to resolve Artifact [{}]", artifactEntry.getArtifactCoordinates(),
-                             e);
+                logger.error("Failed to resolve Artifact [{}]",
+                             artifactEntry.getArtifactCoordinates(), e);
                 continue;
             }
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
@@ -102,7 +102,7 @@ public class ProxyRepositoryProvider
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to resolve Path for proxied artifact [%s]", repositoryPath),
+            logger.error("Failed to resolve Path for proxied artifact [{}]", repositoryPath,
                          e);
 
             throw e;

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/ProxyRepositoryProvider.java
@@ -102,8 +102,8 @@ public class ProxyRepositoryProvider
         }
         catch (IOException e)
         {
-            logger.error("Failed to resolve Path for proxied artifact [{}]", repositoryPath,
-                         e);
+            logger.error("Failed to resolve Path for proxied artifact [{}]",
+                         repositoryPath, e);
 
             throw e;
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryArtifactResolver.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryArtifactResolver.java
@@ -86,7 +86,7 @@ public class ProxyRepositoryArtifactResolver
     {
         //We need this to force initialize lazy connection to remote repository.
         int available = is.available();
-        logger.debug("Got [{}] avaliable bytes for [{}].", available, repositoryPath);
+        logger.debug("Got [{}] available bytes for [{}].", available, repositoryPath);
         
         
         RepositoryPath result = onSuccessfulProxyRepositoryResponse(is, repositoryPath);

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryArtifactResolver.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryArtifactResolver.java
@@ -59,7 +59,7 @@ public class ProxyRepositoryArtifactResolver
         final RemoteRepository remoteRepository = repository.getRemoteRepository();
         if (!remoteRepositoryAlivenessCacheManager.isAlive(remoteRepository))
         {
-            logger.debug("Remote repository '" + remoteRepository.getUrl() + "' is down.");
+            logger.debug("Remote repository '{}' is down.", remoteRepository.getUrl());
 
             return null;
         }
@@ -86,7 +86,7 @@ public class ProxyRepositoryArtifactResolver
     {
         //We need this to force initialize lazy connection to remote repository.
         int available = is.available();
-        logger.debug(String.format("Got [%s] avaliable bytes for [%s].", available, repositoryPath));
+        logger.debug("Got [{}] avaliable bytes for [{}].", available, repositoryPath);
         
         
         RepositoryPath result = onSuccessfulProxyRepositoryResponse(is, repositoryPath);

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryInputStream.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryInputStream.java
@@ -224,7 +224,7 @@ public class ProxyRepositoryInputStream extends FilterInputStream
         long retryTimeoutMillis = getRetryTimeoutMillis();
         if (artifactCopyContext.get().getStopWatch().getTime() > retryTimeoutMillis)
         {
-            logger.error("Timeout of [{}] occured while reading [{}]",
+            logger.error("Timeout of [{}] occurred while reading [{}]",
                          retryTimeoutMillis, repositoryPath);
             throw ex;
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryInputStream.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/repository/proxied/ProxyRepositoryInputStream.java
@@ -212,8 +212,8 @@ public class ProxyRepositoryInputStream extends FilterInputStream
         int maxAllowedNumberOfRetryAttempts = getMaxAllowedNumberOfRetryAttempts();
         if (artifactCopyContext.get().getAttempts() > maxAllowedNumberOfRetryAttempts)
         {
-            logger.error(String.format("Maximum retry attempts [%s] reached for [%s]", maxAllowedNumberOfRetryAttempts,
-                                       repositoryPath));
+            logger.error("Maximum retry attempts [{}] reached for [{}]",
+                         maxAllowedNumberOfRetryAttempts, repositoryPath);
             throw ex;
         }
     }
@@ -224,8 +224,8 @@ public class ProxyRepositoryInputStream extends FilterInputStream
         long retryTimeoutMillis = getRetryTimeoutMillis();
         if (artifactCopyContext.get().getStopWatch().getTime() > retryTimeoutMillis)
         {
-            logger.error(String.format("Timeout of [%s] occured while reading [%s]", retryTimeoutMillis,
-                                       repositoryPath));
+            logger.error("Timeout of [{}] occured while reading [{}]",
+                         retryTimeoutMillis, repositoryPath);
             throw ex;
         }
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/search/AbstractSearchProvider.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/providers/search/AbstractSearchProvider.java
@@ -87,8 +87,8 @@ public abstract class AbstractSearchProvider
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to resolve artifact resource for [%s]",
-                                       a.getArtifactCoordinates()), e);
+            logger.error("Failed to resolve artifact resource for [{}]",
+                         a.getArtifactCoordinates(), e);
             return null;
         }
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/repository/AbstractRepositoryManagementStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/repository/AbstractRepositoryManagementStrategy.java
@@ -98,7 +98,7 @@ public abstract class AbstractRepositoryManagementStrategy
         {
             Files.delete(repositoryPath);
 
-            logger.debug(String.format("Removed directory structure for repository '%s'.", repositoryPath));
+            logger.debug("Removed directory structure for repository '{}'.", repositoryPath);
         }
         else
         {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/ArtifactManagementService.java
@@ -114,7 +114,7 @@ public class ArtifactManagementService
         try (final RepositoryOutputStream aos = artifactResolutionService.getOutputStream(repositoryPath))
         {
             result = writeArtifact(repositoryPath, is, aos);
-            logger.debug(String.format("Stored [%s] bytes for [%s].", result, repositoryPath));
+            logger.debug("Stored [{}] bytes for [{}].", result, repositoryPath);
             aos.flush();
         }
         catch (IOException e)
@@ -214,7 +214,7 @@ public class ArtifactManagementService
     private void validateUploadedChecksumAgainstCache(byte[] checksum,
                                                       URI artifactPathId)
     {
-        logger.debug("Received checksum: " + new String(checksum, StandardCharsets.UTF_8));
+        logger.debug("Received checksum: {}", new String(checksum, StandardCharsets.UTF_8));
 
         String artifactPath = artifactPathId.toString();
         String artifactBasePath = artifactPath.substring(0, artifactPath.lastIndexOf('.'));
@@ -222,9 +222,9 @@ public class ArtifactManagementService
 
         if (!matchesChecksum(checksum, artifactBasePath, checksumExtension))
         {
-            logger.error(String.format("The checksum for %s [%s] is invalid!",
-                                       artifactPath,
-                                       new String(checksum, StandardCharsets.UTF_8)));
+            logger.error("The checksum for {} [{}] is invalid!",
+                         artifactPath,
+                         new String(checksum, StandardCharsets.UTF_8));
         }
 
         checksumCacheManager.removeArtifactChecksum(artifactBasePath, checksumExtension);
@@ -254,13 +254,13 @@ public class ArtifactManagementService
         Set<String> matched = matchingMap.get(Boolean.TRUE);
         Set<String> unmatched = matchingMap.get(Boolean.FALSE);
 
-        logger.debug(String.format("Artifact checksum matchings: artifact-[%s]; ext-[%s]; matched-[%s];" +
-                                   " unmatched-[%s]; checksum-[%s]",
-                                   artifactBasePath,
-                                   checksumExtension,
-                                   matched,
-                                   unmatched,
-                                   checksum));
+        logger.debug("Artifact checksum matchings: artifact-[{}]; ext-[{}]; matched-[{}];" +
+                     " unmatched-[{}]; checksum-[{}]",
+                     artifactBasePath,
+                     checksumExtension,
+                     matched,
+                     unmatched,
+                     checksum);
 
         return matched != null && !matched.isEmpty();
     }
@@ -276,7 +276,7 @@ public class ArtifactManagementService
     private boolean performRepositoryAcceptanceValidation(RepositoryPath path)
             throws IOException, ProviderImplementationException, ArtifactCoordinatesValidationException
     {
-        logger.info(String.format("Validate artifact with path [%s]", path));
+        logger.info("Validate artifact with path [{}]", path);
 
         Repository repository = path.getFileSystem().getRepository();
 
@@ -288,7 +288,7 @@ public class ArtifactManagementService
         }
         
         ArtifactCoordinates coordinates = RepositoryFiles.readCoordinates(path);
-        logger.info(String.format("Validate artifact with coordinates [%s]", coordinates));
+        logger.info("Validate artifact with coordinates [{}]", coordinates);
 
         try
         {

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/ArtifactEntryServiceImpl.java
@@ -141,7 +141,7 @@ class ArtifactEntryServiceImpl extends AbstractArtifactEntryService
 
         appendPagingCriteria(sb, pagingCriteria);
 
-        logger.debug("Executing SQL query> " + sb.toString());
+        logger.debug("Executing SQL query> {}", sb);
 
         OSQLSynchQuery<ArtifactEntry> oQuery = new OSQLSynchQuery<>(sb.toString());
 
@@ -296,7 +296,7 @@ class ArtifactEntryServiceImpl extends AbstractArtifactEntryService
         // now query should looks like
         // SELECT * FROM Foo WHERE blah = :blah AND moreBlah = :moreBlah
 
-        logger.debug("Executing SQL query> " + sb.toString());
+        logger.debug("Executing SQL query> {}", sb);
 
         return sb.toString();
     }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryArtifactIdGroupServiceImpl.java
@@ -74,17 +74,17 @@ public class RepositoryArtifactIdGroupServiceImpl
                                                   .compareTo(lastVersionEntry.getArtifactCoordinates());
         if (artifactCoordinatesComparison == 0)
         {
-            logger.debug(String.format("Set [%s] last version to [%s]",
-                                       entity.getArtifactPath(),
-                                       coordinates.getVersion()));
+            logger.debug("Set [{}] last version to [{}]",
+                         entity.getArtifactPath(),
+                         coordinates.getVersion());
             entity.getTagSet().add(lastVersionTag);
         }
         else if (artifactCoordinatesComparison > 0)
         {
-            logger.debug(String.format("Update [%s] last version from [%s] to [%s]",
-                                       entity.getArtifactPath(),
-                                       lastVersionEntry.getArtifactCoordinates().getVersion(),
-                                       coordinates.getVersion()));
+            logger.debug("Update [{}] last version from [{}] to [{}]",
+                         entity.getArtifactPath(),
+                         lastVersionEntry.getArtifactCoordinates().getVersion(),
+                         coordinates.getVersion());
             entity.getTagSet().add(lastVersionTag);
 
             lastVersionEntry.getTagSet().remove(lastVersionTag);
@@ -92,9 +92,9 @@ public class RepositoryArtifactIdGroupServiceImpl
         }
         else
         {
-            logger.debug(String.format("Keep [%s] last version [%s]",
-                                       entity.getArtifactPath(),
-                                       lastVersionEntry.getArtifactCoordinates().getVersion()));
+            logger.debug("Keep [{}] last version [{}]",
+                         entity.getArtifactPath(),
+                         lastVersionEntry.getArtifactCoordinates().getVersion());
             entity.getTagSet().remove(lastVersionTag);
         }
 
@@ -133,7 +133,7 @@ public class RepositoryArtifactIdGroupServiceImpl
         StringBuilder sb = new StringBuilder(sQuery);
         appendPagingCriteria(sb, pagingCriteria);
 
-        logger.debug("Executing SQL query> " + sb.toString());
+        logger.debug("Executing SQL query> {}", sb);
 
         OSQLSynchQuery<ArtifactEntry> oQuery = new OSQLSynchQuery<>(sb.toString());
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
@@ -75,7 +75,8 @@ public class RepositoryManagementServiceImpl
             Repository repository = getConfiguration().getStorage(storageId).getRepository(repositoryId);
 
             logger.warn("Layout provider '{}' could not be resolved. " +
-                        "Using generic implementation instead.", repository.getLayout());
+                        "Using generic implementation instead.",
+                        repository.getLayout());
 
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
 

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/impl/RepositoryManagementServiceImpl.java
@@ -74,14 +74,14 @@ public class RepositoryManagementServiceImpl
         {
             Repository repository = getConfiguration().getStorage(storageId).getRepository(repositoryId);
 
-            logger.warn("Layout provider '" + repository.getLayout() + "' could not be resolved. " +
-                        "Using generic implementation instead.");
+            logger.warn("Layout provider '{}' could not be resolved. " +
+                        "Using generic implementation instead.", repository.getLayout());
 
             RepositoryPath repositoryPath = repositoryPathResolver.resolve(repository);
 
             if (!Files.exists(repositoryPath))
             {
-                logger.info(String.format("Creating directories for [%s/%s]...", repository.getStorage().getId(), repository.getId()));
+                logger.info("Creating directories for [{}/{}]...", repository.getStorage().getId(), repository.getId());
                 repositoryPath.getFileSystem().createRootDirectory();
             }
         }
@@ -153,13 +153,13 @@ public class RepositoryManagementServiceImpl
                 {
                     if (repository.allowsDeletion())
                     {
-                        logger.debug("Emptying trash for repository " + repository.getId() + "...");
+                        logger.debug("Emptying trash for repository {}...", repository.getId());
 
                         deleteTrash(repository.getStorage().getId(), repository.getId());;
                     }
                     else
                     {
-                        logger.warn("Repository " + repository.getId() + " does not support removal of trash.");
+                        logger.warn("Repository {} does not support removal of trash.", repository.getId());
                     }
                 }
             }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/support/ArtifactStoredEventListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/services/support/ArtifactStoredEventListener.java
@@ -43,9 +43,9 @@ public class ArtifactStoredEventListener
 
         if (artifactEntry == null)
         {
-            logger.warn(String.format("No [%s] for [%s].",
-                                      ArtifactEntry.class.getSimpleName(),
-                                      repositoryPath));
+            logger.warn("No [{}] for [{}].",
+                        ArtifactEntry.class.getSimpleName(),
+                        repositoryPath);
 
             return null;
         }

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/checksum/ChecksumCacheManager.java
@@ -62,7 +62,7 @@ public class ChecksumCacheManager
         final boolean containsChecksum = cachedChecksums.containsKey(artifactPath);
         if (containsChecksum)
         {
-            logger.debug("Cache contains artifact path '" + artifactPath + "'.");
+            logger.debug("Cache contains artifact path '{}'.", artifactPath);
         }
 
         return containsChecksum;
@@ -80,7 +80,7 @@ public class ChecksumCacheManager
         final String checksum = artifactChecksum.getChecksum(algorithm);
         if (checksum != null)
         {
-            logger.debug("Found checksum '" + checksum + "' [" + algorithm + "]" + " for '" + artifactBasePath + "' in cache.");
+            logger.debug("Found checksum '{}' [{}] for '{}' in cache.", checksum, algorithm, artifactBasePath);
         }
 
         return checksum;
@@ -102,7 +102,7 @@ public class ChecksumCacheManager
                                                  String algorithm,
                                                  String checksum)
     {
-        logger.debug("Adding checksum '" + checksum + "' [" + algorithm + "]" + " for '" + artifactBasePath + "' in cache.");
+        logger.debug("Adding checksum '{}' [{}] for '{}' in cache.", checksum, algorithm, artifactBasePath);
 
         if (cachedChecksums.containsKey(artifactBasePath))
         {
@@ -136,8 +136,8 @@ public class ChecksumCacheManager
     public synchronized void removeArtifactChecksum(String artifactBasePath)
     {
         Optional.ofNullable(cachedChecksums.remove(artifactBasePath))
-                .ifPresent(ac -> logger.debug(String.format("Removed [%s] artifact checksum value [%s] from cache.",
-                                                            artifactBasePath, ac)));
+                .ifPresent(ac -> logger.debug("Removed [{}] artifact checksum value [{}] from cache.",
+                                              artifactBasePath, ac));
     }
 
     public synchronized void removeExpiredChecksums()

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoriesHeartbeatMonitorInitiator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoriesHeartbeatMonitorInitiator.java
@@ -79,9 +79,8 @@ public class RemoteRepositoriesHeartbeatMonitorInitiator
                                         0,
                                         intervalSeconds, TimeUnit.SECONDS);
 
-        logger.info(
-                "Remote repository " + remoteRepository.getUrl() + " scheduled for monitoring with interval seconds " +
-                intervalSeconds);
+        logger.info("Remote repository {} scheduled for monitoring with interval seconds {}",
+                    remoteRepository.getUrl(), intervalSeconds);
     }
 
     private RemoteRepositoryHeartbeatMonitorStrategy determineMonitorStrategy(final RemoteRepository remoteRepository)

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryHeartbeatMonitor.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryHeartbeatMonitor.java
@@ -47,7 +47,7 @@ class RemoteRepositoryHeartbeatMonitor
         }
         catch (Exception ex)
         {
-            logger.error("Problem determining remote repository [" + remoteRepository.getUrl() + "] aliveness", ex);
+            logger.error("Problem determining remote repository [{}] aliveness", remoteRepository.getUrl(), ex);
         }
 
         logger.debug("Thread name is [{}]. Remote repository [{}] is alive ? [{}]", Thread.currentThread().getName(),

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/GenericReleaseVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/GenericReleaseVersionValidator.java
@@ -38,8 +38,8 @@ public class GenericReleaseVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/GenericSnapshotVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/GenericSnapshotVersionValidator.java
@@ -38,8 +38,8 @@ public class GenericSnapshotVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/SemanticVersioningValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/SemanticVersioningValidator.java
@@ -34,8 +34,7 @@ public class SemanticVersioningValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/SemanticVersioningValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/artifact/version/SemanticVersioningValidator.java
@@ -34,7 +34,8 @@ public class SemanticVersioningValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/deployment/RedeploymentValidator.java
+++ b/strongbox-storage/strongbox-storage-api/src/main/java/org/carlspring/strongbox/storage/validation/deployment/RedeploymentValidator.java
@@ -47,8 +47,8 @@ public class RedeploymentValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -83,7 +83,7 @@ public class TestArtifactContext implements AutoCloseable
     {
         checkArguments();
             
-        logger.debug(String.format("Create [%s] resource [%s] ", TestArtifact.class.getSimpleName(), id(testArtifact)));
+        logger.debug("Create [{}] resource [{}] ", TestArtifact.class.getSimpleName(), id(testArtifact));
         Class<? extends ArtifactGenerator> generatorClass = testArtifact.generator();
 
         generatorBasePath = Paths.get(propertiesBooter.getVaultDirectory(), ".temp",

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -190,7 +190,7 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
 
         opened = true;
 
-        logger.debug("Created [%s] with id [%s] ",
+        logger.debug("Created [{}] with id [{}] ",
                      TestRepository.class.getSimpleName(),
                      id(testRepository));
     }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -114,9 +114,9 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
             throws IOException,
                    RepositoryManagementStrategyException
     {
-        logger.debug(String.format("Create [%s] with id [%s] ",
-                                  TestRepository.class.getSimpleName(),
-                                  id(testRepository)));
+        logger.debug("Create [{}] with id [{}] ",
+                     TestRepository.class.getSimpleName(),
+                     id(testRepository));
 
         if (groupRepository != null && remoteRepository != null)
         {
@@ -190,9 +190,9 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
 
         opened = true;
 
-        logger.debug(String.format("Created [%s] with id [%s] ",
-                                  TestRepository.class.getSimpleName(),
-                                  id(testRepository)));
+        logger.debug("Created [%s] with id [%s] ",
+                     TestRepository.class.getSimpleName(),
+                     id(testRepository));
     }
 
     private List<MutableRoutingRuleRepository> routingRepositories(String[] repositories)
@@ -230,9 +230,9 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
     public void close()
         throws IOException
     {
-        logger.debug(String.format("Close [%s] with id [%s] ",
-                                  TestRepository.class.getSimpleName(),
-                                  id(testRepository)));
+        logger.debug("Close [{}] with id [{}] ",
+                     TestRepository.class.getSimpleName(),
+                     id(testRepository));
 
         try
         {
@@ -240,24 +240,24 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to close [%s] with id [%s] ",
-                                       TestRepository.class.getSimpleName(),
-                                       id(testRepository)), e);
+            logger.error("Failed to close [{}] with id [{}] ",
+                         TestRepository.class.getSimpleName(),
+                         id(testRepository), e);
 
             throw e;
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to close [%s] with id [%s] ",
-                                       TestRepository.class.getSimpleName(),
-                                       id(testRepository)), e);
+            logger.error("Failed to close [{}] with id [{}] ",
+                         TestRepository.class.getSimpleName(),
+                         id(testRepository), e);
 
             throw new IOException(e);
         }
 
-        logger.debug(String.format("Closed [%s] with id [%s] ",
-                                  TestRepository.class.getSimpleName(),
-                                  id(testRepository)));
+        logger.debug("Closed [{}] with id [{}] ",
+                     TestRepository.class.getSimpleName(),
+                     id(testRepository));
     }
 
     private void closeInternal()

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryManagementApplicationContext.java
@@ -221,7 +221,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
                 {
                     if (lock.tryLock() || lock.tryLock(100, TimeUnit.MILLISECONDS))
                     {
-                        logger.debug(String.format("Test resource [%s] locked.", resourceId));
+                        logger.debug("Test resource [{}] locked.", resourceId);
                         continue outer;
                     }
                 }
@@ -261,7 +261,7 @@ public class TestRepositoryManagementApplicationContext extends AnnotationConfig
             ReentrantLock lock = entry.getValue();
             lock.unlock();
 
-            logger.debug(String.format("Test resource [%s] unlocked.", id));
+            logger.debug("Test resource [{}] unlocked.", id);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/AbstractMappedProviderRegistry.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/AbstractMappedProviderRegistry.java
@@ -36,9 +36,9 @@ public abstract class AbstractMappedProviderRegistry<T>
     {
         providers.entrySet()
                  .stream()
-                 .forEach(e -> logger.info(String.format("Registered repository provider '%s' with alias '%s'.",
-                                                         e.getValue().getClass().getCanonicalName(),
-                                                         e.getKey())));
+                 .forEach(e -> logger.info("Registered repository provider '{}' with alias '{}'.",
+                                           e.getValue().getClass().getCanonicalName(),
+                                           e.getKey()));
         this.providers = providers;
     }
 

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/datastore/FileSystemStorageProvider.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/datastore/FileSystemStorageProvider.java
@@ -33,7 +33,8 @@ public class FileSystemStorageProvider extends AbstractStorageProvider
     @Override
     public void register()
     {
-        logger.info("Registered storage provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered storage provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/repository/RepositoryProviderRegistry.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/providers/repository/RepositoryProviderRegistry.java
@@ -37,7 +37,7 @@ public class RepositoryProviderRegistry extends AbstractMappedProviderRegistry<R
         logger.debug("Listing repository providers:");
         for (String providerName : getProviders().keySet())
         {
-            logger.debug(" provider: " + providerName);
+            logger.debug(" provider: {}", providerName);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/monitor/HttpGetRemoteRepositoryCheckStrategy.java
+++ b/strongbox-storage/strongbox-storage-core/src/main/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/monitor/HttpGetRemoteRepositoryCheckStrategy.java
@@ -46,7 +46,7 @@ class HttpGetRemoteRepositoryCheckStrategy
         }
         catch (IOException e)
         {
-            logger.error("Problem executing HTTP GET request to " + remoteRepositoryUrl, e);
+            logger.error("Problem executing HTTP GET request to {}", remoteRepositoryUrl, e);
         }
         finally
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
@@ -178,9 +178,8 @@ public class MetadataMerger
         }
         catch (IOException e)
         {
-            logger.error(
-                    "*** Error occurred while trying to extract plugin.xml from artifact " + artifact.getArtifactId() +
-                    " " + e.getMessage());
+            logger.error("*** Error occurred while trying to extract plugin.xml from artifact {}",
+                         artifact.getArtifactId(), e);
         }
 
         return pluginMap;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
@@ -178,7 +178,7 @@ public class MetadataMerger
         }
         catch (IOException e)
         {
-            logger.error("*** Error occurred while trying to extract plugin.xml from artifact {}",
+            logger.error("Error occurred while trying to extract plugin.xml from artifact {}",
                          artifact.getArtifactId(), e);
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/MetadataMerger.java
@@ -203,7 +203,7 @@ public class MetadataMerger
         }
         catch (IOException | SAXException | ParserConfigurationException e)
         {
-            logger.error("*** Error occurred while trying to parse the plugin.xml File " + e.getMessage());
+            logger.error("*** Error occurred while trying to parse the plugin.xml File ", e);
         }
 
         return handler.getPluginMap();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/VersionCollector.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/VersionCollector.java
@@ -120,7 +120,7 @@ public class VersionCollector
             }
             catch (XmlPullParserException | IOException e)
             {
-                logger.error("POM file '" + versionDirectoryPath.toAbsolutePath() + "' appears to be corrupt.", e);
+                logger.error("POM file '{}' appears to be corrupt.", versionDirectoryPath.toAbsolutePath(), e);
             }
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/maven/visitors/ArtifactVersionDirectoryVisitor.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/src/main/java/org/carlspring/strongbox/storage/metadata/maven/visitors/ArtifactVersionDirectoryVisitor.java
@@ -58,7 +58,7 @@ public class ArtifactVersionDirectoryVisitor
                 // Current action: Don't add matching file to matched paths and log a warning message
                 // Result: Generates metadata as if the directory contains only timestamped artifacts (if any)
                 //
-                logger.warn("Snapshot artifact name contains SNAPSHOT instead of timestamp: "+file.toAbsolutePath().toString());
+                logger.warn("Snapshot artifact name contains SNAPSHOT instead of timestamp: {}", file.toAbsolutePath());
             }
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJob.java
@@ -57,8 +57,7 @@ public class DownloadRemoteMavenIndexCronJob
         if (!repository.isProxyRepository())
         {
             logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a proxy repository. Exiting ...",
-                        storageId,
-                        repositoryId);
+                        storageId, repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/DownloadRemoteMavenIndexCronJob.java
@@ -49,18 +49,16 @@ public class DownloadRemoteMavenIndexCronJob
         String storageId = config.getProperty(PROPERTY_STORAGE_ID);
         String repositoryId = config.getProperty(PROPERTY_REPOSITORY_ID);
 
-        logger.debug(String.format(
-                "Executing DownloadRemoteMavenIndexCronJob for storageId = [%s], repositoryId = [%s]", storageId,
-                repositoryId));
+        logger.debug("Executing DownloadRemoteMavenIndexCronJob for storageId = [{}], repositoryId = [{}]",
+                     storageId, repositoryId);
 
         Repository repository = configurationManager.getRepository(storageId, repositoryId);
 
         if (!repository.isProxyRepository())
         {
-            logger.warn(String.format(
-                    "Repository identified by storageId = [%s], repositoryId = [%s] is not a proxy repository. Exiting ...",
-                    storageId,
-                    repositoryId));
+            logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a proxy repository. Exiting ...",
+                        storageId,
+                        repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/MergeMavenGroupRepositoryIndexCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/MergeMavenGroupRepositoryIndexCronJob.java
@@ -52,8 +52,7 @@ public class MergeMavenGroupRepositoryIndexCronJob
         if (!repository.isGroupRepository())
         {
             logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a group repository. Exiting ...",
-                        storageId,
-                        repositoryId);
+                        storageId, repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/MergeMavenGroupRepositoryIndexCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/MergeMavenGroupRepositoryIndexCronJob.java
@@ -44,18 +44,16 @@ public class MergeMavenGroupRepositoryIndexCronJob
         String storageId = config.getProperty(PROPERTY_STORAGE_ID);
         String repositoryId = config.getProperty(PROPERTY_REPOSITORY_ID);
 
-        logger.debug(String.format(
-                "Executing MergeMavenGroupRepositoryIndexCronJob for storageId = [%s], repositoryId = [%s]", storageId,
-                repositoryId));
+        logger.debug("Executing MergeMavenGroupRepositoryIndexCronJob for storageId = [{}], repositoryId = [{}]",
+                     storageId, repositoryId);
 
         Repository repository = configurationManager.getRepository(storageId, repositoryId);
 
         if (!repository.isGroupRepository())
         {
-            logger.warn(String.format(
-                    "Repository identified by storageId = [%s], repositoryId = [%s] is not a group repository. Exiting ...",
-                    storageId,
-                    repositoryId));
+            logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a group repository. Exiting ...",
+                        storageId,
+                        repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJob.java
@@ -44,18 +44,16 @@ public class RebuildMavenIndexesCronJob
         String storageId = config.getProperty(PROPERTY_STORAGE_ID);
         String repositoryId = config.getProperty(PROPERTY_REPOSITORY_ID);
 
-        logger.debug(String.format(
-                "Executing RebuildMavenIndexesCronJob for storageId = [%s], repositoryId = [%s]", storageId,
-                repositoryId));
+        logger.debug("Executing RebuildMavenIndexesCronJob for storageId = [{}], repositoryId = [{}]",
+                     storageId, repositoryId);
 
         Repository repository = configurationManager.getRepository(storageId, repositoryId);
 
         if (!repository.isHostedRepository())
         {
-            logger.warn(String.format(
-                    "Repository identified by storageId = [%s], repositoryId = [%s] is not a hosted repository. Exiting ...",
-                    storageId,
-                    repositoryId));
+            logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a hosted repository. Exiting ...",
+                        storageId,
+                        repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJob.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/cron/jobs/RebuildMavenIndexesCronJob.java
@@ -52,8 +52,7 @@ public class RebuildMavenIndexesCronJob
         if (!repository.isHostedRepository())
         {
             logger.warn("Repository identified by storageId = [{}], repositoryId = [{}] is not a hosted repository. Exiting ...",
-                        storageId,
-                        repositoryId);
+                        storageId, repositoryId);
             return;
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/BaseMavenArtifactEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/BaseMavenArtifactEventListener.java
@@ -53,7 +53,7 @@ public abstract class BaseMavenArtifactEventListener
         }
         catch (Exception e)
         {
-            logger.error("Unable to update parent group repositories metadata of file " + event.getPath(), e);
+            logger.error("Unable to update parent group repositories metadata of file {}", event.getPath(), e);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/MavenArtifactFetchedFromRemoteEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/event/artifact/MavenArtifactFetchedFromRemoteEventListener.java
@@ -90,8 +90,8 @@ public class MavenArtifactFetchedFromRemoteEventListener
         }
         catch (Exception e)
         {
-            logger.error("Unable to resolve artifact metadata of file " + event.getPath() + " of repository " +
-                         getRepository(event).getId(), e);
+            logger.error("Unable to resolve artifact metadata of file {} of repository {}",
+                         event.getPath(), getRepository(event).getId(), e);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/locator/handlers/GenerateMavenMetadataOperation.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/locator/handlers/GenerateMavenMetadataOperation.java
@@ -47,7 +47,7 @@ public class GenerateMavenMetadataOperation
         }
         catch (Exception e)
         {
-            logger.error("Failed to generate metadata for " + artifactGroupDirectoryPath, e);
+            logger.error("Failed to generate metadata for {}", artifactGroupDirectoryPath, e);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/locator/handlers/RemoveTimestampedSnapshotOperation.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/locator/handlers/RemoveTimestampedSnapshotOperation.java
@@ -114,7 +114,7 @@ public class RemoveTimestampedSnapshotOperation
         }
         catch (IOException | XmlPullParserException e)
         {
-            logger.error("Failed to delete timestamped snapshot artifacts for " + basePath, e);
+            logger.error("Failed to delete timestamped snapshot artifacts for {}", basePath, e);
         }
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenProxyRepositoryPathExpiredEventListener.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/io/MavenProxyRepositoryPathExpiredEventListener.java
@@ -51,7 +51,7 @@ public class MavenProxyRepositoryPathExpiredEventListener
             }
             catch (IOException e)
             {
-                logger.error(String.format("Expired path [%s] improperly handled.", repositoryPath), e);
+                logger.error("Expired path [{}] improperly handled.", repositoryPath, e);
             }
         };
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2FileSystemProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2FileSystemProvider.java
@@ -70,7 +70,7 @@ public class Maven2FileSystemProvider extends LayoutFileSystemProvider
     {
         RepositoryPath repositoryPath = (RepositoryPath) path;
         
-        logger.debug("Removing " + repositoryPath + "...");
+        logger.debug("Removing {}...", repositoryPath);
 
         if (Files.isDirectory(repositoryPath))
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2LayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2LayoutProvider.java
@@ -50,7 +50,7 @@ public class Maven2LayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     protected MavenArtifactCoordinates getArtifactCoordinates(RepositoryPath repositoryPath)
@@ -159,8 +159,8 @@ public class Maven2LayoutProvider
             }
             catch (IOException e)
             {
-                logger.warn(String.format("Unable to list filenames in archive path %s using %s", repositoryPath,
-                                          JarArchiveListingFunction.INSTANCE.getClass()), e);
+                logger.warn("Unable to list filenames in archive path {} using {}",
+                            repositoryPath, JarArchiveListingFunction.INSTANCE.getClass(), e);
             }
         }
         return Collections.emptySet();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2LayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/Maven2LayoutProvider.java
@@ -50,7 +50,8 @@ public class Maven2LayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered layout provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     protected MavenArtifactCoordinates getArtifactCoordinates(RepositoryPath repositoryPath)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/services/impl/ArtifactMetadataServiceImpl.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/services/impl/ArtifactMetadataServiceImpl.java
@@ -179,7 +179,7 @@ public class ArtifactMetadataServiceImpl
         {
             // No need to throw an exception here.
             // Logging the error should suffice.
-            logger.error("Version " + version + " already exists in the metadata file.");
+            logger.error("Version {} already exists in the metadata file.", version);
         }
     }
 
@@ -314,11 +314,12 @@ public class ArtifactMetadataServiceImpl
             {
                 iterator.remove();
 
-                logger.debug("Removed timestamped SNAPSHOT (" + version +
+                logger.debug("Removed timestamped SNAPSHOT ({}{}) from metadata.",
+                             version,
                              (classifier != null ? ":" + classifier :
                               (snapshotVersion.getClassifier() != null && !snapshotVersion.getClassifier().equals("") ?
                                ":" + snapshotVersion.getClassifier() + ":" : ":") +
-                              snapshotVersion.getExtension()) + ") from metadata.");
+                              snapshotVersion.getExtension()));
             }
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/IndexPacker.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/IndexPacker.java
@@ -38,7 +38,7 @@ public class IndexPacker
             request.setUseTargetProperties(true);
             IndexPacker.INSTANCE.packIndex(request);
 
-            logger.info(String.format("Index for %s was packed successfully.", indexPath));
+            logger.info("Index for {} was packed successfully.", indexPath);
         }
         finally
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/group/RepositoryGroupIndexCreator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/group/RepositoryGroupIndexCreator.java
@@ -77,7 +77,7 @@ public class RepositoryGroupIndexCreator
                 }
                 catch (IndexNotFoundException ex)
                 {
-                    logger.warn(String.format("IndexNotFound in [%s]", subRepositoryIndexDirectoryPath), ex);
+                    logger.warn("IndexNotFound in [{}]", subRepositoryIndexDirectoryPath, ex);
                 }
             }
             finally

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/local/ArtifactEntryJarFileContentsIndexCreator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/local/ArtifactEntryJarFileContentsIndexCreator.java
@@ -113,9 +113,9 @@ public class ArtifactEntryJarFileContentsIndexCreator
 
         final String fieldValue = sb.toString().trim();
 
-        logger.debug(String.format("Updating ArtifactInfo using artifactEntry [%s] by classNames [%s]",
-                                   artifactEntry,
-                                   fieldValue));
+        logger.debug("Updating ArtifactInfo using artifactEntry [{}] by classNames [{}]",
+                     artifactEntry,
+                     fieldValue);
 
         if (fieldValue.length() != 0)
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/IndexResourceFetcher.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/IndexResourceFetcher.java
@@ -59,7 +59,7 @@ public class IndexResourceFetcher
     {
         final String uri = MessageFormat.format(INDEX_URI_PATTERN, repositoryBaseUrl, indexName);
 
-        logger.debug("Getting " + uri + "...");
+        logger.debug("Getting {}...", uri);
 
         InputStream result = null;
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryProxyIndexCreator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryProxyIndexCreator.java
@@ -98,7 +98,7 @@ public class RepositoryProxyIndexCreator
                                          final String repositoryId)
             throws IOException
     {
-        logger.debug("Downloading remote index for %s:%s ...", storageId, repositoryId);
+        logger.debug("Downloading remote index for {}:{} ...", storageId, repositoryId);
 
         final IndexUpdateRequest updateRequest = new IndexUpdateRequest(indexingContext,
                                                                         resourceFetcherFactory.createIndexResourceFetcher(

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryProxyIndexCreator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryProxyIndexCreator.java
@@ -71,8 +71,8 @@ public class RepositoryProxyIndexCreator
         final Date contextCurrentTimestamp = indexingContext.getTimestamp();
         if (Objects.equals(updateResult.getTimestamp(), contextCurrentTimestamp))
         {
-            logger.debug(String.format("No update required for remote index %s:%s, as the index is up to date!",
-                                       storageId, repositoryId));
+            logger.debug("No update required for remote index {}:{}, as the index is up to date!",
+                         storageId, repositoryId);
             if (!IndexPacker.packageExists(repositoryIndexDirectoryPath))
             {
                 IndexPacker.pack(repositoryIndexDirectoryPath, indexingContext);
@@ -81,15 +81,13 @@ public class RepositoryProxyIndexCreator
         }
         if (updateResult.isFullUpdate())
         {
-            logger.debug(String.format("Performed a full index update for %s:%s.", storageId, repositoryId));
+            logger.debug("Performed a full index update for {}:{}.", storageId, repositoryId);
 
         }
         else
         {
-            logger.debug(
-                    String.format(
-                            "Performed an incremental update, with changes covering the period between %s - %s.",
-                            contextCurrentTimestamp, updateResult.getTimestamp()));
+            logger.debug("Performed an incremental update, with changes covering the period between {} - {}.",
+                         contextCurrentTimestamp, updateResult.getTimestamp());
         }
         IndexPacker.pack(repositoryIndexDirectoryPath, indexingContext);
     }
@@ -100,7 +98,7 @@ public class RepositoryProxyIndexCreator
                                          final String repositoryId)
             throws IOException
     {
-        logger.debug(String.format("Downloading remote index for %s:%s ...", storageId, repositoryId));
+        logger.debug("Downloading remote index for %s:%s ...", storageId, repositoryId);
 
         final IndexUpdateRequest updateRequest = new IndexUpdateRequest(indexingContext,
                                                                         resourceFetcherFactory.createIndexResourceFetcher(

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryRemoteIndexingContextFactory.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/indexing/remote/RepositoryRemoteIndexingContextFactory.java
@@ -37,9 +37,8 @@ public class RepositoryRemoteIndexingContextFactory
         final RemoteRepository remoteRepository = repository.getRemoteRepository();
         if (remoteRepository == null)
         {
-            logger.warn(
-                    String.format("Repository [%s:%s] was expected to have remote repository provided but was null.",
-                                  repository.getStorage().getId(), repository.getId()));
+            logger.warn("Repository [{}:{}] was expected to have remote repository provided but was null.",
+                        repository.getStorage().getId(), repository.getId());
             return null;
 
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
@@ -362,7 +362,8 @@ public class MavenMetadataManager
         }
 
         RepositoryPath artifactBasePath = repositoryPath.getParent().getParent();
-        logger.debug("Artifact merge metadata triggered for {}({}). {}", artifact, artifactBasePath, repository.getType());
+        logger.debug("Artifact merge metadata triggered for {}({}). {}",
+                     artifact, artifactBasePath, repository.getType());
 
         try
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenMetadataManager.java
@@ -84,7 +84,7 @@ public class MavenMetadataManager
             artifactBasePath = repositoryPath.getParent().getParent();
         }
 
-        logger.debug("Getting metadata for " + artifactBasePath);
+        logger.debug("Getting metadata for {}", artifactBasePath);
 
         return readMetadata(artifactBasePath);
     }
@@ -163,14 +163,13 @@ public class MavenMetadataManager
         LayoutProvider layoutProvider = getLayoutProvider(repository, layoutProviderRegistry);
         if (!RepositoryFiles.artifactExists(artifactGroupDirectoryPath))
         {
-            logger.error("Artifact metadata generation failed: " + artifactGroupDirectoryPath + ").");
+            logger.error("Artifact metadata generation failed: {}).", artifactGroupDirectoryPath);
 
             return;
         }
 
-        logger.debug("Artifact metadata generation triggered for " + artifactGroupDirectoryPath +
-                     " in '" + repository.getStorage().getId() + ":" + repository.getId() + "'" +
-                     " [policy: " + repository.getPolicy() + "].");
+        logger.debug("Artifact metadata generation triggered for {} in '{}:{}' [policy: {}].",
+                     artifactGroupDirectoryPath, repository.getStorage().getId(), repository.getId(), repository.getPolicy());
 
         Pair<String, String> artifactGroup = MavenArtifactUtils.getDirectoryGA(artifactGroupDirectoryPath);
         String artifactGroupId = artifactGroup.getValue0();
@@ -211,9 +210,7 @@ public class MavenMetadataManager
             // Write basic metadata
             storeMetadata(artifactGroupDirectoryPath, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
 
-            logger.debug("Generated Maven metadata for " +
-                         artifactGroupId + ":" +
-                         artifactId + ".");
+            logger.debug("Generated Maven metadata for {}:{}.", artifactGroupId, artifactId);
         }
         /**
          * In a snapshot repository we need to generate maven-metadata.xml in the artifactBasePath and
@@ -245,8 +242,7 @@ public class MavenMetadataManager
             // Write artifact metadata
             storeMetadata(artifactGroupDirectoryPath, null, metadata, MetadataType.ARTIFACT_ROOT_LEVEL);
 
-            logger.debug("Generated Maven metadata for " + artifactGroupId + ":" +
-                         artifactId + ".");
+            logger.debug("Generated Maven metadata for {}:{}.", artifactGroupId, artifactId);
         }
         else if (repository.getPolicy().equals(RepositoryPolicyEnum.MIXED.getPolicy()))
         {
@@ -272,7 +268,7 @@ public class MavenMetadataManager
 
         storeMetadata(pluginMetadataPath, null, pluginMetadata, MetadataType.PLUGIN_GROUP_LEVEL);
 
-        logger.debug("Generated Maven plugin metadata for " + groupId + ":" + aritfactId + ".");
+        logger.debug("Generated Maven plugin metadata for {}:{}.", groupId, aritfactId);
     }
 
     public Metadata generateSnapshotVersioningMetadata(String groupId,
@@ -327,10 +323,12 @@ public class MavenMetadataManager
                 catch (Exception e)
                 {
                     // Exception not propagated, intentionally
-                    logger.debug("Unable to merge the metadata to " + metadataBasePath + " by source metadata " +
-                                 ReflectionToStringBuilder.toString(mergeMetadata) +
-                                 ". Exception message was: {}. Continuing with storing new metadata ...",
-                                 e.getMessage());
+                    logger.debug("Unable to merge the metadata to {} by source metadata {}. " +
+                                 "Exception message was: {}. Continuing with storing new metadata ...",
+                                 metadataBasePath,
+                                 ReflectionToStringBuilder.toString(mergeMetadata),
+                                 e.getMessage(),
+                                 e);
                 }
             }
 
@@ -364,8 +362,7 @@ public class MavenMetadataManager
         }
 
         RepositoryPath artifactBasePath = repositoryPath.getParent().getParent();
-        logger.debug("Artifact merge metadata triggered for " + artifact.toString() + "(" + artifactBasePath + "). " +
-                     repository.getType());
+        logger.debug("Artifact merge metadata triggered for {}({}). {}", artifact, artifactBasePath, repository.getType());
 
         try
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenSnapshotManager.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/MavenSnapshotManager.java
@@ -52,14 +52,13 @@ public class MavenSnapshotManager
         Repository repository = basePath.getRepository();
         if (!RepositoryFiles.artifactExists(basePath))
         {
-            logger.error("Removal of timestamped Maven snapshot artifact: " + basePath + ".");
+            logger.error("Removal of timestamped Maven snapshot artifact: {}.", basePath);
             
             return;
         }
         
-        logger.debug("Removal of timestamped Maven snapshot artifact " + basePath +
-                     " in '" + repository.getStorage()
-                                         .getId() + ":" + repository.getId() + "'.");
+        logger.debug("Removal of timestamped Maven snapshot artifact {} in '{}:{}'.",
+                     basePath, repository.getStorage().getId(), repository.getId());
 
         Pair<String, String> artifactGroup = MavenArtifactUtils.getDirectoryGA(basePath);
         String artifactGroupId = artifactGroup.getValue0();
@@ -79,7 +78,7 @@ public class MavenSnapshotManager
                 continue;
             }
 
-            logger.debug("Generate snapshot versioning metadata for " + versionDirectoryPath + ".");
+            logger.debug("Generate snapshot versioning metadata for {}.", versionDirectoryPath);
 
             mavenMetadataManager.generateSnapshotVersioningMetadata(artifactGroupId,
                                                                     artifactId,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidator.java
@@ -44,8 +44,7 @@ public class MavenArtifactIdLowercaseValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/artifactid/MavenArtifactIdLowercaseValidator.java
@@ -44,7 +44,8 @@ public class MavenArtifactIdLowercaseValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/groupid/MavenGroupIdLowercaseValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/groupid/MavenGroupIdLowercaseValidator.java
@@ -43,8 +43,8 @@ public class MavenGroupIdLowercaseValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidator.java
@@ -37,8 +37,7 @@ public class MavenReleaseVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenReleaseVersionValidator.java
@@ -37,7 +37,8 @@ public class MavenReleaseVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidator.java
@@ -37,8 +37,7 @@ public class MavenSnapshotVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '" + getClass().getCanonicalName() +"'" +
-                    " with alias '" + ALIAS + "'.");
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/main/java/org/carlspring/strongbox/storage/validation/version/MavenSnapshotVersionValidator.java
@@ -37,7 +37,8 @@ public class MavenSnapshotVersionValidator
     {
         artifactCoordinatesValidatorRegistry.addProvider(ALIAS, this);
 
-        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered artifact coordinates validator '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     @Override

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
@@ -150,7 +150,7 @@ public class MavenArtifactDeployer
 
         String url = client.getContextBaseUrl() + "/storages/" + storageId + "/" + repositoryId + "/" + metadataPath;
 
-        logger.debug("Deploying " + url + "...");
+        logger.debug("Deploying {}...", url);
 
         client.deployMetadata(is, url, metadataPath.substring(metadataPath.lastIndexOf("/")));
 
@@ -218,7 +218,7 @@ public class MavenArtifactDeployer
 
             String url = client.getContextBaseUrl() + "/storages/" + storageId + "/" + repositoryId + "/" + artifactToPath;
 
-            logger.debug("Deploying " + url + "...");
+            logger.debug("Deploying {}...", url);
 
             String fileName = MavenArtifactTestUtils.getArtifactFileName(artifact);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -300,7 +300,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         model.setVersion(artifact.getVersion());
         model.setPackaging(packaging);
 
-        logger.debug("Generating pom file for " + artifact.toString() + "...");
+        logger.debug("Generating pom file for {}...", artifact);
 
         try (OutputStreamWriter pomFileWriter = new OutputStreamWriter(newOutputStream(pomFile)))
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -696,8 +696,6 @@ public class ArtifactManagementServiceImplTest
         catch (Exception e)
         {
             logger.error("Unexpected Exception while getting result:", e);
-            e.printStackTrace();
-
             return 0L;
         }
     }
@@ -738,7 +736,6 @@ public class ArtifactManagementServiceImplTest
             }
             catch (Exception ex)
             {
-                ex.printStackTrace();
                 logger.error("Failed to store artifact [{}]", repositoryPath, ex);
 
                 return 0L;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactManagementServiceImplTest.java
@@ -739,7 +739,7 @@ public class ArtifactManagementServiceImplTest
             catch (Exception ex)
             {
                 ex.printStackTrace();
-                logger.error(String.format("Failed to store artifact [%s]", repositoryPath), ex);
+                logger.error("Failed to store artifact [{}]", repositoryPath, ex);
 
                 return 0L;
             }
@@ -771,8 +771,7 @@ public class ArtifactManagementServiceImplTest
             }
             catch (InterruptedException e)
             {
-                e.printStackTrace();
-                logger.error(String.format("Failed to read artifact [%s]", path), e);
+                logger.error("Failed to read artifact [{}]", path, e);
                 
                 return 0L;
             }
@@ -797,8 +796,7 @@ public class ArtifactManagementServiceImplTest
             }
             catch (Exception ex)
             {
-                ex.printStackTrace();
-                logger.error(String.format("Failed to read artifact [%s]", repositoryPath), ex);
+                logger.error("Failed to read artifact [{}]", repositoryPath, ex);
                 
                 return 0L;
             }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/services/ArtifactMetadataServiceReleasesTest.java
@@ -323,9 +323,8 @@ public class ArtifactMetadataServiceReleasesTest
                         }
                         catch (IOException e)
                         {
-                            logger.error(
-                                    String.format("Failed to change creation date for [%s]", filePath),
-                                    e);
+                            logger.error("Failed to change creation date for [{}]",
+                                         filePath, e);
                         }
                     });
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/remote/MockedIndexResourceFetcher.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/storage/indexing/remote/MockedIndexResourceFetcher.java
@@ -43,8 +43,8 @@ public class MockedIndexResourceFetcher
         this.storageId = split[0];
         this.repositoryId = split[1];
 
-        logger.debug("storageId:    " + this.storageId);
-        logger.debug("repositoryId: " + this.repositoryId);
+        logger.debug("storageId:    {}", this.storageId);
+        logger.debug("repositoryId: {}", this.repositoryId);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class MockedIndexResourceFetcher
     public InputStream retrieve(String name)
             throws IOException
     {
-        logger.debug("Requesting index from " + name + "...");
+        logger.debug("Requesting index from {}...", name);
 
         Repository repository = getConfiguration().getStorage(storageId).getRepository(repositoryId);
         RemoteRepository remoteRepository = repository.getRemoteRepository();
@@ -74,7 +74,7 @@ public class MockedIndexResourceFetcher
                                      "/.index/local");
         File indexResourceFile = new File(indexBaseDir, name);
 
-        logger.debug("indexResourceFile: " + indexResourceFile.getAbsolutePath());
+        logger.debug("indexResourceFile: {}", indexResourceFile.getAbsolutePath());
 
         return new FileInputStream(indexResourceFile);
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NpmLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NpmLayoutProvider.java
@@ -44,7 +44,7 @@ public class NpmLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     protected NpmArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NpmPackageSupplier.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NpmPackageSupplier.java
@@ -109,7 +109,7 @@ public class NpmPackageSupplier implements Function<Path, NpmPackageDesc>
         } 
         catch (NoSuchFileException e) 
         {
-            logger.warn(String.format("Checksum file not found [%s].", shasumPath));
+            logger.warn("Checksum file not found [{}].", shasumPath);
         }
         catch (IOException e)
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
@@ -142,7 +142,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         }
         catch (Exception e)
         {
-            logger.error("Failed to searhc NPM packages [{}]", remoteRepositoryUrl, e);
+            logger.error("Failed to search NPM packages [{}]", remoteRepositoryUrl, e);
             
             return;
         } 
@@ -210,7 +210,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
         try
         {
-            logger.debug("Fetching remote cnages for [{}] since [{}].", replicateUrl, since);
+            logger.debug("Fetching remote changes for [{}] since [{}].", replicateUrl, since);
 
             WebTarget service = restClient.target(replicateUrl);
             service = service.path("_changes");
@@ -272,7 +272,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
                 }
                 catch (Exception e)
                 {
-                    logger.error("Failed to parse NPM cnahges feed [{}] since [{}]: \n {}",
+                    logger.error("Failed to parse NPM changes feed [{}] since [{}]: \n {}",
                                  repositoryConfiguration.getReplicateUrl(),
                                  repositoryConfiguration.getLastChangeId(),
                                  changeValue,
@@ -301,7 +301,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
 
         }
 
-        logger.debug("Fetched remote cnages for  [{}] since [{}].",
+        logger.debug("Fetched remote changes for  [{}] since [{}].",
                      repositoryConfiguration.getReplicateUrl(),
                      repositoryConfiguration.getLastChangeId());
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
@@ -400,7 +400,8 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             Predicate predicate = event.getPredicate();
             Long packageCount = countPackages(storageId, repositoryId, predicate);
 
-            logger.debug("NPM remote repository [{}] cached package count is [{}]", repository.getId(), packageCount);
+            logger.debug("NPM remote repository [{}] cached package count is [{}]",
+                         repository.getId(), packageCount);
 
             Runnable job = () -> fetchRemoteSearchResult(storageId, repositoryId, npmSearchRequest.getText(),
                                                          npmSearchRequest.getSize());
@@ -457,7 +458,8 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             Predicate predicate = event.getPredicate();
             Long packageCount = countPackages(storageId, repositoryId, predicate);
 
-            logger.debug("NPM remote repository [{}] cached package count is [{}]", repository.getId(), packageCount);
+            logger.debug("NPM remote repository [{}] cached package count is [{}]",
+                         repository.getId(), packageCount);
 
             Runnable job = () -> fetchRemotePackageFeed(storage.getId(), repository.getId(),
                                                         npmSearchRequest.getPackageId());

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/main/java/org/carlspring/strongbox/repository/NpmRepositoryFeatures.java
@@ -129,7 +129,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
         try
         {
-            logger.debug(String.format("Search NPM packages for [%s].", remoteRepositoryUrl));
+            logger.debug("Search NPM packages for [{}].", remoteRepositoryUrl);
 
             WebTarget service = restClient.target(remoteRepository.getUrl());
             service = service.path("-/v1/search").queryParam("text", text).queryParam("size", size);
@@ -137,12 +137,12 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             InputStream inputStream = service.request().buildGet().invoke(InputStream.class);
             searchResults = npmJacksonMapper.readValue(inputStream, SearchResults.class);
 
-            logger.debug(String.format("Searched NPM packages for [%s].", remoteRepository.getUrl()));
+            logger.debug("Searched NPM packages for [{}].", remoteRepository.getUrl());
 
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to searhc NPM packages [%s]", remoteRepositoryUrl), e);
+            logger.error("Failed to searhc NPM packages [{}]", remoteRepositoryUrl, e);
             
             return;
         } 
@@ -157,7 +157,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to parse NPM packages search result for [%s]", remoteRepositoryUrl), e);
+            logger.error("Failed to parse NPM packages search result for [{}]", remoteRepositoryUrl, e);
         }
     }
 
@@ -184,7 +184,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         NpmRemoteRepositoryConfiguration configuration = (NpmRemoteRepositoryConfiguration) remoteRepository.getCustomConfiguration();
         if (configuration == null)
         {
-            logger.warn(String.format("Remote npm configuration not found for [%s]/[%s]", storageId, repositoryId));
+            logger.warn("Remote npm configuration not found for [{}]/[{}]", storageId, repositoryId);
             return;
         }
         Long lastCnahgeId = configuration.getLastChangeId();
@@ -210,7 +210,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
         try
         {
-            logger.debug(String.format("Fetching remote cnages for [%s] since [%s].", replicateUrl, since));
+            logger.debug("Fetching remote cnages for [{}] since [{}].", replicateUrl, since);
 
             WebTarget service = restClient.target(replicateUrl);
             service = service.path("_changes");
@@ -272,10 +272,10 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
                 }
                 catch (Exception e)
                 {
-                    logger.error(String.format("Failed to parse NPM cnahges feed [%s] since [%s]: %n %s",
-                                               repositoryConfiguration.getReplicateUrl(),
-                                               repositoryConfiguration.getLastChangeId(),
-                                               changeValue),
+                    logger.error("Failed to parse NPM cnahges feed [{}] since [{}]: \n {}",
+                                 repositoryConfiguration.getReplicateUrl(),
+                                 repositoryConfiguration.getLastChangeId(),
+                                 changeValue,
                                  e);
 
                     return result;
@@ -288,9 +288,9 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
                 }
                 catch (Exception e)
                 {
-                    logger.error(String.format("Failed to parse NPM feed [%s/%s]",
-                                               ((RepositoryData)repository).getRemoteRepository().getUrl(),
-                                               packageFeed.getName()),
+                    logger.error("Failed to parse NPM feed [{}/{}]",
+                                 ((RepositoryData)repository).getRemoteRepository().getUrl(),
+                                 packageFeed.getName(),
                                  e);
 
                 }
@@ -301,9 +301,9 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
 
         }
 
-        logger.debug(String.format("Fetched remote cnages for  [%s] since [%s].",
-                                   repositoryConfiguration.getReplicateUrl(),
-                                   repositoryConfiguration.getLastChangeId()));
+        logger.debug("Fetched remote cnages for  [{}] since [{}].",
+                     repositoryConfiguration.getReplicateUrl(),
+                     repositoryConfiguration.getLastChangeId());
 
         return result;
     }
@@ -327,7 +327,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
         try
         {
-            logger.debug(String.format("Downloading NPM changes feed for [%s].", remoteRepositoryUrl));
+            logger.debug("Downloading NPM changes feed for [{}].", remoteRepositoryUrl);
 
             WebTarget service = restClient.target(remoteRepository.getUrl());
             service = service.path(packageId);
@@ -335,12 +335,12 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             InputStream inputStream = service.request().buildGet().invoke(InputStream.class);
             packageFeed = npmJacksonMapper.readValue(inputStream, PackageFeed.class);
 
-            logger.debug(String.format("Downloaded NPM changes feed for [%s].", remoteRepository.getUrl()));
+            logger.debug("Downloaded NPM changes feed for [{}].", remoteRepository.getUrl());
 
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to fetch NPM changes feed [%s]", remoteRepositoryUrl), e);
+            logger.error("Failed to fetch NPM changes feed [{}]", remoteRepositoryUrl, e);
             return;
         } 
         finally
@@ -354,9 +354,9 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to parse NPM feed [%s/%s]",
-                                       ((RepositoryData)repository).getRemoteRepository().getUrl(),
-                                       packageFeed.getName()),
+            logger.error("Failed to parse NPM feed [{}/{}]",
+                         ((RepositoryData)repository).getRemoteRepository().getUrl(),
+                         packageFeed.getName(),
                          e);
         }
     }
@@ -400,8 +400,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             Predicate predicate = event.getPredicate();
             Long packageCount = countPackages(storageId, repositoryId, predicate);
 
-            logger.debug(String.format("NPM remote repository [%s] cached package count is [%s]", repository.getId(),
-                                       packageCount));
+            logger.debug("NPM remote repository [{}] cached package count is [{}]", repository.getId(), packageCount);
 
             Runnable job = () -> fetchRemoteSearchResult(storageId, repositoryId, npmSearchRequest.getText(),
                                                          npmSearchRequest.getSize());
@@ -458,8 +457,7 @@ public class NpmRepositoryFeatures implements RepositoryFeatures
             Predicate predicate = event.getPredicate();
             Long packageCount = countPackages(storageId, repositoryId, predicate);
 
-            logger.debug(String.format("NPM remote repository [%s] cached package count is [%s]", repository.getId(),
-                                       packageCount));
+            logger.debug("NPM remote repository [{}] cached package count is [{}]", repository.getId(), packageCount);
 
             Runnable job = () -> fetchRemotePackageFeed(storage.getId(), repository.getId(),
                                                         npmSearchRequest.getPackageId());

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/artifact/coordinates/PathNupkg.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/artifact/coordinates/PathNupkg.java
@@ -73,13 +73,13 @@ public class PathNupkg implements Nupkg
         RepositoryPath checkSumPath = checksumPathMap.values().iterator().next();
         if (!Files.exists(checkSumPath))
         {
-            logger.trace(String.format("Failed to resolve checksum file for [%s]", path));
+            logger.trace("Failed to resolve checksum file for [{}]", path);
             return "";
         }
         List<String> checkSumContents = Files.readAllLines(checkSumPath);
         if (checkSumContents.isEmpty() || checkSumContents.size() > 1)
         {
-            logger.error(String.format("Found illegal checksum contents for [%s]", path));
+            logger.error("Found illegal checksum contents for [{}]", path);
             return null;
         }
         
@@ -101,7 +101,7 @@ public class PathNupkg implements Nupkg
         RepositoryPath nuspecPath = path.resolveSibling(artifactCoordinates.getId() + ".nuspec");
         if (!Files.exists(nuspecPath))
         {
-            logger.trace(String.format("Failed to resolve .nuspec file for [%s]", path));
+            logger.trace("Failed to resolve .nuspec file for [{}]", path);
             Nuspec result = new Nuspec();
             Metadata metadata = result.getMetadata();
             metadata.id = artifactCoordinates.getId();
@@ -116,7 +116,7 @@ public class PathNupkg implements Nupkg
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to read .nuspec file for [%s]", path), e);
+            logger.error("Failed to read .nuspec file for [{}]", path, e);
             return null;
         }
     }
@@ -169,7 +169,7 @@ public class PathNupkg implements Nupkg
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to parse version for [%s]", path));
+            logger.error("Failed to parse version for [{}]", path);
             return null;
         }
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NugetLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NugetLayoutProvider.java
@@ -53,7 +53,8 @@ public class NugetLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered layout provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     protected NugetArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NugetLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/NugetLayoutProvider.java
@@ -53,7 +53,7 @@ public class NugetLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     protected NugetArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/repository/NugetRepositoryFeatures.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/repository/NugetRepositoryFeatures.java
@@ -179,7 +179,8 @@ public class NugetRepositoryFeatures
         {
             logger.error("Failed to fetch Nuget remote feed [{}]", remoteRepositoryUrl, e);
             return false;
-        } finally
+        }
+        finally
         {
             restClient.close();
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/repository/NugetRepositoryFeatures.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/repository/NugetRepositoryFeatures.java
@@ -163,21 +163,21 @@ public class NugetRepositoryFeatures
         Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
         try
         {
-            logger.debug(String.format("Downloading remote feed for [%s].", remoteRepositoryUrl));
+            logger.debug("Downloading remote feed for [{}].", remoteRepositoryUrl);
 
             WebTarget service = restClient.target(remoteRepository.getUrl());
             packageFeed = queryParams(service.path("Search()"), nugetSearchRequest, paginator).request()
                                                                                               .buildGet()
                                                                                               .invoke(PackageFeed.class);
-            
-            logger.debug(String.format("Downloaded remote feed for [%s], size [%s].",
-                                       remoteRepository.getUrl(),
-                                       Optional.of(packageFeed).map(f -> f.getEntries().size()).orElse(0)));
+
+            logger.debug("Downloaded remote feed for [{}], size [{}].",
+                         remoteRepository.getUrl(),
+                         Optional.of(packageFeed).map(f -> f.getEntries().size()).orElse(0));
 
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to fetch Nuget remote feed [%s]", remoteRepositoryUrl), e);
+            logger.error("Failed to fetch Nuget remote feed [{}]", remoteRepositoryUrl, e);
             return false;
         } finally
         {
@@ -304,8 +304,7 @@ public class NugetRepositoryFeatures
             OQueryTemplate<Long, RemoteArtifactEntry> queryTemplate = new OQueryTemplate<>(entityManager);
             Long packageCount = queryTemplate.select(selector);
 
-            logger.debug(String.format("Remote repository [%s] cached package count is [%s]", repository.getId(),
-                                       packageCount));
+            logger.debug("Remote repository [{}] cached package count is [{}]", repository.getId(), packageCount);
 
             Client restClient = proxyRepositoryConnectionPoolConfigurationService.getRestClient();
             PackageFeed feed;
@@ -317,31 +316,29 @@ public class NugetRepositoryFeatures
                                                                    nugetSearchRequest, new Paginator()).request()
                                                                                                        .buildGet()
                                                                                                        .invoke(String.class));
-                logger.debug(String.format("Remote repository [%s] remote package count is [%s]",
-                                           repository.getId(), remotePackageCount));
+                logger.debug("Remote repository [{}] remote package count is [{}]", repository.getId(), remotePackageCount);
 
                 if (Long.valueOf(remotePackageCount).compareTo(packageCount) == 0)
                 {
-                    logger.debug(String.format("No need to download remote feed, there was no changes in remote repository [%s] against local cache.",
-                                               remoteRepository.getUrl()));
+                    logger.debug("No need to download remote feed, there was no changes in remote repository [{}] against local cache.",
+                                 remoteRepository.getUrl());
                     return;
                 }
 
-                logger.debug(String.format("Downloading remote feed for [%s].",
-                                           remoteRepository.getUrl()));
+                logger.debug("Downloading remote feed for [{}].", remoteRepository.getUrl());
 
                 feed = queryParams(service.path("Search()"), nugetSearchRequest, event.getPaginator()).request()
                                                                                                       .buildGet()
                                                                                                       .invoke(PackageFeed.class);
 
-                logger.debug(String.format("Downloaded remote feed for [%s], size [%s].",
-                                           remoteRepository.getUrl(),
-                                           Optional.of(feed).map(f -> f.getEntries().size()).orElse(0)));
+                logger.debug("Downloaded remote feed for [{}], size [{}].",
+                             remoteRepository.getUrl(),
+                             Optional.of(feed).map(f -> f.getEntries().size()).orElse(0));
 
             }
             catch (Exception e)
             {
-                logger.error(String.format("Failed to fetch Nuget remote feed [%s]", remoteRepository.getUrl()), e);
+                logger.error("Failed to fetch Nuget remote feed [{}]", remoteRepository.getUrl(), e);
                 return;
             } 
             finally

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/AssemblyTargetFrameworkAdapter.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/AssemblyTargetFrameworkAdapter.java
@@ -78,7 +78,7 @@ public class AssemblyTargetFrameworkAdapter extends XmlAdapter<String, EnumSet<F
             }
             catch (Exception e)
             {
-                logger.warn(java.text.MessageFormat.format("Can not add framework: \"{0}\"", name), e);
+                logger.warn("Can not add framework: \"{}\"", name, e);
             }
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/Dependency.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/Dependency.java
@@ -115,7 +115,7 @@ public class Dependency implements Serializable
 
             if (dependency.framework == null)
             {
-                logger.warn("Package:" + id + "The framework was not found" + frameWorkString);
+                logger.warn("Package:{} The framework was not found {}", id, frameWorkString);
             }
         }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/Framework.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/main/java/org/carlspring/strongbox/storage/metadata/nuget/Framework.java
@@ -312,7 +312,7 @@ public enum Framework
         }
         catch (IllegalArgumentException e)
         {
-            logger.warn(format("Can not find framework for string \"{0}\" used default value", value), e);
+            logger.warn("Can not find framework for string \"{}\" used default value", value, e);
             result = EnumSet.allOf(Framework.class);
         }
         return result;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/P2LayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/P2LayoutProvider.java
@@ -32,7 +32,8 @@ public class P2LayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered layout provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     protected P2ArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/P2LayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/P2LayoutProvider.java
@@ -32,7 +32,7 @@ public class P2LayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     protected P2ArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/PypiLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/PypiLayoutProvider.java
@@ -42,7 +42,7 @@ public class PypiLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS );
     }
 
     protected PypiArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/PypiLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/PypiLayoutProvider.java
@@ -42,7 +42,8 @@ public class PypiLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS );
+        logger.info("Registered layout provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS );
     }
 
     protected PypiArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/util/PypiMetadataParser.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/util/PypiMetadataParser.java
@@ -59,7 +59,7 @@ public class PypiMetadataParser
             }
             catch (IllegalAccessException ex)
             {
-                logger.error("Exception occurred {} ...", ExceptionUtils.getStackTrace(ex));
+                logger.error("Exception occurred ", ex);
                 throw ex;
             }
         }
@@ -86,7 +86,7 @@ public class PypiMetadataParser
         }
         catch (IOException ex)
         {
-            logger.error("Exception occurred {} ...", ExceptionUtils.getStackTrace(ex));
+            logger.error("Exception occurred ", ex);
             throw ex;
         }
         return keyValueMap;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/util/PypiMetadataParser.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/main/java/org/carlspring/strongbox/util/PypiMetadataParser.java
@@ -86,7 +86,7 @@ public class PypiMetadataParser
         }
         catch (IOException ex)
         {
-            logger.error("Exception occured {} ...", ExceptionUtils.getStackTrace(ex));
+            logger.error("Exception occurred {} ...", ExceptionUtils.getStackTrace(ex));
             throw ex;
         }
         return keyValueMap;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/RawLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/RawLayoutProvider.java
@@ -38,7 +38,8 @@ public class RawLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
+        logger.info("Registered layout provider '{}' with alias '{}'.",
+                    getClass().getCanonicalName(), ALIAS);
     }
 
     protected NullArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/RawLayoutProvider.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/src/main/java/org/carlspring/strongbox/providers/layout/RawLayoutProvider.java
@@ -38,7 +38,7 @@ public class RawLayoutProvider
     @PostConstruct
     public void register()
     {
-        logger.info("Registered layout provider '" + getClass().getCanonicalName() + "' with alias '" + ALIAS + "'.");
+        logger.info("Registered layout provider '{}' with alias '{}'.", getClass().getCanonicalName(), ALIAS);
     }
 
     protected NullArtifactCoordinates getArtifactCoordinates(RepositoryPath path) throws IOException

--- a/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/testing/AssignedPorts.java
+++ b/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/testing/AssignedPorts.java
@@ -40,7 +40,7 @@ public class AssignedPorts
                 final int port = Integer.parseInt(System.getProperty(portKey));
                 ports.put(portKey, port);
 
-                logger.debug("Discovered port '" + portKey + "' = '" + port + "'.");
+                logger.debug("Discovered port '{}' = '{}'.", portKey, port);
             }
         }
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/StrongboxSpringBootApplication.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/StrongboxSpringBootApplication.java
@@ -36,8 +36,8 @@ public class StrongboxSpringBootApplication
     {
         if (System.getProperty(OrientDbProfile.PROPERTY_PROFILE) == null)
         {
-            logger.info(String.format("OrientDB profile not set, will use [%s] profile as default",
-                                      OrientDbProfile.PROFILE_EMBEDDED));
+            logger.info("OrientDB profile not set, will use [{}] profile as default",
+                        OrientDbProfile.PROFILE_EMBEDDED);
 
             System.setProperty(OrientDbProfile.PROPERTY_PROFILE, OrientDbProfile.PROFILE_EMBEDDED);
         }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/boot/DefaultBootServlet.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/app/boot/DefaultBootServlet.java
@@ -52,7 +52,7 @@ public class DefaultBootServlet
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
             response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
         }
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -111,7 +111,7 @@ public class BrowseController
                                ModelMap model,
                                @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String acceptHeader)
     {
-        logger.debug("Requested browsing for repositories in storage : " + storageId);
+        logger.debug("Requested browsing for repositories in storage : {}", storageId);
 
         try
         {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/DefaultExceptionHandler.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/DefaultExceptionHandler.java
@@ -17,6 +17,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -35,6 +37,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @ControllerAdvice
 public class DefaultExceptionHandler extends ResponseEntityExceptionHandler
 {
+    private final Logger logger = LoggerFactory.getLogger(DefaultExceptionHandler.class);
 
     @Inject
     private ContentNegotiationManager contentNegotiationManager;
@@ -100,7 +103,7 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler
     protected ResponseEntity<?> handleUnknownError(Exception ex,
                                                    WebRequest request)
     {
-        logger.error(String.format("Request [%s] failed.", request), ex);
+        logger.error("Request [{}] failed.", request, ex);
         
         return provideDefaultErrorResponse(ex, request, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -160,7 +163,7 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler
         }
         catch (HttpMediaTypeNotAcceptableException e1)
         {
-            logger.error(String.format("Reuqested invalid content-type [%s]", request.getHeader(HttpHeaders.ACCEPT)));
+            logger.error("Reuqested invalid content-type [{}]", request.getHeader(HttpHeaders.ACCEPT));
             mediaTypes.add(MediaType.APPLICATION_JSON);
         }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/DefaultExceptionHandler.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/DefaultExceptionHandler.java
@@ -163,7 +163,7 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler
         }
         catch (HttpMediaTypeNotAcceptableException e1)
         {
-            logger.error("Reuqested invalid content-type [{}]", request.getHeader(HttpHeaders.ACCEPT));
+            logger.error("Requested invalid content-type [{}]", request.getHeader(HttpHeaders.ACCEPT), e1);
             mediaTypes.add(MediaType.APPLICATION_JSON);
         }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/LoggingManagementController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/LoggingManagementController.java
@@ -242,7 +242,8 @@ public class LoggingManagementController
                                               @RequestHeader(value = HttpHeaders.ACCEPT,
                                                              required = false) String acceptHeader)
     {
-        logger.debug("Requested directory listing of logs {}/logs/{}", ROOT_CONTEXT, rawPath.orElse(""));
+        logger.debug("Requested directory listing of logs {}/logs/{}",
+                     ROOT_CONTEXT, rawPath.orElse(""));
 
         try
         {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/LoggingManagementController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/LoggingManagementController.java
@@ -242,7 +242,7 @@ public class LoggingManagementController
                                               @RequestHeader(value = HttpHeaders.ACCEPT,
                                                              required = false) String acceptHeader)
     {
-        logger.debug("Requested directory listing of logs " + ROOT_CONTEXT + "/logs/{}", rawPath.orElse(""));
+        logger.debug("Requested directory listing of logs {}/logs/{}", ROOT_CONTEXT, rawPath.orElse(""));
 
         try
         {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/SearchController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/SearchController.java
@@ -63,8 +63,8 @@ public class SearchController
         String accept = request.getHeader("accept");
         String q = URLDecoder.decode(query, "UTF-8");
 
-        logger.debug("[search] " + q + "\n\taccept " + accept + "\n\tstorageId = " +
-                     storageId + "\n\trepositoryId = " + repositoryId);
+        logger.debug("[search] {}\n\taccept {}\n\tstorageId = {}\n\trepositoryId = {}",
+                     q, accept, storageId, repositoryId);
 
         if (accept.equalsIgnoreCase(MediaType.TEXT_PLAIN_VALUE))
         {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationController.java
@@ -218,7 +218,7 @@ public class StoragesConfigurationController
 
                 configurationManagementService.removeStorage(storageId);
 
-                logger.debug("Removed storage " + storageId + ".");
+                logger.debug("Removed storage {}.", storageId);
 
                 return getSuccessfulResponseEntity(SUCCESSFUL_STORAGE_REMOVAL, accept);
             }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/security/cors/CorsConfigurationController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/configuration/security/cors/CorsConfigurationController.java
@@ -107,7 +107,7 @@ public class CorsConfigurationController
         }
         catch (Exception ex)
         {
-            logger.error(String.format("Unable to set CORS allowed origins"), ex);
+            logger.error("Unable to set CORS allowed origins", ex);
             return false;
         }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -419,7 +419,7 @@ public class NpmArtifactController
         String shasum = Optional.ofNullable(packageDef.getDist()).map(p -> p.getShasum()).orElse(null);
         if (shasum == null)
         {
-            logger.warn(String.format("No checksum provided for package [%s]", packageDef.getName()));
+            logger.warn("No checksum provided for package [{}]", packageDef.getName());
             return;
         }
 
@@ -475,7 +475,7 @@ public class NpmArtifactController
                                                 jp.currentToken().name()));
 
                     String packageAttachmentName = jp.nextFieldName();
-                    logger.info(String.format("Found npm package attachment [%s]", packageAttachmentName));
+                    logger.info("Found npm package attachment [{}]", packageAttachmentName);
 
                     moveToAttachment(jp, packageAttachmentName);
                     packageTgzPath = extractPackage(jp);

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactController.java
@@ -112,7 +112,7 @@ public class NugetArtifactController
         }
         catch (IOException e)
         {
-            logger.error(String.format("Failed to process Nuget delete request: path-[%s]", path), e);
+            logger.error("Failed to process Nuget delete request: path-[{}]", path, e);
 
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
@@ -209,7 +209,7 @@ public class NugetArtifactController
             }
             catch (NoSuchAlgorithmException | IOException | NugetFormatException e)
             {
-                logger.error("Failed to parse package " + nupkg, e);
+                logger.error("Failed to parse package {}", nupkg, e);
             }
         }
         logger.debug("Got {} packages", new Object[] { packageEntrys.size() });
@@ -338,7 +338,7 @@ public class NugetArtifactController
                            }
                            catch (Exception e)
                            {
-                               logger.error(String.format("Failed to resolve Nuget package path [%s]", p), e);
+                               logger.error("Failed to resolve Nuget package path [{}]", p, e);
                                return null;
                            }
                        })
@@ -427,9 +427,9 @@ public class NugetArtifactController
 
             if (packagePartInputStream == null)
             {
-                logger.error(String.format("Failed to extract Nuget package from request: [%s]:[%s]",
-                                           storageId,
-                                           repositoryId));
+                logger.error("Failed to extract Nuget package from request: [{}]:[{}]",
+                             storageId,
+                             repositoryId);
 
                 return ResponseEntity.badRequest().build();
             }
@@ -438,7 +438,7 @@ public class NugetArtifactController
         }
         catch (Exception e)
         {
-            logger.error(String.format("Failed to process Nuget push request: %s:%s", storageId, repositoryId), e);
+            logger.error("Failed to process Nuget push request: {}:{}", storageId, repositoryId, e);
 
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
@@ -594,7 +594,7 @@ public class NugetArtifactController
             }
 
             int contentLength = multipartStream.readBodyData(packagePartOutputStream);
-            logger.info(String.format("NuGet package content length [%s]", contentLength));
+            logger.info("NuGet package content length [{}]", contentLength);
         }
     }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/AuthenticationSuppliers.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/AuthenticationSuppliers.java
@@ -32,7 +32,7 @@ public class AuthenticationSuppliers
     {
         if (suppliers == null || suppliers.isEmpty())
         {
-            logger.debug(String.format("There was no any [%s] provided.", AuthenticationSupplier.class));
+            logger.debug("There was no any [{}] provided.", AuthenticationSupplier.class);
             
             return null;
         }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/AuthenticationSuppliers.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/AuthenticationSuppliers.java
@@ -32,7 +32,7 @@ public class AuthenticationSuppliers
     {
         if (suppliers == null || suppliers.isEmpty())
         {
-            logger.debug("There was no any [{}] provided.", AuthenticationSupplier.class);
+            logger.debug("There was no [{}] provided.", AuthenticationSupplier.class);
             
             return null;
         }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/BasicAuthenticationSupplier.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/BasicAuthenticationSupplier.java
@@ -57,7 +57,7 @@ class BasicAuthenticationSupplier implements AuthenticationSupplier
 
         String username = tokens[0];
 
-        logger.debug("Basic Authentication Authorization header found for user '" + username + "'");
+        logger.debug("Basic Authentication Authorization header found for user '{}'", username);
 
         return new PasswordAuthentication(username, tokens[1]);
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/vote/ExtendedAuthoritiesVoter.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/vote/ExtendedAuthoritiesVoter.java
@@ -10,6 +10,9 @@ import org.aopalliance.intercept.MethodInvocation;
 import org.carlspring.strongbox.users.domain.Privileges;
 import org.carlspring.strongbox.users.userdetails.SpringSecurityUser;
 import org.carlspring.strongbox.utils.UrlUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.ConfigAttribute;
 import org.springframework.security.access.expression.method.ExpressionBasedPreInvocationAdvice;
 import org.springframework.security.access.prepost.PreInvocationAuthorizationAdviceVoter;
@@ -25,6 +28,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExtendedAuthoritiesVoter extends PreInvocationAuthorizationAdviceVoter
 {
+    private final Logger logger = LoggerFactory.getLogger(ExtendedAuthoritiesVoter.class);
 
     public ExtendedAuthoritiesVoter()
     {
@@ -60,8 +64,7 @@ public class ExtendedAuthoritiesVoter extends PreInvocationAuthorizationAdviceVo
         {
             Object principal = authentication.getPrincipal();
             Collection<? extends GrantedAuthority> apiAuthorities = authentication.getAuthorities();
-            logger.debug(String.format("Privileges for [%s] are [%s]", principal,
-                                       apiAuthorities));
+            logger.debug("Privileges for [{}] are [{}]", principal, apiAuthorities);
 
             if (!authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken)
             {
@@ -71,7 +74,7 @@ public class ExtendedAuthoritiesVoter extends PreInvocationAuthorizationAdviceVo
             else if (!(principal instanceof SpringSecurityUser))
             {
 
-                logger.warn(String.format("Unknown authentication principal type [%s]", principal.getClass()));
+                logger.warn("Unknown authentication principal type [{}]", principal.getClass());
 
                 return authentication.getAuthorities();
             }
@@ -99,8 +102,7 @@ public class ExtendedAuthoritiesVoter extends PreInvocationAuthorizationAdviceVo
 
             List<GrantedAuthority> extendedAuthorities = new ArrayList<>(apiAuthorities);
             extendedAuthorities.addAll(storageAuthorities);
-            logger.debug(String.format("Privileges for [%s] was extended to [%s]", userDetails.getUsername(),
-                                       extendedAuthorities));
+            logger.debug("Privileges for [{}] was extended to [{}]", userDetails.getUsername(), extendedAuthorities);
 
             return extendedAuthorities;
         }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/ArtifactControllerHelper.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/ArtifactControllerHelper.java
@@ -68,7 +68,7 @@ public class ArtifactControllerHelper
         {
             long partialLength = calculatePartialRangeLength(byteRange, length);
 
-            logger.debug("Calculated partial range length ->>> " + partialLength + "\n");
+            logger.debug("Calculated partial range length ->>> {}\n", partialLength);
 
             StreamUtils.setCurrentByteRange(bris, byteRange);
 
@@ -97,15 +97,15 @@ public class ArtifactControllerHelper
     {
         if (byteRange.getLimit() > 0L && byteRange.getOffset() > 0L)
         {
-            logger.debug("Partial content byteRange.getOffset: " + byteRange.getOffset());
-            logger.debug("Partial content byteRange.getLimit: " + byteRange.getLimit());
-            logger.debug("Partial content length: " + (byteRange.getLimit() - byteRange.getOffset()));
+            logger.debug("Partial content byteRange.getOffset: {}", byteRange.getOffset());
+            logger.debug("Partial content byteRange.getLimit: {}", byteRange.getLimit());
+            logger.debug("Partial content length: {}", (byteRange.getLimit() - byteRange.getOffset()));
 
             return byteRange.getLimit() - byteRange.getOffset();
         }
         else if (length > 0L && byteRange.getOffset() > 0L && byteRange.getLimit() == 0L)
         {
-            logger.debug("Partial content length: " + (length - byteRange.getOffset()));
+            logger.debug("Partial content length: {}", (length - byteRange.getOffset()));
             return length - byteRange.getOffset();
         }
         else
@@ -122,7 +122,7 @@ public class ArtifactControllerHelper
         response.setHeader("Content-Range",
                            "bytes " + br.getOffset() + "-" + (length - 1L) + "/" + length);
 
-        logger.debug("Content-Range HEADER ->>> " + response.getHeader("Content-Range"));
+        logger.debug("Content-Range HEADER ->>> {}", response.getHeader("Content-Range"));
         response.setHeader("Pragma", "no-cache");
     }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/CustomAntPathMatcher.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/CustomAntPathMatcher.java
@@ -114,7 +114,7 @@ public class CustomAntPathMatcher
         String[] pathDirs = path.split(pathSeparator);
         String[] patternDirs = pattern.split(pathSeparator);
 
-        logger.trace("pathDirs {} {}" , pathDirs.length, Arrays.deepToString(pathDirs));
+        logger.trace("pathDirs {} {}", pathDirs.length, Arrays.deepToString(pathDirs));
         logger.trace("patternDirs {} {}", patternDirs.length, Arrays.deepToString(patternDirs));
 
         int pathSubDirCount = pathDirs.length;
@@ -144,8 +144,8 @@ public class CustomAntPathMatcher
 
         String pathVarValue = path.substring(subPathLength);
 
-        logger.trace("subPathLength {}",subPathLength);
-        logger.trace("pathVarValue {}",pathVarValue);
+        logger.trace("subPathLength {}", subPathLength);
+        logger.trace("pathVarValue {}", pathVarValue);
 
         return pathVarValue;
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/CustomAntPathMatcher.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/utils/CustomAntPathMatcher.java
@@ -76,9 +76,8 @@ public class CustomAntPathMatcher
             uriTemplateVariables.put(pathVariableName, getPathVariableValue(pattern, path));
         }
 
-        logger.trace("[doMatch] pattern " + pattern + "\n\tpath " + path + "\n\tfullMatch " +
-                     fullMatch + "\n\turiTemplateVariables " +
-                     uriTemplateVariables + "\n\tdefaultMatchResult " + defaultMatchResult);
+        logger.trace("[doMatch] pattern {}\n\tpath {}\n\tfullMatch {}\n\turiTemplateVariables {}\n\tdefaultMatchResult {}",
+                     pattern, path, fullMatch, uriTemplateVariables, defaultMatchResult);
 
         return defaultMatchResult;
     }
@@ -108,15 +107,15 @@ public class CustomAntPathMatcher
     private String getPathVariableValue(String pattern,
                                         String path)
     {
-        logger.trace("pattern " + pattern);
-        logger.trace("path " + path);
+        logger.trace("pattern {}", pattern);
+        logger.trace("path {}", path);
 
         // get the rest of source path based on the path variables count and path prefix
         String[] pathDirs = path.split(pathSeparator);
         String[] patternDirs = pattern.split(pathSeparator);
 
-        logger.trace("pathDirs " + pathDirs.length + " " + Arrays.deepToString(pathDirs));
-        logger.trace("patternDirs " + patternDirs.length + " " + Arrays.deepToString(patternDirs));
+        logger.trace("pathDirs {} {}" , pathDirs.length, Arrays.deepToString(pathDirs));
+        logger.trace("patternDirs {} {}", patternDirs.length, Arrays.deepToString(patternDirs));
 
         int pathSubDirCount = pathDirs.length;
         int subPathIndex = patternDirs.length;
@@ -135,7 +134,7 @@ public class CustomAntPathMatcher
         {
             String subPath = pathDirs[i];
 
-            logger.trace("Append subPath length " + subPath.length() + " for subPath " + subPath);
+            logger.trace("Append subPath length {} for subPath {}", subPath.length(), subPath);
 
             subPathLength += subPath.length();
             subPathLength += pathSeparatorLength;
@@ -145,8 +144,8 @@ public class CustomAntPathMatcher
 
         String pathVarValue = path.substring(subPathLength);
 
-        logger.trace("subPathLength " + subPathLength);
-        logger.trace("pathVarValue " + pathVarValue);
+        logger.trace("subPathLength {}",subPathLength);
+        logger.trace("pathVarValue {}",pathVarValue);
 
         return pathVarValue;
     }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/validation/configuration/routing/RoutingRuleRepositoryFormValidator.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/validation/configuration/routing/RoutingRuleRepositoryFormValidator.java
@@ -8,10 +8,14 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RoutingRuleRepositoryFormValidator
         implements ConstraintValidator<RoutingRuleRepositoryFormValid, RoutingRuleRepositoryForm>
 {
+
+    private final Logger logger = LoggerFactory.getLogger(RoutingRuleRepositoryFormValidator.class);
 
     @Inject
     private ConfigurationManagementService configurationManagementService;
@@ -52,7 +56,7 @@ public class RoutingRuleRepositoryFormValidator
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            logger.error(e.getMessage(), e);
         }
 
         return valid;

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ProxyConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/ProxyConfigurationControllerTestIT.java
@@ -89,7 +89,7 @@ public class ProxyConfigurationControllerTestIT
                .statusCode(HttpStatus.OK.value())
                .body(containsString(SUCCESSFUL_UPDATE));
 
-        logger.debug("Current proxy host: " + proxyConfiguration.getHost());
+        logger.debug("Current proxy host: {}", proxyConfiguration.getHost());
 
         MutableProxyConfiguration pc = mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                                               .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/configuration/StoragesConfigurationControllerTestIT.java
@@ -185,7 +185,7 @@ public class StoragesConfigurationControllerTestIT
 
         String url = getContextBaseUrl();
 
-        logger.debug("Using storage class " + storage1.getClass().getName());
+        logger.debug("Using storage class {}", storage1.getClass().getName());
 
         // 1. Create storage
         givenCustom().contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/MavenRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/MavenRestAssuredBaseTest.java
@@ -83,7 +83,7 @@ public abstract class MavenRestAssuredBaseTest
 
     protected boolean pathExists(String url)
     {
-        logger.trace("[pathExists] URL -> " + url);
+        logger.trace("[pathExists] URL -> {}", url);
 
         return mockMvc.header("user-agent", "Maven/*")
                       .contentType(MediaType.TEXT_PLAIN_VALUE)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NpmRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/NpmRestAssuredBaseTest.java
@@ -76,7 +76,7 @@ public abstract class NpmRestAssuredBaseTest
     {
         String url = getContextBaseUrl() + artifactPath;
 
-        logger.debug("Requesting " + url + "...");
+        logger.debug("Requesting {}...", url);
 
         InputStream is = client.getResource(url);
         if (is == null)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/RawRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/RawRestAssuredBaseTest.java
@@ -80,7 +80,7 @@ public class RawRestAssuredBaseTest
 
     protected boolean pathExists(String url)
     {
-        logger.trace("[pathExists] URL -> " + url);
+        logger.trace("[pathExists] URL -> {}", url);
 
         return mockMvc.header("user-agent", "Raw/*")
                       .contentType(MediaType.TEXT_PLAIN_VALUE)
@@ -99,7 +99,7 @@ public class RawRestAssuredBaseTest
     {
         String url = getContextBaseUrl() + artifactPath;
 
-        logger.debug("Requesting " + url + "...");
+        logger.debug("Requesting {}...", url);
 
         InputStream is = client.getResource(url);
         if (is == null)


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1500.
There are still some usages of Apache Commons Logging which doesn't support the SLF4J logging format, I figured changing the logger used is out of the PR scope.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
