### PR TITLE
#1535 generating test artifacts with a specified size for Maven

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -22,7 +22,7 @@ public interface ArtifactGenerator
      */
     Path generateArtifact(String id,
                           String version,
-                          int size)
+                          long size)
         throws IOException;
 
     /**
@@ -34,7 +34,7 @@ public interface ArtifactGenerator
      * @throws IOException in case of failure
      */
     Path generateArtifact(URI uri,
-                          int size)
+                          long size)
         throws IOException;
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -11,12 +11,28 @@ import java.nio.file.Path;
 public interface ArtifactGenerator
 {
 
+    /**
+     * Generate artifact with POM and checksums. Adds additional file with random content with given size inside JAR.
+     * Whole size of artifact will be larger than given size.
+     * @param id {@link String} id of artifact - should contains minimum one ':'
+     * @param version {@link String} version of artifact, could contains 'SNAPSHOT` phrase
+     * @param size additional size of file inside artifact
+     * @return {@link Path} path to the artifact
+     * @throws IOException in case of failure
+     */
     Path generateArtifact(String id,
                           String version,
                           int size)
         throws IOException;
 
-    
+    /**
+     * Generate artifact with POM and checksums. Adds additional file with random content with given size inside JAR.
+     * Whole size of artifact will be larger than given size.
+     * @param uri {@link URI} URI of artifact
+     * @param size additional size of file inside artifact
+     * @return {@link Path} path to the artifact
+     * @throws IOException in case of failure
+     */
     Path generateArtifact(URI uri,
                           int size)
         throws IOException;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/NullArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/NullArtifactGenerator.java
@@ -36,7 +36,7 @@ public class NullArtifactGenerator implements ArtifactGenerator
     @Override
     public Path generateArtifact(String id,
                                  String version,
-                                 int size)
+                                 long size)
         throws IOException
     {
         throw new UnsupportedOperationException();
@@ -44,7 +44,7 @@ public class NullArtifactGenerator implements ArtifactGenerator
 
     @Override
     public Path generateArtifact(URI uri,
-                                 int size)
+                                 long size)
         throws IOException
     {
         Path path = baseDir.resolve(uri.toString());
@@ -52,7 +52,7 @@ public class NullArtifactGenerator implements ArtifactGenerator
         return generateArtifact(size, path);
     }
 
-    private Path generateArtifact(int size,
+    private Path generateArtifact(long size,
                                   Path path)
         throws IOException
     {

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
@@ -17,7 +17,7 @@ public interface ArtifactGeneratorStrategy<T extends ArtifactGenerator>
     Path generateArtifact(T artifactGenerator,
                           String id,
                           String version,
-                          int size,
+                          long size,
                           Map<String, Object> attributesMap)
         throws IOException;
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/DefaultArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/DefaultArtifactGeneratorStrategy.java
@@ -1,22 +1,24 @@
 package org.carlspring.strongbox.testing.artifact;
 
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
-import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
-
-public class DefaultArtrifactGeneratorStrategy implements ArtifactGeneratorStrategy<ArtifactGenerator>
+public class DefaultArtifactGeneratorStrategy
+        implements ArtifactGeneratorStrategy<ArtifactGenerator>
 {
 
     @Override
     public Path generateArtifact(ArtifactGenerator artifactGenerator,
                                  String id,
                                  String version,
-                                 int size,
-                                 Map<String, Object> attributesMap) throws IOException
+                                 long size,
+                                 Map<String, Object> attributesMap)
+            throws IOException
     {
         return artifactGenerator.generateArtifact(id, version, size);
     }
-    
+
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
@@ -71,6 +71,6 @@ public @interface TestArtifact
     /**
      * Artifact size in bytes.
      */
-    int size() default 1024;
+    long size() default 1024;
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifact.java
@@ -66,7 +66,7 @@ public @interface TestArtifact
     /**
      * {@link ArtifactGeneratorStrategy} class to use.
      */
-    Class<? extends ArtifactGeneratorStrategy<?>> strategy() default DefaultArtrifactGeneratorStrategy.class;    
+    Class<? extends ArtifactGeneratorStrategy<?>> strategy() default DefaultArtifactGeneratorStrategy.class;
     
     /**
      * Artifact size in bytes.

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -153,7 +153,7 @@ public class TestArtifactContext implements AutoCloseable
 
     private Path generateArtifact(String id,
                                   String version,
-                                  int size)
+                                  long size)
         throws IOException
     {
         @SuppressWarnings("unchecked")
@@ -166,7 +166,7 @@ public class TestArtifactContext implements AutoCloseable
         return deployArtifact(artifactPathLocal);
     }
     
-    private Path generateArtifact(String resource, int size)
+    private Path generateArtifact(String resource, long size)
             throws IOException
     {
         Path artifactPathLocal = artifactGenerator.generateArtifact(URI.create(resource), size);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -1,5 +1,7 @@
 package org.carlspring.strongbox.artifact.generation;
 
+import org.apache.maven.artifact.Artifact;
+import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
@@ -42,12 +44,12 @@ public class MavenArtifactGeneratorTest
                                        Repository repository,
                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
                                                           id = "org.carlspring.strongbox.testing:matg",
-                                                          versions = "1.2.3")
+                                                          versions = "1.2.3", size = 1073741824)
                                        Path artifactPath)
             throws Exception
     {
         assertThat(Files.exists(artifactPath)).as("Failed to generate JAR file!").isTrue();
-
+        assertThat(Files.size(artifactPath)).isGreaterThan(1073741824);
         // JAR MD5 file.
         String fileName = artifactPath.getFileName().toString();
         String checksumFileName = fileName + "." + MessageDigestAlgorithms.MD5.toLowerCase();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -1,7 +1,5 @@
 package org.carlspring.strongbox.artifact.generation;
 
-import org.apache.maven.artifact.Artifact;
-import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
@@ -19,9 +17,9 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.carlspring.strongbox.util.MessageDigestUtils.calculateChecksum;
 import static org.carlspring.strongbox.util.MessageDigestUtils.readChecksumFile;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
 /**

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -44,12 +44,12 @@ public class MavenArtifactGeneratorTest
                                        Repository repository,
                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
                                                           id = "org.carlspring.strongbox.testing:matg",
-                                                          versions = "1.2.3", size = 1073741824)
+                                                          versions = "1.2.3", size = 2048)
                                        Path artifactPath)
             throws Exception
     {
         assertThat(Files.exists(artifactPath)).as("Failed to generate JAR file!").isTrue();
-        assertThat(Files.size(artifactPath)).isGreaterThan(1073741824);
+
         // JAR MD5 file.
         String fileName = artifactPath.getFileName().toString();
         String checksumFileName = fileName + "." + MessageDigestAlgorithms.MD5.toLowerCase();
@@ -91,6 +91,9 @@ public class MavenArtifactGeneratorTest
         String expectedPomSHA1 = calculateChecksum(artifactPomPath, MessageDigestAlgorithms.SHA_1);
         String pomSHA1 = readChecksumFile(artifactPomPathSha1.toString());
         assertThat(pomSHA1).isEqualTo(expectedPomSHA1);
+
+        // JAR size
+        assertThat(Files.size(artifactPath)).isGreaterThan(2048);
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -42,7 +42,8 @@ public class MavenArtifactGeneratorTest
                                        Repository repository,
                                        @MavenTestArtifact(repositoryId = REPOSITORY_RELEASES,
                                                           id = "org.carlspring.strongbox.testing:matg",
-                                                          versions = "1.2.3", size = 2048)
+                                                          versions = "1.2.3",
+                                                          size = 2048)
                                        Path artifactPath)
             throws Exception
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
@@ -66,7 +66,7 @@ public class MavenArtifactDeployer
                    ArtifactOperationException, ArtifactTransportException
     {
         generatePom(artifact, packaging);
-        createArchive(artifact, 1024);
+        createArchive(artifact);
 
         deploy(artifact, storageId, repositoryId);
         deployPOM(MavenArtifactTestUtils.getPOMArtifact(artifact), storageId, repositoryId);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactDeployer.java
@@ -66,7 +66,7 @@ public class MavenArtifactDeployer
                    ArtifactOperationException, ArtifactTransportException
     {
         generatePom(artifact, packaging);
-        createArchive(artifact);
+        createArchive(artifact, 1024);
 
         deploy(artifact, storageId, repositoryId);
         deployPOM(MavenArtifactTestUtils.getPOMArtifact(artifact), storageId, repositoryId);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -18,7 +18,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,6 +44,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
 {
 
     private static final Logger logger = LoggerFactory.getLogger(MavenArtifactGenerator.class);
+    private static final int DEFAULT_SIZE = 1000000;
 
     public static final String PACKAGING_JAR = "jar";
 
@@ -139,7 +139,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
             throws IOException,
                    NoSuchAlgorithmException
     {
-        generate(artifact, new Random().nextInt(1024));
+        generate(artifact, new Random().nextInt(DEFAULT_SIZE));
     }
 
     public void generate(Artifact artifact, String packaging)
@@ -161,7 +161,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     public void createArchive(Artifact artifact)
             throws IOException, NoSuchAlgorithmException
     {
-        createArchive(artifact, new Random().nextInt(1024));
+        createArchive(artifact, new Random().nextInt(DEFAULT_SIZE));
     }
 
     public void createArchive(Artifact artifact, long size)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -70,20 +70,27 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     }
 
     @Override
-    public Path generateArtifact(String id, String version, long size) throws IOException
+    public Path generateArtifact(String id,
+                                 String version,
+                                 long size)
+            throws IOException
     {
         Artifact artifact = MavenArtifactTestUtils.getArtifactFromGAVTC(String.format("%s:%s", id, version));
         return generateArtifact(artifact, size);
     }
 
     @Override
-    public Path generateArtifact(URI uri, long size) throws IOException
+    public Path generateArtifact(URI uri,
+                                 long size)
+            throws IOException
     {
         Artifact artifact = MavenArtifactUtils.convertPathToArtifact(uri.toString());
         return generateArtifact(artifact, size);
     }
 
-    private Path generateArtifact(Artifact artifact, long size) throws IOException
+    private Path generateArtifact(Artifact artifact,
+                                  long size)
+            throws IOException
     {
         try
         {
@@ -275,7 +282,9 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         zos.closeEntry();
     }
 
-    private void createFile(ZipOutputStream zos, long size) throws IOException
+    private void createFile(ZipOutputStream zos,
+                            long size)
+            throws IOException
     {
         ZipEntry ze = new ZipEntry("file-with-given-size");
         zos.putNextEntry(ze);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -70,20 +70,20 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     }
 
     @Override
-    public Path generateArtifact(String id, String version, int size) throws IOException
+    public Path generateArtifact(String id, String version, long size) throws IOException
     {
         Artifact artifact = MavenArtifactTestUtils.getArtifactFromGAVTC(String.format("%s:%s", id, version));
         return generateArtifact(artifact, size);
     }
 
     @Override
-    public Path generateArtifact(URI uri, int size) throws IOException
+    public Path generateArtifact(URI uri, long size) throws IOException
     {
         Artifact artifact = MavenArtifactUtils.convertPathToArtifact(uri.toString());
         return generateArtifact(artifact, size);
     }
 
-    private Path generateArtifact(Artifact artifact, int size) throws IOException
+    private Path generateArtifact(Artifact artifact, long size) throws IOException
     {
         try
         {
@@ -143,7 +143,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         createArchive(artifact);
     }
 
-    public void generate(Artifact artifact, int size)
+    public void generate(Artifact artifact, long size)
             throws IOException,
                    NoSuchAlgorithmException
     {
@@ -157,7 +157,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         createArchive(artifact, new Random().nextInt(1024));
     }
 
-    public void createArchive(Artifact artifact, int size)
+    public void createArchive(Artifact artifact, long size)
             throws NoSuchAlgorithmException,
                    IOException
     {
@@ -275,7 +275,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         zos.closeEntry();
     }
 
-    private void createFile(ZipOutputStream zos, int size) throws IOException
+    private void createFile(ZipOutputStream zos, long size) throws IOException
     {
         ZipEntry ze = new ZipEntry("file-with-given-size");
         zos.putNextEntry(ze);

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
@@ -9,7 +9,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Map;
 
 import org.apache.maven.artifact.Artifact;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy<MavenArtifactGenerator>
 {
@@ -18,7 +17,7 @@ public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy
     public Path generateArtifact(MavenArtifactGenerator artifactGenerator,
                                  String id,
                                  String version,
-                                 int size,
+                                 long size,
                                  Map<String, Object> attributesMap)
         throws IOException
     {
@@ -32,7 +31,7 @@ public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy
             {
                 artifactGenerator.generate(pluginArtifact);
             }
-            catch (NoSuchAlgorithmException | XmlPullParserException e)
+            catch (NoSuchAlgorithmException e)
             {
                 throw new IOException(e);
             }
@@ -55,7 +54,7 @@ public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy
                 {
                     artifactGenerator.generate(artifactWithClassifier);
                 }
-                catch (NoSuchAlgorithmException | XmlPullParserException e)
+                catch (NoSuchAlgorithmException e)
                 {
                     throw new IOException(e);
                 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -69,5 +69,5 @@ public @interface MavenTestArtifact
      * Additional artifact size in bytes.
      */
     @AliasFor(annotation = TestArtifact.class)
-    long size() default 1024;
+    long size() default 1000000;
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -67,7 +67,7 @@ public @interface MavenTestArtifact
     String packaging() default "jar";
 
     /**
-     * Artifact size in bytes.
+     * Additional artifact size in bytes.
      */
     @AliasFor(annotation = TestArtifact.class)
     int size() default 1024;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -1,5 +1,6 @@
 package org.carlspring.strongbox.testing.artifact;
 
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -65,4 +66,9 @@ public @interface MavenTestArtifact
      */
     String packaging() default "jar";
 
+    /**
+     * Artifact size in bytes.
+     */
+    @AliasFor(annotation = TestArtifact.class)
+    int size() default 1024;
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -1,19 +1,18 @@
 package org.carlspring.strongbox.testing.artifact;
 
-import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
+import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
+import org.carlspring.strongbox.storage.Storage;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import org.apache.maven.model.Repository;
-import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
-import org.carlspring.strongbox.artifact.generator.MavenArtifactGenerator;
-import org.carlspring.strongbox.storage.Storage;
 import org.springframework.core.annotation.AliasFor;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * @author sbespalov

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -70,5 +70,5 @@ public @interface MavenTestArtifact
      * Additional artifact size in bytes.
      */
     @AliasFor(annotation = TestArtifact.class)
-    int size() default 1024;
+    long size() default 1024;
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -202,7 +202,7 @@ public class NpmArtifactGenerator
 
     @Override
     public Path generateArtifact(URI uri,
-                                 int size)
+                                 long size)
             throws IOException
     {
         // Use of size is not implemented
@@ -212,7 +212,7 @@ public class NpmArtifactGenerator
     @Override
     public Path generateArtifact(String id,
                                  String version,
-                                 int size)
+                                 long size)
             throws IOException
     {
         // Use of size is not implemented

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
@@ -19,7 +19,7 @@ public class NpmArtifactGeneratorStrategy implements ArtifactGeneratorStrategy<N
     public Path generateArtifact(NpmArtifactGenerator artifactGenerator,
                                  String id,
                                  String version,
-                                 int size,
+                                 long size,
                                  Map<String, Object> attributesMap)
             throws IOException
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
@@ -69,7 +69,7 @@ public class NugetArtifactGenerator
     @Override
     public Path generateArtifact(String id,
                                  String version,
-                                 int size)
+                                 long size)
             throws IOException
     {
         // Use of size is not implemented
@@ -78,7 +78,7 @@ public class NugetArtifactGenerator
 
     @Override
     public Path generateArtifact(URI uri,
-                                 int size)
+                                 long size)
             throws IOException
     {
         // Use of size is not implemented

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NugetArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NugetArtifactGeneratorStrategy.java
@@ -15,7 +15,7 @@ public class NugetArtifactGeneratorStrategy
     public Path generateArtifact(NugetArtifactGenerator artifactGenerator,
                                  String id,
                                  String version,
-                                 int size,
+                                 long size,
                                  Map<String, Object> attributesMap)
             throws IOException
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
@@ -81,7 +81,7 @@ public class PypiArtifactGenerator
     @Override
     public Path generateArtifact(String id,
                                  String version,
-                                 int size)
+                                 long size)
             throws IOException
     {
         PypiArtifactCoordinates coordinates = new PypiArtifactCoordinates(id,
@@ -96,7 +96,7 @@ public class PypiArtifactGenerator
 
     @Override
     public Path generateArtifact(URI uri,
-                                 int size)
+                                 long size)
             throws IOException
     {
         PypiArtifactCoordinates coordinates = PypiArtifactCoordinates.parse(FilenameUtils.getName(uri.toString()));

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiArtifactGeneratorStrategy.java
@@ -18,7 +18,7 @@ public class PypiArtifactGeneratorStrategy
     public Path generateArtifact(PypiArtifactGenerator artifactGenerator,
                                  String id,
                                  String version,
-                                 int size,
+                                 long size,
                                  Map<String, Object> attributesMap)
             throws IOException
     {


### PR DESCRIPTION
# Pull Request Description

Annotation used in tests improved to jar generation with given size.
This pull request closes #1535 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
