### PR TITLE
Pattern change for NpmArtifactController.downloadPackageWithScope mapping

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -361,7 +361,7 @@ public class NpmArtifactController
         }
 
         //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
-        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length() + 1);
+        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length());
 
         NpmArtifactCoordinates coordinates;
         try

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -319,10 +319,11 @@ public class NpmArtifactController
         if (!packageNameWithVersion.startsWith(packageName + "-"))
         {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
         }
 
         //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
-        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length());
+        final String packageVersion = getPackageVersion(packageNameWithVersion, packageName);
 
         NpmArtifactCoordinates coordinates;
         try
@@ -358,10 +359,11 @@ public class NpmArtifactController
         if (!packageNameWithVersion.startsWith(packageName + "-"))
         {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
         }
 
         //Example of packageNameWithVersion core-9.0.1-next.8.tgz
-        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length());
+        final String packageVersion = getPackageVersion(packageNameWithVersion, packageName);
 
         NpmArtifactCoordinates coordinates;
         try
@@ -615,5 +617,11 @@ public class NpmArtifactController
             return null;
         }
     }
-    
+
+    private String getPackageVersion(String packageNameWithVersion, String packageName){
+
+        return packageNameWithVersion.substring(packageName.length() + 1);
+
+    }
+
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -300,20 +300,25 @@ public class NpmArtifactController
     }
 
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
-    @RequestMapping(path = "{storageId}/{repositoryId}/{packageScope}/{packageName}/-/{packageName}-{packageVersion}.{packageExtension}",
+    @RequestMapping(path = "{storageId}/{repositoryId}/{packageScope}/{packageName}/-/{packageNameWithVersion}.{packageExtension}",
                     method = { RequestMethod.GET, RequestMethod.HEAD })
     public void downloadPackageWithScope(@RepositoryMapping Repository repository,
                                          @PathVariable(name = "packageScope") String packageScope,
                                          @PathVariable(name = "packageName") String packageName,
-                                         @PathVariable(name = "packageVersion") String packageVersion,
+                                         @PathVariable(name = "packageNameWithVersion") String packageNameWithVersion,
                                          @PathVariable(name = "packageExtension") String packageExtension,
                                          @RequestHeader HttpHeaders httpHeaders,
                                          HttpServletRequest request,
                                          HttpServletResponse response)
         throws Exception
     {
+
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
+
+        //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
+        String pattern = packageName + "-";
+        final String packageVersion = packageNameWithVersion.replaceAll(pattern, "");
 
         NpmArtifactCoordinates coordinates;
         try

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -360,7 +360,7 @@ public class NpmArtifactController
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         }
 
-        //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
+        //Example of packageNameWithVersion core-9.0.1-next.8.tgz
         final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length());
 
         NpmArtifactCoordinates coordinates;

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -316,9 +316,13 @@ public class NpmArtifactController
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
 
+        if (!packageNameWithVersion.startsWith(packageName + "-"))
+        {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
         //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
-        String pattern = packageName + "-";
-        final String packageVersion = packageNameWithVersion.replaceAll(pattern, "");
+        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length());
 
         NpmArtifactCoordinates coordinates;
         try
@@ -337,11 +341,11 @@ public class NpmArtifactController
     }
 
     @PreAuthorize("hasAuthority('ARTIFACTS_RESOLVE')")
-    @RequestMapping(path = "{storageId}/{repositoryId}/{packageName}/-/{packageName}-{packageVersion}.{packageExtension}",
+    @RequestMapping(path = "{storageId}/{repositoryId}/{packageName}/-/{packageNameWithVersion}.{packageExtension}",
                     method = { RequestMethod.GET, RequestMethod.HEAD })
     public void downloadPackage(@RepositoryMapping Repository repository,
                                 @PathVariable(name = "packageName") String packageName,
-                                @PathVariable(name = "packageVersion") String packageVersion,
+                                @PathVariable(name = "packageNameWithVersion") String packageNameWithVersion,
                                 @PathVariable(name = "packageExtension") String packageExtension,
                                 @RequestHeader HttpHeaders httpHeaders,
                                 HttpServletRequest request,
@@ -350,6 +354,14 @@ public class NpmArtifactController
     {
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
+
+        if (!packageNameWithVersion.startsWith(packageName + "-"))
+        {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+
+        //Example of packageNameWithVersion  core-9.0.1-next.8.tgz
+        final String packageVersion = packageNameWithVersion.substring(packageName.length() + 1, packageNameWithVersion.length() + 1);
 
         NpmArtifactCoordinates coordinates;
         try

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -221,8 +221,7 @@ public class NpmArtifactControllerTest
                              "rxjs:assd5.6.0-hsds" })
     public void packageNameTestBadRequest(String packageNameWithVersion,
                                           @NpmRepository(repositoryId = REPOSITORY_RELEASES)
-                                          Repository repository,
-                                          TestInfo testInfo)
+                                          Repository repository)
             throws Exception
     {
         final String storageId = repository.getStorage().getId();
@@ -231,8 +230,8 @@ public class NpmArtifactControllerTest
         //Splitting each string from parameterized test array to packageId and packageVersion
         final String[] packageDetails = packageNameWithVersion.split(":");
         final String packageId = packageDetails[0];
-        String packageName = "";
         final String packageVersion = packageDetails[1];
+        String packageName = "";
 
         if(packageId.startsWith("@"))
         {
@@ -251,7 +250,7 @@ public class NpmArtifactControllerTest
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                .when()
                .get(url, storageId, repositoryId, artifactId)
-                .prettyPeek()
+               .prettyPeek()
                .then()
                .statusCode(HttpStatus.BAD_REQUEST.value());
     }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -40,8 +40,6 @@ public class NpmArtifactControllerTest
 {
     private static final String REPOSITORY_RELEASES = "npm-releases-test";
 
-    private Path generatorBasePath;
-
     @Inject
     private PropertiesBooter propertiesBooter;
 
@@ -146,7 +144,7 @@ public class NpmArtifactControllerTest
                              "react:0.0.0-0c756fb-f7f79fd",
                              "react:0.0.0-5faf377df",
                              "prop-types:15.5.7-alpha.1",
-                             "commander:4.0.0-1",
+                             "commander:4.0.0.0-1",
                              "aws-sdk:2.555.0",
                              "rxjs:5.6.0-forward-compat.5",
                              "@lifaon/observables:1.6.0" })
@@ -158,6 +156,9 @@ public class NpmArtifactControllerTest
     {
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
+
+
+        Path generatorBasePath;
 
         //Splitting each string from paramterized test array to packageId and packageVersion
         final String[] packageDetails = packageNameWithVersion.split(":");
@@ -210,6 +211,49 @@ public class NpmArtifactControllerTest
                .statusCode(HttpStatus.OK.value())
                .assertThat()
                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(artifact))));
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @ParameterizedTest
+    @ValueSource(strings = { "@angular/core:next.8",
+                             "react:@32.1.911",
+                             "@lifaon/obser@323jj:hds:121",
+                             "rxjs:assd5.6.0-hsds" })
+    public void packageNameTestBadRequest(String packageNameWithVersion,
+                                          @NpmRepository(repositoryId = REPOSITORY_RELEASES)
+                                          Repository repository,
+                                          TestInfo testInfo)
+            throws Exception
+    {
+        final String storageId = repository.getStorage().getId();
+        final String repositoryId = repository.getId();
+
+        //Splitting each string from parameterized test array to packageId and packageVersion
+        final String[] packageDetails = packageNameWithVersion.split(":");
+        final String packageId = packageDetails[0];
+        String packageName = "";
+        final String packageVersion = packageDetails[1];
+
+        if(packageId.startsWith("@"))
+        {
+            packageName = packageId.split("/")[1];
+        }
+        else
+        {
+            packageName = packageId;
+        }
+
+        final String artifactFileName = String.format("%s-%s.%s", packageName, packageVersion, "tgz");
+        final String artifactId = String.format("%s/-/%s", packageId, artifactFileName );
+
+        //Download
+        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}";
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+               .when()
+               .get(url, storageId, repositoryId, artifactId)
+                .prettyPeek()
+               .then()
+               .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -181,35 +181,35 @@ public class NpmArtifactControllerTest
         //Publish
         String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}";
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(publishJsonContent)
-                .when()
-                .put(url, storageId, repositoryId, coordinates.getId())
-                .peek()
-                .then()
-                .statusCode(HttpStatus.OK.value());
+               .body(publishJsonContent)
+               .when()
+               .put(url, storageId, repositoryId, coordinates.getId())
+               .peek()
+               .then()
+               .statusCode(HttpStatus.OK.value());
 
         //View
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates.getId())
-                .peek()
-                .then()
-                .assertThat()
-                .body("name", equalTo(packageId))
-                .and()
-                .assertThat()
-                .body("versions." + "'" + packageVersion + "'" +".version", equalTo(packageVersion))
-                .statusCode(HttpStatus.OK.value());
+               .when()
+               .get(url, storageId, repositoryId, coordinates.getId())
+               .peek()
+               .then()
+               .assertThat()
+               .body("name", equalTo(packageId))
+               .and()
+               .assertThat()
+               .body("versions." + "'" + packageVersion + "'" +".version", equalTo(packageVersion))
+               .statusCode(HttpStatus.OK.value());
 
         //Download
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates.toResource())
-                .prettyPeek()
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .assertThat()
-                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(artifact))));
+               .when()
+               .get(url, storageId, repositoryId, coordinates.toResource())
+               .prettyPeek()
+               .then()
+               .statusCode(HttpStatus.OK.value())
+               .assertThat()
+               .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(artifact))));
     }
 
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -1,6 +1,8 @@
 package org.carlspring.strongbox.controllers.layout.npm;
 
 import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
+import org.carlspring.strongbox.artifact.generator.NpmArtifactGenerator;
+import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
@@ -13,13 +15,19 @@ import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementT
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import javax.inject.Inject;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 
@@ -31,6 +39,11 @@ public class NpmArtifactControllerTest
         extends NpmRestAssuredBaseTest
 {
     private static final String REPOSITORY_RELEASES = "npm-releases-test";
+
+    private Path generatorBasePath;
+
+    @Inject
+    private PropertiesBooter propertiesBooter;
 
     @Override
     @BeforeEach
@@ -87,6 +100,7 @@ public class NpmArtifactControllerTest
                                       Path packagePath)
             throws Exception
     {
+
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
         final String packageId = "@carlspring/npm-test-release";
@@ -125,43 +139,51 @@ public class NpmArtifactControllerTest
                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath))));
     }
 
-    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-                  ArtifactManagementTestExecutionListener.class })
-    @Test
-    public void packageNameAcceptanceTest(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @ParameterizedTest
+    @ValueSource(strings = { "@angular/core:9.0.1-next.8",
+                             "react:0.0.0-experimental-5faf377df",
+                             "react:0.0.0-0c756fb-f7f79fd",
+                             "react:0.0.0-5faf377df",
+                             "prop-types:15.5.7-alpha.1",
+                             "commander:4.0.0-1",
+                             "aws-sdk:2.555.0",
+                             "rxjs:5.6.0-forward-compat.5",
+                             "@lifaon/observables:1.6.0" })
+    public void packageNameAcceptanceTest(String packageNameWithVersion,
+                                          @NpmRepository(repositoryId = REPOSITORY_RELEASES)
                                           Repository repository,
-                                          @NpmTestArtifact(id = "npm-test-release",
-                                                           versions = "1.0.0",
-                                                           scope = "@carlspring")
-                                          Path packagePath1,
-                                          @NpmTestArtifact(id = "core",
-                                                           versions = "9.0.1-next.8",
-                                                           scope = "@angular")
-                                          Path packagePath2,
-                                          @NpmTestArtifact(id = "some-package",
-                                                           versions = "4.0.4-alpha.3",
-                                                           scope = "@value")
-                                          Path packagePath3)
+                                          TestInfo testInfo)
             throws Exception
     {
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
 
-        //Artifact#1
-        final String packageId1 = "@carlspring/npm-test-release";
-        final String packageVersion1 = "1.0.0";
+        //Splitting each string from paramterized test array to packageId and packageVersion
+        final String[] packageDetails = packageNameWithVersion.split(":");
+        final String packageId = packageDetails[0];
+        final String packageVersion = packageDetails[1];
 
-        NpmArtifactCoordinates coordinates1 = NpmArtifactCoordinates.of(packageId1, packageVersion1);
+        //Manually generating each artifacts
+        generatorBasePath = Paths.get(propertiesBooter.getVaultDirectory(),
+                                      ".temp",
+                                      testInfo.getTestClass().get().getSimpleName(),
+                                      testInfo.getTestMethod().get().getName()).toAbsolutePath().normalize();
 
-        Path publishJsonPath1 = packagePath1.resolveSibling("publish.json");
-        byte[] publishJsonContent1 = Files.readAllBytes(publishJsonPath1);
+        NpmArtifactGenerator artifactGenerator = new NpmArtifactGenerator(generatorBasePath);
+        Path artifact = artifactGenerator.generateArtifact(packageId, packageVersion);
+
+        NpmArtifactCoordinates coordinates = NpmArtifactCoordinates.of(packageId, packageVersion);
+
+        Path publishJsonPath = artifact.resolveSibling("publish.json");
+        byte[] publishJsonContent = Files.readAllBytes(publishJsonPath);
 
         //Publish
         String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}";
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(publishJsonContent1)
+                .body(publishJsonContent)
                 .when()
-                .put(url, storageId, repositoryId, coordinates1.getId())
+                .put(url, storageId, repositoryId, coordinates.getId())
                 .peek()
                 .then()
                 .statusCode(HttpStatus.OK.value());
@@ -169,90 +191,25 @@ public class NpmArtifactControllerTest
         //View
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .get(url, storageId, repositoryId, coordinates1.getId())
+                .get(url, storageId, repositoryId, coordinates.getId())
                 .peek()
                 .then()
+                .assertThat()
+                .body("name", equalTo(packageId))
+                .and()
+                .assertThat()
+                .body("versions." + "'" + packageVersion + "'" +".version", equalTo(packageVersion))
                 .statusCode(HttpStatus.OK.value());
 
         //Download
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .get(url, storageId, repositoryId, coordinates1.toResource())
+                .get(url, storageId, repositoryId, coordinates.toResource())
+                .prettyPeek()
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .assertThat()
-                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath1))));
-
-        //Artifact#2
-        final String packageId2 = "@angular/core";
-        final String packageVersion2 = "9.0.1-next.8";
-
-        NpmArtifactCoordinates coordinates2 = NpmArtifactCoordinates.of(packageId2, packageVersion2);
-
-        Path publishJsonPath2 = packagePath2.resolveSibling("publish.json");
-        byte[] publishJsonContent2 = Files.readAllBytes(publishJsonPath2);
-
-        //Publish
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(publishJsonContent2)
-                .when()
-                .put(url, storageId, repositoryId, coordinates2.getId())
-                .peek()
-                .then()
-                .statusCode(HttpStatus.OK.value());
-
-        //View
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates2.getId())
-                .peek()
-                .then()
-                .statusCode(HttpStatus.OK.value());
-
-        //Download
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates2.toResource())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .assertThat()
-                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath2))));
-
-        //Artifact#3
-        final String packageId3 = "@value/some-package";
-        final String packageVersion3 = "4.0.4-alpha.3";
-
-        NpmArtifactCoordinates coordinates3 = NpmArtifactCoordinates.of(packageId3, packageVersion3);
-
-        Path publishJsonPath3 = packagePath3.resolveSibling("publish.json");
-        byte[] publishJsonContent3 = Files.readAllBytes(publishJsonPath3);
-
-        //Publish
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(publishJsonContent3)
-                .when()
-                .put(url, storageId, repositoryId, coordinates3.getId())
-                .peek()
-                .then()
-                .statusCode(HttpStatus.OK.value());
-
-        //View
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates3.getId())
-                .peek()
-                .then()
-                .statusCode(HttpStatus.OK.value());
-
-        //Download
-        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get(url, storageId, repositoryId, coordinates3.toResource())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .assertThat()
-                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath3))));
-
+                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(artifact))));
     }
 
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -125,4 +125,134 @@ public class NpmArtifactControllerTest
                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath))));
     }
 
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    @Test
+    public void packageNameAcceptanceTest(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
+                                          Repository repository,
+                                          @NpmTestArtifact(id = "npm-test-release",
+                                                           versions = "1.0.0",
+                                                           scope = "@carlspring")
+                                          Path packagePath1,
+                                          @NpmTestArtifact(id = "core",
+                                                           versions = "9.0.1-next.8",
+                                                           scope = "@angular")
+                                          Path packagePath2,
+                                          @NpmTestArtifact(id = "some-package",
+                                                           versions = "4.0.4-alpha.3",
+                                                           scope = "@value")
+                                          Path packagePath3)
+            throws Exception
+    {
+        final String storageId = repository.getStorage().getId();
+        final String repositoryId = repository.getId();
+
+        //Artifact#1
+        final String packageId1 = "@carlspring/npm-test-release";
+        final String packageVersion1 = "1.0.0";
+
+        NpmArtifactCoordinates coordinates1 = NpmArtifactCoordinates.of(packageId1, packageVersion1);
+
+        Path publishJsonPath1 = packagePath1.resolveSibling("publish.json");
+        byte[] publishJsonContent1 = Files.readAllBytes(publishJsonPath1);
+
+        //Publish
+        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}";
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(publishJsonContent1)
+                .when()
+                .put(url, storageId, repositoryId, coordinates1.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //View
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates1.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //Download
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates1.toResource())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath1))));
+
+        //Artifact#2
+        final String packageId2 = "@angular/core";
+        final String packageVersion2 = "9.0.1-next.8";
+
+        NpmArtifactCoordinates coordinates2 = NpmArtifactCoordinates.of(packageId2, packageVersion2);
+
+        Path publishJsonPath2 = packagePath2.resolveSibling("publish.json");
+        byte[] publishJsonContent2 = Files.readAllBytes(publishJsonPath2);
+
+        //Publish
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(publishJsonContent2)
+                .when()
+                .put(url, storageId, repositoryId, coordinates2.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //View
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates2.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //Download
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates2.toResource())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath2))));
+
+        //Artifact#3
+        final String packageId3 = "@value/some-package";
+        final String packageVersion3 = "4.0.4-alpha.3";
+
+        NpmArtifactCoordinates coordinates3 = NpmArtifactCoordinates.of(packageId3, packageVersion3);
+
+        Path publishJsonPath3 = packagePath3.resolveSibling("publish.json");
+        byte[] publishJsonContent3 = Files.readAllBytes(publishJsonPath3);
+
+        //Publish
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(publishJsonContent3)
+                .when()
+                .put(url, storageId, repositoryId, coordinates3.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //View
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates3.getId())
+                .peek()
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        //Download
+        mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get(url, storageId, repositoryId, coordinates3.toResource())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath3))));
+
+    }
+
 }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1481 

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No
