### PR TITLE
Issue 1513 Unit test for RemoteRepositoryAlivenessCacheManager

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryAlivenessCacheManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryAlivenessCacheManagerTest.java
@@ -90,7 +90,7 @@ public class RemoteRepositoryAlivenessCacheManagerTest
 
     @ParameterizedTest
     @EnumSource(RepoAliveness.class)
-    void put(RepoAliveness repoAliveness)
+    void putRepository(RepoAliveness repoAliveness)
     {
         // Given
         remoteRepositoryAlivenessCacheManager = new RemoteRepositoryAlivenessCacheManager(cacheManager);
@@ -103,7 +103,7 @@ public class RemoteRepositoryAlivenessCacheManagerTest
     }
 
     @Test
-    void destroy()
+    void destroyRepositories()
             throws Exception
     {
         // Given

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryAlivenessCacheManagerTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/repository/remote/heartbeat/RemoteRepositoryAlivenessCacheManagerTest.java
@@ -1,0 +1,144 @@
+package org.carlspring.strongbox.storage.repository.remote.heartbeat;
+
+import org.carlspring.strongbox.data.CacheName;
+import org.carlspring.strongbox.storage.repository.remote.RemoteRepositoryDto;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class RemoteRepositoryAlivenessCacheManagerTest
+{
+
+    static final String REMOTE_REPO_URL = "https://strongbox.github.io/";
+
+    @Mock
+    CacheManager cacheManager;
+    @Mock
+    Cache cache;
+    RemoteRepositoryDto remoteRepository;
+    RemoteRepositoryAlivenessCacheManager remoteRepositoryAlivenessCacheManager;
+
+    private static Stream<Arguments> repoAlivenessProvider()
+    {
+        return Stream.of(
+                Arguments.of(RepoInCache.FOUND_IN_CACHE, RepoAliveness.ALIVE),
+                Arguments.of(RepoInCache.NOT_FOUND_IN_CACHE, RepoAliveness.DEAD)
+        );
+    }
+
+    @BeforeEach
+    void setUp()
+    {
+        initMocks(this);
+        when(cacheManager.getCache(CacheName.Repository.REMOTE_REPOSITORY_ALIVENESS)).thenReturn(cache);
+        remoteRepository = new RemoteRepositoryDto();
+        remoteRepository.setUrl(REMOTE_REPO_URL);
+    }
+
+    @Test
+    void testCacheManagerHavingNoCacheForRepo()
+    {
+        // Given
+        when(cacheManager.getCache(CacheName.Repository.REMOTE_REPOSITORY_ALIVENESS)).thenReturn(null);
+
+        // When - Then
+        assertThrows(NullPointerException.class, () -> new RemoteRepositoryAlivenessCacheManager(cacheManager));
+    }
+
+    @ParameterizedTest
+    @MethodSource("repoAlivenessProvider")
+    void testCachedValuesForRepo(RepoInCache repoFoundInCache,
+                                 RepoAliveness expectedAlive)
+    {
+        // Given
+        remoteRepositoryAlivenessCacheManager = new RemoteRepositoryAlivenessCacheManager(cacheManager);
+        when(cache.get(REMOTE_REPO_URL, Boolean.class)).thenReturn(repoFoundInCache.repoInCache);
+
+        // When
+        boolean repositoryIsAlive = remoteRepositoryAlivenessCacheManager.isAlive(remoteRepository);
+
+        // Then
+        assertThat(repositoryIsAlive).isEqualTo(expectedAlive.expectedRepoAliveness);
+    }
+
+    @Test
+    void testNoCachedValueForRepo()
+    {
+        // Given
+        remoteRepositoryAlivenessCacheManager = new RemoteRepositoryAlivenessCacheManager(cacheManager);
+        when(cache.get(REMOTE_REPO_URL, Boolean.class)).thenReturn(null);
+
+        // When
+        boolean repositoryIsAlive = remoteRepositoryAlivenessCacheManager.isAlive(remoteRepository);
+
+        // Then
+        assertThat(repositoryIsAlive).isEqualTo(true);
+    }
+
+    @ParameterizedTest
+    @EnumSource(RepoAliveness.class)
+    void put(RepoAliveness repoAliveness)
+    {
+        // Given
+        remoteRepositoryAlivenessCacheManager = new RemoteRepositoryAlivenessCacheManager(cacheManager);
+
+        // When
+        remoteRepositoryAlivenessCacheManager.put(remoteRepository, repoAliveness.expectedRepoAliveness);
+
+        // Then
+        verify(cache, times(1)).put(REMOTE_REPO_URL, repoAliveness.expectedRepoAliveness);
+    }
+
+    @Test
+    void destroy()
+            throws Exception
+    {
+        // Given
+        remoteRepositoryAlivenessCacheManager = new RemoteRepositoryAlivenessCacheManager(cacheManager);
+
+        // When
+        remoteRepositoryAlivenessCacheManager.destroy();
+
+        // Then
+        verify(cache, times(1)).clear();
+    }
+
+    enum RepoInCache
+    {
+        FOUND_IN_CACHE(true),
+        NOT_FOUND_IN_CACHE(false);
+
+        private final boolean repoInCache;
+
+        RepoInCache(boolean repoInCache)
+        {
+            this.repoInCache = repoInCache;
+        }
+    }
+
+    enum RepoAliveness
+    {
+        ALIVE(true),
+        DEAD(false);
+
+        private final boolean expectedRepoAliveness;
+
+        RepoAliveness(boolean expectedRepoAliveness)
+        {
+            this.expectedRepoAliveness = expectedRepoAliveness;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Description

Just now I noticed that there [exists](https://github.com/strongbox/strongbox/pull/1520) an attempt to resolve the issue. But still the current PR can bring something at the table. Namely:
* It is a pure unit test, meaning that the test does not depend on the spring container initialisation, hence it is much faster . 
* Used a parameterised test with enum as arguments. This makes the test results much more readable (see below). On the other hand a new enum needs to be declared. This is of course a matter of taste :)

![image](https://user-images.githubusercontent.com/16381881/67238838-7d6a6400-f456-11e9-8425-74859f8952b1.png)

This pull request closes #1513  

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
