### PR TITLE
Issue 1542: DirectoryListingService instances to be managed by Spring

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -204,8 +204,8 @@ public class WebConfig
     }
 
     @Bean
-    @Qualifier("browseRepoDirectoryListingService")
-    public DirectoryListingService getBrowseRepoDirectoryListingService()
+    @Qualifier("browseRepositoryDirectoryListingService")
+    public DirectoryListingService getBrowseRepositoryDirectoryListingService()
     {
         String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
         return new DirectoryListingServiceImpl(String.format("%s/api/browse", baseUrl));

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -100,7 +100,7 @@ public class WebConfig
     private YAMLMapperFactory yamlMapperFactory;
     
     @Inject
-    protected ConfigurationManager configurationManager;
+    private ConfigurationManager configurationManager;
 
     WebConfig()
     {
@@ -199,16 +199,21 @@ public class WebConfig
     @Qualifier("loggingManagementDirectoryListingService")
     public DirectoryListingService getLoggingManagementDirectoryListingService()
     {
+        return createDirectoryListingServiceForTemplate("%s/api/logging");
+    }
+
+    private DirectoryListingService createDirectoryListingServiceForTemplate(String template)
+    {
         String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
-        return new DirectoryListingServiceImpl(String.format("%s/api/logging", baseUrl));
+        String finalUrl = String.format(template, baseUrl);
+        return new DirectoryListingServiceImpl(finalUrl);
     }
 
     @Bean
     @Qualifier("browseRepositoryDirectoryListingService")
     public DirectoryListingService getBrowseRepositoryDirectoryListingService()
     {
-        String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
-        return new DirectoryListingServiceImpl(String.format("%s/api/browse", baseUrl));
+        return createDirectoryListingServiceForTemplate("%s/api/browse");
     }
 
     @Override

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -1,5 +1,7 @@
 package org.carlspring.strongbox.config;
 
+import org.apache.commons.lang.StringUtils;
+import org.carlspring.strongbox.configuration.ConfigurationManager;
 import org.carlspring.strongbox.configuration.StrongboxSecurityConfig;
 import org.carlspring.strongbox.converters.RoleFormToRoleConverter;
 import org.carlspring.strongbox.converters.RoleListFormToRoleListConverter;
@@ -15,6 +17,8 @@ import org.carlspring.strongbox.cron.config.CronTasksConfig;
 import org.carlspring.strongbox.interceptors.MavenArtifactRequestInterceptor;
 import org.carlspring.strongbox.mapper.WebObjectMapperSubtypes;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
+import org.carlspring.strongbox.services.DirectoryListingService;
+import org.carlspring.strongbox.services.DirectoryListingServiceImpl;
 import org.carlspring.strongbox.utils.CustomAntPathMatcher;
 import org.carlspring.strongbox.web.CustomRequestMappingHandlerMapping;
 import org.carlspring.strongbox.web.DirectoryTraversalFilter;
@@ -93,6 +97,9 @@ public class WebConfig
 
     @Inject
     private YAMLMapperFactory yamlMapperFactory;
+    
+    @Inject
+    protected ConfigurationManager configurationManager;
 
     WebConfig()
     {
@@ -185,6 +192,21 @@ public class WebConfig
     public Validator localValidatorFactoryBean()
     {
         return new LocalValidatorFactoryBean();
+    }
+    
+    @Bean("loggingMgmtDirectoryListingService")
+    public DirectoryListingService getLoggingManagementDirectoryListingService()
+    {
+    	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
+
+        return new DirectoryListingServiceImpl(String.format("%s/api/logging", baseUrl));
+    }
+    
+    @Bean("browseRepoDirectoryListingService")
+    public DirectoryListingService getBrowseRepoDirectoryListingService()
+    {
+    	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
+        return new DirectoryListingServiceImpl(String.format("%s/api/browse", baseUrl));
     }
 
     @Override

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -36,6 +36,7 @@ import org.jtwig.spring.boot.config.JtwigViewResolverConfigurer;
 import org.jtwig.web.servlet.JtwigRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -194,7 +195,8 @@ public class WebConfig
         return new LocalValidatorFactoryBean();
     }
     
-    @Bean("loggingMgmtDirectoryListingService")
+    @Bean
+    @Qualifier("loggingManagementDirectoryListingService")
     public DirectoryListingService getLoggingManagementDirectoryListingService()
     {
     	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
@@ -202,7 +204,8 @@ public class WebConfig
         return new DirectoryListingServiceImpl(String.format("%s/api/logging", baseUrl));
     }
     
-    @Bean("browseRepoDirectoryListingService")
+    @Bean
+    @Qualifier("browseRepoDirectoryListingService")
     public DirectoryListingService getBrowseRepoDirectoryListingService()
     {
     	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/config/WebConfig.java
@@ -199,16 +199,15 @@ public class WebConfig
     @Qualifier("loggingManagementDirectoryListingService")
     public DirectoryListingService getLoggingManagementDirectoryListingService()
     {
-    	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
-
+        String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
         return new DirectoryListingServiceImpl(String.format("%s/api/logging", baseUrl));
     }
-    
+
     @Bean
     @Qualifier("browseRepoDirectoryListingService")
     public DirectoryListingService getBrowseRepoDirectoryListingService()
     {
-    	String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
+        String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
         return new DirectoryListingServiceImpl(String.format("%s/api/browse", baseUrl));
     }
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -51,7 +51,7 @@ public class BrowseController
     public final static String ROOT_CONTEXT = "/api/browse";
 
     @Inject
-    @Qualifier("browseRepoDirectoryListingService")
+    @Qualifier("browseRepositoryDirectoryListingService")
     private volatile DirectoryListingService directoryListingService;
     
     @ApiOperation(value = "List configured storages.")

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -4,7 +4,6 @@ import org.carlspring.strongbox.domain.DirectoryListing;
 import org.carlspring.strongbox.providers.io.RepositoryFiles;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.services.DirectoryListingService;
-import org.carlspring.strongbox.services.DirectoryListingServiceImpl;
 import org.carlspring.strongbox.storage.Storage;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.web.RepositoryMapping;
@@ -55,11 +54,6 @@ public class BrowseController
     @Qualifier("browseRepoDirectoryListingService")
     private volatile DirectoryListingService directoryListingService;
     
-    public DirectoryListingService getDirectoryListingService()
-    {
-        return directoryListingService;
-    }
-    
     @ApiOperation(value = "List configured storages.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "The list was returned."),
                             @ApiResponse(code = 500, message = "An error occurred.") })
@@ -76,7 +70,7 @@ public class BrowseController
         try
         {
             Map<String, Storage> storages = configurationManager.getConfiguration().getStorages();
-            DirectoryListing directoryListing = getDirectoryListingService().fromStorages(storages);
+            DirectoryListing directoryListing = directoryListingService.fromStorages(storages);
 
             if (acceptHeader != null && acceptHeader.contains(MediaType.APPLICATION_JSON_VALUE))
             {
@@ -121,7 +115,7 @@ public class BrowseController
                 return getNotFoundResponseEntity("The requested storage was not found.", acceptHeader);
             }
 
-            DirectoryListing directoryListing = getDirectoryListingService().fromRepositories(storage.getRepositories());
+            DirectoryListing directoryListing = directoryListingService.fromRepositories(storage.getRepositories());
 
             if (acceptHeader != null && acceptHeader.contains(MediaType.APPLICATION_JSON_VALUE))
             {
@@ -178,7 +172,7 @@ public class BrowseController
                 return getNotFoundResponseEntity("Requested repository doesn't allow browsing.", acceptHeader);
             }
 
-            DirectoryListing directoryListing = getDirectoryListingService().fromRepositoryPath(repositoryPath);
+            DirectoryListing directoryListing = directoryListingService.fromRepositoryPath(repositoryPath);
 
             if (acceptHeader != null && acceptHeader.contains(MediaType.APPLICATION_JSON_VALUE))
             {

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BrowseController.java
@@ -25,6 +25,7 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -50,14 +51,13 @@ public class BrowseController
     // must be the same as @RequestMapping value on the class definition
     public final static String ROOT_CONTEXT = "/api/browse";
 
+    @Inject
+    @Qualifier("browseRepoDirectoryListingService")
     private volatile DirectoryListingService directoryListingService;
     
     public DirectoryListingService getDirectoryListingService()
     {
-        return Optional.ofNullable(directoryListingService).orElseGet(() -> {
-            String baseUrl = StringUtils.chomp(configurationManager.getConfiguration().getBaseUrl(), "/");
-            return directoryListingService = new DirectoryListingServiceImpl(String.format("%s/api/browse", baseUrl));
-        });
+        return directoryListingService;
     }
     
     @ApiOperation(value = "List configured storages.")


### PR DESCRIPTION
# Pull Request Description
I have found the following references of the DirectoryListingService getting initialized directly in the code.

`org.carlspring.strongbox.controllers.BrowseController`
`org.carlspring.strongbox.controllers.LoggingManagementController`

I have refactored these initialization steps to WebConfig and provided these two beans through Spring configuration by referring to them using their names.

This pull request closes #1542  

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
