### PR TITLE
Issue 1563: Clean up properties in the strongbox-parent

### DIFF
--- a/strongbox-testing/strongbox-testing-core/pom.xml
+++ b/strongbox-testing/strongbox-testing-core/pom.xml
@@ -60,7 +60,6 @@
                         <strongbox.home>${basedir}/target/strongbox</strongbox.home>
                         <strongbox.vault>${basedir}/target/strongbox-vault</strongbox.vault>
                         <strongbox.storage.booter.basedir>${basedir}/target/strongbox-vault/storages</strongbox.storage.booter.basedir>
-                        <port.jetty.listen>${port.jetty.listen}</port.jetty.listen>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -169,18 +168,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>set-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <!-- Default ports for local development: -->
-                <port.jetty.listen>48080</port.jetty.listen>
-                <port.jetty.shutdown>19081</port.jetty.shutdown>
-            </properties>
         </profile>
     </profiles>
 

--- a/strongbox-testing/strongbox-testing-web/pom.xml
+++ b/strongbox-testing/strongbox-testing-web/pom.xml
@@ -181,41 +181,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-
-                        <executions>
-                            <execution>
-                                <id>reserve-network-port</id>
-                                <goals>
-                                    <goal>reserve-network-port</goal>
-                                </goals>
-                                <phase>process-resources</phase>
-                                <configuration>
-                                    <portNames>
-                                        <portName>port.jetty.listen</portName>
-                                        <portName>port.jetty.shutdown</portName>
-                                    </portNames>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>set-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <properties>
-                <!-- Default ports for local development: -->
-                <port.jetty.listen>48080</port.jetty.listen>
-                <port.jetty.shutdown>19081</port.jetty.shutdown>
-            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes strongbox/strongbox#1563.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [x] Yes, please see strongbox/strongbox-parent/pull/55.
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
