### PR TITLE
issue-1584: Remove usage of peek in tests where the endpoint is streaming files

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
@@ -1193,7 +1193,6 @@ public class MavenArtifactControllerTest
                       .contentType(MediaType.TEXT_PLAIN_VALUE)
                       .when()
                       .get(url, storageId, repositoryId, artifactRepositoryPathStr)
-                      .peek()
                       .thenReturn();
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenIndexControllerTest.java
@@ -293,8 +293,9 @@ public class MavenIndexControllerTest
 
         mockMvc.header(new Header("User-Agent", "Maven/*"))
                .get(url)
-               .peek()
                .then()
+               .log().status()
+               .log().headers()
                .statusCode(HttpStatus.OK.value())
                .contentType(APPLICATION_X_GZIP_VALUE)
                .body(CoreMatchers.notNullValue());
@@ -326,8 +327,9 @@ public class MavenIndexControllerTest
 
         mockMvc.header(new Header("User-Agent", "Maven/*"))
                .get(url)
-               .peek()
                .then()
+               .log().status()
+               .log().headers()
                .statusCode(HttpStatus.OK.value())
                .contentType(MediaType.TEXT_PLAIN_VALUE)
                .body(CoreMatchers.notNullValue());

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTest.java
@@ -133,6 +133,8 @@ public class NpmArtifactControllerTest
                .when()
                .get(url, storageId, repositoryId, coordinates.toResource())
                .then()
+               .log().status()
+               .log().headers()
                .statusCode(HttpStatus.OK.value())
                .assertThat()
                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(packagePath))));
@@ -280,8 +282,9 @@ public class NpmArtifactControllerTest
         mockMvc.contentType(MediaType.APPLICATION_JSON_VALUE)
                .when()
                .get(url, storageId, repositoryId, coordinates.toResource())
-               .prettyPeek()
                .then()
+               .log().status()
+               .log().headers()
                .statusCode(HttpStatus.OK.value())
                .assertThat()
                .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(Files.size(artifact))));

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactControllerTestIT.java
@@ -229,7 +229,6 @@ public class NpmArtifactControllerTestIT
                       .contentType(MediaType.TEXT_PLAIN_VALUE)
                       .when()
                       .get(url, storageId, repositoryId, packageName, packageName, packageVersion, packageExtension)
-                      .peek()
                       .thenReturn();
     }
 }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
@@ -238,8 +238,9 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
             mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                    .when()
                    .get(url, storageId, repositoryId, packageId, packageVersion)
-                   .peek()
                    .then()
+                   .log().status()
+                   .log().headers()
                    .statusCode(HttpStatus.OK.value())
                    .assertThat()
                    .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
@@ -249,8 +250,9 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
             mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                    .when()
                    .get(url, storageId, repositoryId, packageId, packageVersion)
-                   .peek()
                    .then()
+                   .log().status()
+                   .log().headers()
                    .statusCode(HttpStatus.OK.value())
                    .assertThat()
                    .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
@@ -353,7 +355,8 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
                .then()
                .statusCode(HttpStatus.OK.value())
                .and()
-               .log().body().and()
+               .log().body()
+               .and()
                .assertThat()
                .body(equalTo("1"));
 
@@ -521,8 +524,9 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
             mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                    .when()
                    .get(url, packageId, packageVersion)
-                   .peek()
                    .then()
+                   .log().status()
+                   .log().headers()
                    .statusCode(HttpStatus.OK.value())
                    .assertThat()
                    .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(1499857)));
@@ -620,7 +624,6 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
                       .contentType(MediaType.TEXT_PLAIN_VALUE)
                       .when()
                       .get(url, storageId, repositoryId, packageId, packageVersion)
-                      .peek()
                       .thenReturn();
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/raw/RawArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/raw/RawArtifactControllerTest.java
@@ -175,7 +175,6 @@ public class RawArtifactControllerTest
                       .contentType(MediaType.TEXT_PLAIN_VALUE)
                       .when()
                       .get(url, storageId, repositoryId, pathStr)
-                      .peek()
                       .thenReturn();
     }
 }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1584 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
