### PR TITLE
Issue 1569: Integration Tests fail in strongbox-web-core due to messa…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,3 +147,4 @@ To accept, please:
 | Marcin Słowiak               |                                              | Sanok, Poland                           | 2019-09-23 |
 | David Barda                  |                                              | Tel-Aviv, Israel                        | 2019-10-14 |
 | Bishnu Gopal Patro           |                                              | Pune, India                             | 2019-10-19 |
+| Bartosz Czyzowski            |                                              | Jozefow, Poland                         | 2019-11-17 |

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
@@ -371,8 +371,7 @@ public class RepositoryFormTestIT
         String message;
         try
         {
-            final String translatedMessage = new PlatformResourceBundleLocator(
-                    "org.hibernate.validator.ValidationMessages")
+            final String translatedMessage = new PlatformResourceBundleLocator("org.hibernate.validator.ValidationMessages")
                                                                  .getResourceBundle(Locale.getDefault())
                                                                  .getString("javax.validation.constraints.Pattern.message");
             message = translatedMessage.replace("\"{regexp}\"", expectedPattern);
@@ -381,6 +380,7 @@ public class RepositoryFormTestIT
         {
             message = "must match ";
         }
+        
         return message;
     }
 

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
@@ -369,12 +369,15 @@ public class RepositoryFormTestIT
     private String getPatternLocalisedMessage(String expectedPattern)
     {
         String message;
-        try {
+        try
+        {
             final String translatedMessage = new PlatformResourceBundleLocator("org.hibernate.validator.ValidationMessages")
                     .getResourceBundle(Locale.getDefault())
                     .getString("javax.validation.constraints.Pattern.message");
             message = translatedMessage.replace("\"{regexp}\"", expectedPattern);
-        } catch (MissingResourceException e) {
+        }
+        catch (MissingResourceException e)
+        {
             message = "must match ";
         }
         return message;

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
@@ -371,9 +371,10 @@ public class RepositoryFormTestIT
         String message;
         try
         {
-            final String translatedMessage = new PlatformResourceBundleLocator("org.hibernate.validator.ValidationMessages")
-                    .getResourceBundle(Locale.getDefault())
-                    .getString("javax.validation.constraints.Pattern.message");
+            final String translatedMessage = new PlatformResourceBundleLocator(
+                    "org.hibernate.validator.ValidationMessages")
+                                                                 .getResourceBundle(Locale.getDefault())
+                                                                 .getString("javax.validation.constraints.Pattern.message");
             message = translatedMessage.replace("\"{regexp}\"", expectedPattern);
         }
         catch (MissingResourceException e)

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/forms/configuration/RepositoryFormTestIT.java
@@ -12,10 +12,13 @@ import javax.inject.Inject;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.groups.Default;
+import java.util.Locale;
+import java.util.MissingResourceException;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -187,7 +190,7 @@ public class RepositoryFormTestIT
         repositoryForm.setHttpConnectionPool(HTTP_CONNECTION_POOL_VALID);
         repositoryForm.setRepositoryConfiguration(repositoryConfiguration);
 
-        validateAndAssert(repositoryForm, 1, "must match \"[a-zA-Z0-9\\-\\_\\.]+\"");
+        validateAndAssert(repositoryForm, 1, getPatternLocalisedMessage("\"[a-zA-Z0-9\\-\\_\\.]+\""));
     }
 
     @ParameterizedTest
@@ -362,4 +365,19 @@ public class RepositoryFormTestIT
 
         validateAndAssert(repositoryForm, 1, "A httpConnectionPool must be positive or zero.");
     }
+
+    private String getPatternLocalisedMessage(String expectedPattern)
+    {
+        String message;
+        try {
+            final String translatedMessage = new PlatformResourceBundleLocator("org.hibernate.validator.ValidationMessages")
+                    .getResourceBundle(Locale.getDefault())
+                    .getString("javax.validation.constraints.Pattern.message");
+            message = translatedMessage.replace("\"{regexp}\"", expectedPattern);
+        } catch (MissingResourceException e) {
+            message = "must match ";
+        }
+        return message;
+    }
+
 }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1569 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
