### PR TITLE
Issue 1532 :: Fixing NPE thrown RepositoryHostedIndexCreatorTest

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactManagementTestExecutionListener.java
@@ -93,23 +93,28 @@ public class ArtifactManagementTestExecutionListener extends TestRepositoryManag
         {
             return Proxy.newProxyInstance(ArtifactManagementTestExecutionListener.class.getClassLoader(),
                                           new Class[] { List.class },
-                                          new ListInvocationHandler(id(testArtifact)));
+                                          new ListInvocationHandler(id(testArtifact), testApplicationContext));
         }
-        
+
         return Proxy.newProxyInstance(ArtifactManagementTestExecutionListener.class.getClassLoader(),
                                       new Class[] { Path.class },
-                                      new TestArtifactProxyInvocationHandler(id(testArtifact)));
+                                      new TestArtifactProxyInvocationHandler(id(testArtifact), testApplicationContext));
     }
     
     private class ListInvocationHandler implements InvocationHandler
     {
 
         private List<Path> target;
+
         private final String id;
 
-        private ListInvocationHandler(String id)
+        private final TestRepositoryManagementContext context;
+
+        private ListInvocationHandler(String id,
+                                      TestRepositoryManagementContext context)
         {
             this.id = id;
+            this.context = context;
         }
 
         @Override
@@ -128,17 +133,17 @@ public class ArtifactManagementTestExecutionListener extends TestRepositoryManag
                 throw e.getTargetException();
             }
         }
-        
+
         public List<Path> getTarget()
         {
             if (target == null)
             {
-                target = getTestRepositoryManagementContext().getTestArtifactContext(id).getArtifacts();
+                target = context.getTestArtifactContext(id).getArtifacts();
             }
 
             return target;
         }
-       
+
     }
 
     /**
@@ -152,18 +157,23 @@ public class ArtifactManagementTestExecutionListener extends TestRepositoryManag
     {
 
         private Path target;
+
         private final String id;
 
-        private TestArtifactProxyInvocationHandler(String id)
+        private final TestRepositoryManagementContext context;
+
+        private TestArtifactProxyInvocationHandler(String id,
+                                                   TestRepositoryManagementContext context)
         {
             this.id = id;
+            this.context = context;
         }
 
         public Path getTarget()
         {
             if (target == null)
             {
-                target = getTestRepositoryManagementContext().getTestArtifactContext(id).getArtifacts().stream().findFirst().get();
+                target = context.getTestArtifactContext(id).getArtifacts().stream().findFirst().get();
             }
 
             return target;

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/RepositoryManagementTestExecutionListener.java
@@ -46,7 +46,7 @@ public class RepositoryManagementTestExecutionListener extends TestRepositoryMan
         return Proxy.newProxyInstance(RepositoryManagementTestExecutionListener.class.getClassLoader(),
                                       new Class[] { Repository.class },
                                       new TestRepositoryProxyInvocationHandler(
-                                              id(testRepository)));
+                                              id(testRepository), getTestRepositoryManagementContext()));
     }
 
     /**
@@ -59,11 +59,16 @@ public class RepositoryManagementTestExecutionListener extends TestRepositoryMan
     {
 
         private Repository target;
+
         private final String id;
 
-        private TestRepositoryProxyInvocationHandler(String id)
+        private final TestRepositoryManagementContext context;
+
+        private TestRepositoryProxyInvocationHandler(String id,
+                                                     TestRepositoryManagementContext context)
         {
             this.id = id;
+            this.context = context;
         }
 
         @Override
@@ -74,7 +79,7 @@ public class RepositoryManagementTestExecutionListener extends TestRepositoryMan
         {
             if (target == null)
             {
-                target = getTestRepositoryManagementContext().getTestRepositoryContext(id).getRepository();
+                target = context.getTestRepositoryContext(id).getRepository();
             }
 
             try


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1532 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
