### PR TITLE
Issue 1599: Fix to move test resource of meta inf maven from source to target

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactControllerTest.java
@@ -117,6 +117,8 @@ public class MavenArtifactControllerTest
 
     private static final String REPOSITORY_RELEASES_OUT_OF_SERVICE = "mact-releases-out-of-service";
 
+    private static final String TEST_RESOURCES_TEMP_META_INF_MAVEN = "target/test-resources/temp/%s/META-INF/maven";
+
     private static Path pluginXmlFilePath;
 
     @Spy
@@ -239,7 +241,7 @@ public class MavenArtifactControllerTest
             throws Exception
     {
         Path filePath = Paths.get("").toAbsolutePath().normalize();
-        pluginXmlFilePath = filePath.resolve("src/test/resources/temp/" + artifactId + "/META-INF/maven");
+        pluginXmlFilePath = filePath.resolve(String.format(TEST_RESOURCES_TEMP_META_INF_MAVEN, artifactId));
         Files.createDirectories(pluginXmlFilePath);
 
         String xmlSource = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1599 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
