### PR TITLE
Issue 841 - Create a Debian distribution package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Strongbox is available in the following formats:
 * [rpm][release-rpm]
 * [tar.gz][release-tar.gz]
 * [zip][release-zip]
+* [deb][release-deb]
 
 Other release could be downloaded from [here][release-all].
 
@@ -145,6 +146,7 @@ We'd also like to thank our sponsors for generously providing us with licenses f
 [release-rpm]: https://github.com/strongbox/strongbox/releases/download/1.0-SNAPSHOT/strongbox-distribution-1.0-SNAPSHOT.rpm
 [release-tar.gz]: https://github.com/strongbox/strongbox/releases/download/1.0-SNAPSHOT/strongbox-distribution-1.0-SNAPSHOT.tar.gz
 [release-zip]: https://github.com/strongbox/strongbox/releases/download/1.0-SNAPSHOT/strongbox-distribution-1.0-SNAPSHOT.zip
+[release-deb]: https://github.com/strongbox/strongbox/releases/download/1.0-SNAPSHOT/strongbox-distribution-1.0-SNAPSHOT.deb
 
 [<--# Sponsors -->]: #
 [yourkit-logo]: https://www.yourkit.com/images/yklogo.png

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -377,6 +377,34 @@
                     <tarLongFileMode>gnu</tarLongFileMode>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <artifactId>jdeb</artifactId>
+                <groupId>org.vafer</groupId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jdeb</goal>
+                        </goals>
+                        <configuration>
+                            <deb>${basedir}/target/strongbox-distribution-${project.version}.deb</deb>
+                            <controlDir>${basedir}/src/main/resources/deb</controlDir>
+                            <installDir>/opt/strongbox</installDir>
+                            <skipPOMs>false</skipPOMs>
+                            <dataSet>
+                            
+                                <data>
+                                    <src>${basedir}/target/assembly</src>
+                                    <type>directory</type>
+                                </data>
+                                
+                            </dataSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
 

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -658,6 +658,7 @@
                                         <include>${project.artifactId}*.tar.gz</include>
                                         <include>${project.artifactId}*.zip</include>
                                         <include>${project.artifactId}*.rpm</include>
+                                        <include>${project.artifactId}*.deb</include>
                                     </includes>
                                 </fileSet>
                             </fileSets>

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -390,15 +390,94 @@
                         <configuration>
                             <deb>${basedir}/target/strongbox-distribution-${project.version}.deb</deb>
                             <controlDir>${basedir}/src/main/resources/deb</controlDir>
-                            <installDir>/opt/strongbox</installDir>
                             <skipPOMs>false</skipPOMs>
                             <dataSet>
                             
                                 <data>
-                                    <src>${basedir}/target/assembly</src>
+                                    <src>${basedir}/target/assembly/strongbox-${project.version}/bin</src>
                                     <type>directory</type>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox/bin</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>770</filemode>
+					<dirmode>770</dirmode>
+ 				    </mapper>
+                                </data>
+
+                                <data>
+                                    <src>${basedir}/target/assembly/strongbox-${project.version}/lib</src>
+                                    <type>directory</type>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox/lib</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>770</filemode>
+					<dirmode>770</dirmode>
+ 				    </mapper>
+                                </data>
+
+                                <data>
+                                    <src>${basedir}/target/assembly/strongbox-${project.version}/logs</src>
+                                    <type>directory</type>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox/logs</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>770</filemode>
+					<dirmode>770</dirmode>
+ 				    </mapper>
+                                </data>
+
+                                <data>
+                                    <src>${basedir}/target/assembly/strongbox-${project.version}/tmp</src>
+                                    <type>directory</type>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox/tmp</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>770</filemode>
+					<dirmode>770</dirmode>
+ 				    </mapper>
+                                </data>
+
+                                <data>
+                                    <src>${basedir}/target/assembly/strongbox-${project.version}/etc</src>
+                                    <type>directory</type>
+				    <conffile>true</conffile>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox/etc</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>770</filemode>
+					<dirmode>770</dirmode>
+ 				    </mapper>
+                                </data>
+
+                                <data>
+                                    <src>${basedir}/src/main/resources/strongbox.service</src>
+                                    <type>file</type>
+				    <mapper>
+					<type>perm</type>
+                                        <prefix>/opt/strongbox</prefix>
+                                        <user>strongbox</user>
+                                        <group>strongbox</group>
+					<filemode>775</filemode>
+					<dirmode>775</dirmode>
+ 				    </mapper>
                                 </data>
                                 
+				<data>
+                                    <linkName>/etc/systemd/system/strongbox.service</linkName>
+				    <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
+                                    <type>link</type>
+                                </data>
+
                             </dataSet>
                         </configuration>
                     </execution>

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -396,85 +396,85 @@
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/bin</src>
                                     <type>directory</type>
-			                     	<mapper>
-				                    	<type>perm</type>
+                                    <mapper>
+                                        <type>perm</type>
                                         <prefix>/opt/strongbox/bin</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					                    <filemode>770</filemode>
-				                    	<dirmode>770</dirmode>
- 				                    </mapper>
+                                        <filemode>770</filemode>
+                                        <dirmode>770</dirmode>
+                                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/lib</src>
                                     <type>directory</type>
-				                       <mapper>
-					                    <type>perm</type>
+                                    <mapper>
+                                        <type>perm</type>
                                         <prefix>/opt/strongbox/lib</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					                    <filemode>770</filemode>
-					                    <dirmode>770</dirmode>
- 				                     </mapper>
+                                        <filemode>770</filemode>
+                                        <dirmode>770</dirmode>
+                                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/logs</src>
                                     <type>directory</type>
-				                    <mapper>
-				                    	<type>perm</type>
+                                    <mapper>
+                                    <type>perm</type>
                                         <prefix>/opt/strongbox/logs</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					                    <filemode>770</filemode>
-					                    <dirmode>770</dirmode>
- 				                    </mapper>
+                                        <filemode>770</filemode>
+                                        <dirmode>770</dirmode>
+                                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/tmp</src>
                                     <type>directory</type>
-				                    <mapper>
-					                    <type>perm</type>
+                                    <mapper>
+                                        <type>perm</type>
                                         <prefix>/opt/strongbox/tmp</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					                    <filemode>770</filemode>
-				                    	<dirmode>770</dirmode>
- 				                   </mapper>
+                                        <filemode>770</filemode>
+                                        <dirmode>770</dirmode>
+                                     </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/etc</src>
                                     <type>directory</type>
-				                    <conffile>true</conffile>
-				                    <mapper>
-				                    	<type>perm</type>
-                                        <prefix>/opt/strongbox/etc</prefix>
-                                        <user>strongbox</user>
-                                        <group>strongbox</group>
-					                    <filemode>770</filemode>
-					                       <dirmode>770</dirmode>
- 				                    </mapper>
+                                    <conffile>true</conffile>
+                                    <mapper>
+                                         <type>perm</type>
+                                         <prefix>/opt/strongbox/etc</prefix>
+                                         <user>strongbox</user>
+                                         <group>strongbox</group>
+                                         <filemode>770</filemode>
+                                         <dirmode>770</dirmode>
+                                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/src/main/resources/strongbox.service</src>
                                     <type>file</type>
-				                    <mapper>
-				                       	<type>perm</type>
+                                    <mapper>
+                                    <type>perm</type>
                                         <prefix>/opt/strongbox</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					                    <filemode>775</filemode>
-					                    <dirmode>775</dirmode>
- 				                    </mapper>
+                                        <filemode>775</filemode>
+                                        <dirmode>775</dirmode>
+                                    </mapper>
                                 </data>
                                 
-				                <data>
+                                <data>
                                     <linkName>/etc/systemd/system/strongbox.service</linkName>
-				                    <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
+                                        <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
                                     <type>link</type>
                                 </data>
 

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -396,85 +396,85 @@
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/bin</src>
                                     <type>directory</type>
-				    <mapper>
-					<type>perm</type>
+			                     	<mapper>
+				                    	<type>perm</type>
                                         <prefix>/opt/strongbox/bin</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>770</filemode>
-					<dirmode>770</dirmode>
- 				    </mapper>
+					                    <filemode>770</filemode>
+				                    	<dirmode>770</dirmode>
+ 				                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/lib</src>
                                     <type>directory</type>
-				    <mapper>
-					<type>perm</type>
+				                       <mapper>
+					                    <type>perm</type>
                                         <prefix>/opt/strongbox/lib</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>770</filemode>
-					<dirmode>770</dirmode>
- 				    </mapper>
+					                    <filemode>770</filemode>
+					                    <dirmode>770</dirmode>
+ 				                     </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/logs</src>
                                     <type>directory</type>
-				    <mapper>
-					<type>perm</type>
+				                    <mapper>
+				                    	<type>perm</type>
                                         <prefix>/opt/strongbox/logs</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>770</filemode>
-					<dirmode>770</dirmode>
- 				    </mapper>
+					                    <filemode>770</filemode>
+					                    <dirmode>770</dirmode>
+ 				                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/tmp</src>
                                     <type>directory</type>
-				    <mapper>
-					<type>perm</type>
+				                    <mapper>
+					                    <type>perm</type>
                                         <prefix>/opt/strongbox/tmp</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>770</filemode>
-					<dirmode>770</dirmode>
- 				    </mapper>
+					                    <filemode>770</filemode>
+				                    	<dirmode>770</dirmode>
+ 				                   </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/etc</src>
                                     <type>directory</type>
-				    <conffile>true</conffile>
-				    <mapper>
-					<type>perm</type>
+				                    <conffile>true</conffile>
+				                    <mapper>
+				                    	<type>perm</type>
                                         <prefix>/opt/strongbox/etc</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>770</filemode>
-					<dirmode>770</dirmode>
- 				    </mapper>
+					                    <filemode>770</filemode>
+					                       <dirmode>770</dirmode>
+ 				                    </mapper>
                                 </data>
 
                                 <data>
                                     <src>${basedir}/src/main/resources/strongbox.service</src>
                                     <type>file</type>
-				    <mapper>
-					<type>perm</type>
+				                    <mapper>
+				                       	<type>perm</type>
                                         <prefix>/opt/strongbox</prefix>
                                         <user>strongbox</user>
                                         <group>strongbox</group>
-					<filemode>775</filemode>
-					<dirmode>775</dirmode>
- 				    </mapper>
+					                    <filemode>775</filemode>
+					                    <dirmode>775</dirmode>
+ 				                    </mapper>
                                 </data>
                                 
-				<data>
+				                <data>
                                     <linkName>/etc/systemd/system/strongbox.service</linkName>
-				    <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
+				                    <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
                                     <type>link</type>
                                 </data>
 

--- a/strongbox-distribution/src/main/resources/deb/control
+++ b/strongbox-distribution/src/main/resources/deb/control
@@ -4,6 +4,6 @@ Architecture: all
 Section: Miscellaneous
 Priority: low
 Homepage: https://github.com/strongbox/strongbox
-Description: Modern artifact repository manager
-Maintainer: Carlspring <carlspring@gmail.com>
+Description: The Strongbox artifact repository manager
+Maintainer: Martin Todorov <carlspring@gmail.com>
 Depends: java8-runtime | java8-runtime-headless

--- a/strongbox-distribution/src/main/resources/deb/control
+++ b/strongbox-distribution/src/main/resources/deb/control
@@ -1,0 +1,8 @@
+Package: strongbox
+Version: [[version]]
+Architecture: all
+Section: Miscellaneous
+Priority: low
+Homepage: https://github.com/strongbox/strongbox
+Description: Modern artifact repository manager
+Maintainer: Carlspring <carlspring@gmail.com>

--- a/strongbox-distribution/src/main/resources/deb/control
+++ b/strongbox-distribution/src/main/resources/deb/control
@@ -6,3 +6,4 @@ Priority: low
 Homepage: https://github.com/strongbox/strongbox
 Description: Modern artifact repository manager
 Maintainer: Carlspring <carlspring@gmail.com>
+Depends: java8-runtime | java8-runtime-headless

--- a/strongbox-distribution/src/main/resources/deb/control
+++ b/strongbox-distribution/src/main/resources/deb/control
@@ -6,4 +6,4 @@ Priority: low
 Homepage: https://github.com/strongbox/strongbox
 Description: The Strongbox artifact repository manager
 Maintainer: Martin Todorov <carlspring@gmail.com>
-Depends: java8-runtime | java8-runtime-headless
+Recommends: java8-runtime | java8-runtime-headless

--- a/strongbox-distribution/src/main/resources/deb/postinst
+++ b/strongbox-distribution/src/main/resources/deb/postinst
@@ -5,5 +5,5 @@ mkdir -p /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault
 getent group strongbox >/dev/null 2>&1 || groupadd --system strongbox
 id -u strongbox >/dev/null 2>&1 || adduser --quiet --system --ingroup strongbox --home /opt/strongbox strongbox
 
-chown -R strongbox:strongbox /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault
-chmod -R 770 /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault
+chown -R strongbox:strongbox /opt/strongbox /opt/strongbox-vault
+chmod -R 770 /opt/strongbox /opt/strongbox-vault

--- a/strongbox-distribution/src/main/resources/deb/postinst
+++ b/strongbox-distribution/src/main/resources/deb/postinst
@@ -1,6 +1,9 @@
 #!/bin/sh
-mkdir /opt/strongbox-vault
-groupadd strongbox
-useradd -d /opt/strongbox -g strongbox --system strongbox
-chown -R strongbox:strongbox /opt/strongbox
-chown -R strongbox:strongbox /opt/strongbox-vault
+set -e
+mkdir -p /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault 
+
+getent group strongbox >/dev/null 2>&1 || groupadd --system strongbox
+id -u strongbox >/dev/null 2>&1 || adduser --quiet --system --ingroup strongbox --home /opt/strongbox strongbox
+
+chown -R strongbox:strongbox /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault
+chmod -R 770 /opt/strongbox/tmp /opt/strongbox/logs /opt/strongbox-vault

--- a/strongbox-distribution/src/main/resources/deb/postinst
+++ b/strongbox-distribution/src/main/resources/deb/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+mkdir /opt/strongbox-vault
+groupadd strongbox
+useradd -d /opt/strongbox -g strongbox --system strongbox
+chown -R strongbox:strongbox /opt/strongbox
+chown -R strongbox:strongbox /opt/strongbox-vault


### PR DESCRIPTION
# Pull Request Description

This pull request closes #841 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] N/A Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] N/A Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] N/A The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [x] Yes, https://github.com/strongbox/strongbox-docs/pull/70
  * [ ] No

# Info

* This does not totally uninstall cleanly even with a purge, it leaves strongbox-vault. I thought that it is best to not remove the vault uninstall/purge. This is up for discussion. 
* This does not remove the strongbox user and group upon uninstall as per [Debian recommendation](https://wiki.debian.org/AccountHandlingInMaintainerScripts)
* It takes a dependency on Java 8 runtime or java 8 runtime headless. These are provided by the JRE packages on Debian, and the JRE is installed as a dependency on the JDK. 
* This is NOT ready to put into an official repository, there are a couple of things like adding GPG signing and more maintainer info that are required by Debian. 
* Should be tested in more scenarios, VM, docker, native, Ubuntu spins, Mint, Pop-OS, others?
* This will build the deb on both Windows and on Linux

# TODO
* [x] wiki changes and make PR
* [x] figure out if strongbox-vault should be removed upon package purge
* [x] tested on Ubuntu 18.04 and 19.10 on docker, along with a Debian 10 VM
        