### PR TITLE
Issue 1616: Clean up temporary file after test run

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/storage/validation/resource/ArtifactOperationsValidatorTest.java
@@ -137,6 +137,7 @@ public class ArtifactOperationsValidatorTest
         {
             assertThat(true).isTrue();
         }
+        Files.delete(path);
     }
 
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1616

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
