### PR TITLE
Revert Nuget Multipart changes

### DIFF
--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiTestArtifact.java
@@ -34,7 +34,7 @@ public @interface PypiTestArtifact
      * {@link Repository} ID.1
      */
     @AliasFor(annotation = TestArtifact.class)
-    String repositoryId() default "releases";
+    String repositoryId() default "";
 
     /**
      * Layout specific artifact URI (ex.'path/to/strbox-1.0-none-any.whl').

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactController.java
@@ -65,7 +65,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-import org.springframework.web.multipart.MultipartFile;
 
 /**
  * This Controller used to handle Nuget requests.
@@ -412,29 +411,28 @@ public class NugetArtifactController
     @RequestMapping(path = "{storageId}/{repositoryId}/", method = RequestMethod.PUT, consumes = MediaType.MULTIPART_FORM_DATA)
     public ResponseEntity putPackage(@RequestHeader(name = "X-NuGet-ApiKey", required = false) String apiKey,
                                      @RepositoryMapping Repository repository,
-                                     @RequestPart(name = "package") MultipartFile file,
                                      HttpServletRequest request)
     {
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
 
         logger.info("Nuget push request: storageId-[{}]; repositoryId-[{}]", storageId, repositoryId);
-//        String contentType = request.getHeader("content-type");
+        String contentType = request.getHeader("content-type");
 
         URI resourceUri;
         try
         {
             ServletInputStream is = request.getInputStream();
-            InputStream packagePartInputStream = file.getInputStream(); //extractPackageMultipartStream(extractBoundary(contentType), is);
+            InputStream packagePartInputStream = extractPackageMultipartStream(extractBoundary(contentType), is);
 
-//            if (packagePartInputStream == null)
-//            {
-//                logger.error("Failed to extract Nuget package from request: [{}]:[{}]",
-//                             storageId,
-//                             repositoryId);
-//
-//                return ResponseEntity.badRequest().build();
-//            }
+            if (packagePartInputStream == null)
+            {
+                logger.error("Failed to extract Nuget package from request: [{}]:[{}]",
+                             storageId,
+                             repositoryId);
+
+                return ResponseEntity.badRequest().build();
+            }
 
             resourceUri = storePackage(storageId, repositoryId, packagePartInputStream);
         }

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
@@ -1,9 +1,5 @@
 package org.carlspring.strongbox.controllers.layout.nuget;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.carlspring.strongbox.utils.ArtifactControllerHelper.MULTIPART_BOUNDARY;
-import static org.hamcrest.CoreMatchers.equalTo;
-
 import org.carlspring.strongbox.artifact.coordinates.NugetArtifactCoordinates;
 import org.carlspring.strongbox.config.IntegrationTest;
 import org.carlspring.strongbox.domain.ArtifactEntry;
@@ -20,7 +16,6 @@ import org.carlspring.strongbox.testing.repository.NugetRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import javax.inject.Inject;
-
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
@@ -29,26 +24,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.module.mockmvc.config.RestAssuredMockMvcConfig;
+import io.restassured.module.mockmvc.response.MockMvcResponse;
+import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import io.restassured.http.ContentType;
-import io.restassured.http.Header;
-import io.restassured.http.Headers;
-import io.restassured.module.mockmvc.config.RestAssuredMockMvcConfig;
-import io.restassured.module.mockmvc.response.MockMvcResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.carlspring.strongbox.utils.ArtifactControllerHelper.MULTIPART_BOUNDARY;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * @author Sergey Bespalov
@@ -75,8 +65,6 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
     @Inject
     private ArtifactEntryService artifactEntryService;
 
-    private MockMvc mvc;
-
     @Override
     @BeforeEach
     public void init()
@@ -87,8 +75,6 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         RestAssuredMockMvcConfig config = RestAssuredMockMvcConfig.config();
         config.getLogConfig().enableLoggingOfRequestAndResponseIfValidationFails();
         mockMvc.config(config);
-
-        mvc = MockMvcBuilders.webAppContextSetup(context).apply(SecurityMockMvcConfigurers.springSecurity()).build();
     }
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
@@ -217,21 +203,19 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         final String packageVersion = "1.0.0";
 
         long packageSize = Files.size(packagePath);
-        byte[] packageContent = Files.readAllBytes(packagePath); // readPackageContent(packagePath);
+        byte[] packageContent = readPackageContent(packagePath);
 
         // Push
-        pushPackage(packageContent, storageId, repositoryId);
-        
-//        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
-//        createPushRequest(packageContent).when()
-//                                         .put(url, storageId, repositoryId)
-//                                         .peek()
-//                                         .then()
-//                                         .statusCode(HttpStatus.CREATED.value());
+        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
+        createPushRequest(packageContent).when()
+                                         .put(url, storageId, repositoryId)
+                                         .peek()
+                                         .then()
+                                         .statusCode(HttpStatus.CREATED.value());
 
         //Find by ID
 
-        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/FindPackagesById()?id='{artifactId}'";
+        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/FindPackagesById()?id='{artifactId}'";
         mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                .when()
                .get(url, storageId, repositoryId, packageId)
@@ -293,24 +277,22 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
         final String packageId = "Org.Carlspring.Strongbox.Examples.Nuget.Mono-Test";
-//        final String packageVersion = "1.0.0";
+        final String packageVersion = "1.0.0";
 
-//        long packageSize = Files.size(packagePath);
-        byte[] packageContent = Files.readAllBytes(packagePath); // readPackageContent(packagePath);
+        long packageSize = Files.size(packagePath);
+        byte[] packageContent = readPackageContent(packagePath);
 
         // Push
-        pushPackage(packageContent, storageId, repositoryId);
-        
-//        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
-//        createPushRequest(repositoryPath).when()
-//                                         .put(url, storageId, repositoryId)
-//                                         .peek()
-//                                         .then()
-//                                         .statusCode(HttpStatus.CREATED.value());
+        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
+        createPushRequest(packageContent).when()
+                                         .put(url, storageId, repositoryId)
+                                         .peek()
+                                         .then()
+                                         .statusCode(HttpStatus.CREATED.value());
 
         //Find by ID
 
-        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/Search()?$filter=IsLatestVersion&$skip=0&$top=30&searchTerm='{artifactId}'&targetFramework=''";
+        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/Search()?$filter=IsLatestVersion&$skip=0&$top=30&searchTerm='{artifactId}'&targetFramework=''";
         mockMvc.header(HttpHeaders.USER_AGENT, "Chocolatey Core",
                        "DataServiceVersion", "1.0;NetFx",
                        "MaxDataServiceVersion", "2.0;NetFx",
@@ -415,21 +397,18 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         String filter = String.format("tolower(Id) eq '%s' and IsLatestVersion", PACKAGE_ID_LAST_VERSION.toLowerCase());
 
         // VERSION 1.0.0
-//        Path packagePathV1 = packagePaths.get(0);
-        byte[] packageContent = Files.readAllBytes(packagePaths.get(0)); // readPackageContent(packagePathV1);
-
+        Path packagePathV1 = packagePaths.get(0);
+        byte[] packageContent = readPackageContent(packagePathV1);
         // Push
-        pushPackage(packageContent, storageId, repositoryId);
-        
-//        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
-//        createPushRequest(repositoryPath).when()
-//                                         .put(url, storageId, repositoryId)
-//                                         .peek()
-//                                         .then()
-//                                         .statusCode(HttpStatus.CREATED.value());
+        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
+        createPushRequest(packageContent).when()
+                                         .put(url, storageId, repositoryId)
+                                         .peek()
+                                         .then()
+                                         .statusCode(HttpStatus.CREATED.value());
 
         // Count
-        String url = getContextBaseUrl() +
+        url = getContextBaseUrl() +
               "/storages/{storageId}/{repositoryId}/Search()/$count?$filter={filter}&targetFramework=";
         mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
                .when()
@@ -457,18 +436,15 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
                .body("feed.entry[0].properties.Version", equalTo("1.0.0"));
 
         // VERSION 2.0.0
-//        Path packagePathV2 = packagePaths.get(1);
-        packageContent = Files.readAllBytes(packagePaths.get(1)); // readPackageContent(packagePathV2);
-
+        Path packagePathV2 = packagePaths.get(1);
+        packageContent = readPackageContent(packagePathV2);
         // Push
-        pushPackage(packageContent, storageId, repositoryId);
-        
-//        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
-//        createPushRequest(repositoryPath).when()
-//                                         .put(url, storageId, repositoryId)
-//                                         .peek()
-//                                         .then()
-//                                         .statusCode(HttpStatus.CREATED.value());
+        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
+        createPushRequest(packageContent).when()
+                                         .put(url, storageId, repositoryId)
+                                         .peek()
+                                         .then()
+                                         .statusCode(HttpStatus.CREATED.value());
         
         // Count
         url = getContextBaseUrl() +
@@ -499,30 +475,12 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
                .body("feed.entry[0].properties.Version", equalTo("2.0.0"));
     }
 
-    public void pushPackage(byte[] packageContent,
-                            String storageId,
-                            String repositoryId)
-        throws Exception
+    public MockMvcRequestSpecification createPushRequest(byte[] packageContent)
     {
-
-        String url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/";
-
-        MockMultipartHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart(url, storageId, repositoryId);
-        builder.with(new RequestPostProcessor()
-        {
-
-            @Override
-            public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request)
-            {
-                request.setMethod("PUT");
-                return request;
-            }
-        });
-
-        mvc.perform(builder.file("package", packageContent)
-                           .header(HttpHeaders.USER_AGENT, "NuGet/*")
-                           .header("X-NuGet-ApiKey", API_KEY))
-           .andExpect(MockMvcResultMatchers.status().isCreated());
+        return mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
+                      .header("X-NuGet-ApiKey", API_KEY)
+                      .contentType(MediaType.MULTIPART_FORM_DATA_VALUE.concat("; boundary=---------------------------123qwe"))
+                      .body(packageContent);
     }
 
     @Test

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/PypiRestAssuredBaseTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/rest/common/PypiRestAssuredBaseTest.java
@@ -1,16 +1,10 @@
 package org.carlspring.strongbox.rest.common;
 
-import org.carlspring.strongbox.rest.client.RestAssuredArtifactClient;
-import org.carlspring.strongbox.users.domain.Privileges;
-
 import javax.inject.Inject;
-
-import java.util.Collection;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.context.WebApplicationContext;
 
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -34,21 +28,12 @@ public abstract class PypiRestAssuredBaseTest
     @Inject
     protected WebApplicationContext context;
 
-    @Inject
-    protected RestAssuredArtifactClient client;
-
     @Value("${strongbox.url}")
     private String contextBaseUrl;
 
     @Inject
     protected MockMvcRequestSpecification mockMvc;
 
-    public void init()
-        throws Exception
-    {
-        client.setUserAgent(PIP_USER_AGENT);
-        client.setContextBaseUrl(contextBaseUrl);
-    }
 
     public String getContextBaseUrl()
     {
@@ -58,11 +43,6 @@ public abstract class PypiRestAssuredBaseTest
     public void setContextBaseUrl(String contextBaseUrl)
     {
         this.contextBaseUrl = contextBaseUrl;
-    }
-
-    protected Collection<? extends GrantedAuthority> provideAuthorities()
-    {
-        return Privileges.all();
     }
 
 }


### PR DESCRIPTION
# Pull Request Description

- Revert invalid changes made within #1625 
- Fix disregarded CR comments of #1625

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No
