### PR TITLE
issue-1667: Include storage-common-proxies:maven-central in group-sbt-proxies which is necessary for SBT s-w-i-t

### DIFF
--- a/strongbox-resources/strongbox-storage-api-resources/src/main/resources/etc/conf/strongbox.yaml
+++ b/strongbox-resources/strongbox-storage-api-resources/src/main/resources/etc/conf/strongbox.yaml
@@ -273,6 +273,7 @@ configuration:
             indexingEnabled: true
             cronExpression: "0 0 2 * * ?"
           groupRepositories:
+            - storage-common-proxies:maven-central
             - sbt-plugin-releases
             - storage-ivy-proxies:group-ivy-proxies
     storage-third-party:


### PR DESCRIPTION
# Pull Request Description

This pull request is related to #1667

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
