### PR TITLE
Subsequent fix of mock instance management for `RemoteRepositoryAlivenessCacheManager`

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/MockedRemoteRepositoriesHeartbeatConfig.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/MockedRemoteRepositoriesHeartbeatConfig.java
@@ -8,6 +8,7 @@ import org.carlspring.strongbox.storage.repository.remote.RemoteRepository;
 import org.carlspring.strongbox.storage.repository.remote.heartbeat.RemoteRepositoriesHeartbeatMonitorInitiator;
 import org.carlspring.strongbox.storage.repository.remote.heartbeat.RemoteRepositoryAlivenessService;
 import org.mockito.Mockito;
+import org.springframework.aop.TargetSource;
 import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.aop.target.ThreadLocalTargetSource;
 import org.springframework.beans.BeansException;
@@ -16,7 +17,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.event.EventListener;
-import org.springframework.test.context.TestContext;
 import org.springframework.test.context.event.AfterTestExecutionEvent;
 
 /**
@@ -85,15 +85,15 @@ public class MockedRemoteRepositoriesHeartbeatConfig
 
     private static class MockedRemoteRepositoryAlivenessTestExecutionListener {
 
-        private final ThreadLocalTargetSource targetSource;
+        private final TargetSource targetSource;
 
-        public MockedRemoteRepositoryAlivenessTestExecutionListener(ThreadLocalTargetSource targetSource)
+        public MockedRemoteRepositoryAlivenessTestExecutionListener(TargetSource targetSource)
         {
             this.targetSource = targetSource;
         }
 
         @EventListener(AfterTestExecutionEvent.class)
-        public void afterTestExecution()
+        public void afterTestExecution() throws Exception
         {
             resetMock((RemoteRepositoryAlivenessService) targetSource.getTarget());
         }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/BaseLocalStorageProxyRepositoryExpiredArtifactsCleanerTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/BaseLocalStorageProxyRepositoryExpiredArtifactsCleanerTest.java
@@ -17,6 +17,7 @@ import org.carlspring.strongbox.providers.repository.proxied.LocalStorageProxyRe
 import org.carlspring.strongbox.services.ArtifactEntryService;
 import org.carlspring.strongbox.services.ConfigurationManagementService;
 import org.carlspring.strongbox.storage.repository.remote.heartbeat.RemoteRepositoryAlivenessService;
+import org.springframework.aop.TargetSource;
 
 /**
  * @author Przemyslaw Fusik
@@ -36,8 +37,8 @@ abstract class BaseLocalStorageProxyRepositoryExpiredArtifactsCleanerTest
     protected LocalStorageProxyRepositoryExpiredArtifactsCleaner localStorageProxyRepositoryExpiredArtifactsCleaner;
 
     @Inject
-    @Named("mockedRemoteRepositoryAlivenessCacheManager")
-    protected RemoteRepositoryAlivenessService remoteRepositoryAlivenessCacheManager;
+    @Named("remoteRepositoryAlivenessCacheManagerTargetSource") 
+    private TargetSource remoteRepositoryAlivenessCacheManagerTargetSource;
 
     @Inject
     protected RepositoryPathResolver repositoryPathResolver;
@@ -95,6 +96,10 @@ abstract class BaseLocalStorageProxyRepositoryExpiredArtifactsCleanerTest
     protected Configuration getConfiguration()
     {
         return configurationManagementService.getConfiguration();
+    }
+    
+    protected RemoteRepositoryAlivenessService getRemoteRepositoryAlivenessMock() throws Exception {
+        return (RemoteRepositoryAlivenessService) remoteRepositoryAlivenessCacheManagerTargetSource.getTarget(); 
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsAliveCleanExpiredArtifactsTestIT.java
@@ -54,7 +54,7 @@ public class WhenRepositoryIsAliveCleanExpiredArtifactsTestIT
             throws Exception
     {
 
-        Mockito.when(remoteRepositoryAlivenessCacheManager.isAlive(
+        Mockito.when(getRemoteRepositoryAlivenessMock().isAlive(
                 argThat(argument -> argument != null && REMOTE_URL.equals(argument.getUrl()))))
                .thenReturn(true);
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsNotAliveDontCleanExpiredArtifactsTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/WhenRepositoryIsNotAliveDontCleanExpiredArtifactsTestIT.java
@@ -52,7 +52,7 @@ public class WhenRepositoryIsNotAliveDontCleanExpiredArtifactsTestIT
     {
         ArtifactEntry artifactEntry = downloadAndSaveArtifactEntry();
 
-        Mockito.when(remoteRepositoryAlivenessCacheManager.isAlive(
+        Mockito.when(getRemoteRepositoryAlivenessMock().isAlive(
                 argThat(argument -> argument != null && REMOTE_URL.equals(argument.getUrl()))))
                .thenReturn(false);
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1671

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
