### PR TITLE
issue-1687: Limit the URI scope which support authentication via access_token cookie

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/JWTAuthenticationSupplier.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/security/authentication/suppliers/JWTAuthenticationSupplier.java
@@ -64,7 +64,7 @@ class JWTAuthenticationSupplier
             hasHeader = StringUtils.isNotBlank(authHeader) && authHeader.startsWith(BEARER_AUTHORIZATION_PREFIX);
         }
         // fallback - check if a cookie is present (necessary for EventSource; check gh#1046).
-        else if (request.getCookies() != null)
+        else if (request.getCookies() != null && (request.getRequestURI().startsWith("/api") || request.getRequestURI().startsWith("/storages")))
         {
             hasCookie = Arrays.stream(request.getCookies())
                               .anyMatch(c -> c.getName()


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1687 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
