### PR TITLE
Issue 1723: Make it possible to specify the license types of test artifacts

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -1,6 +1,6 @@
 package org.carlspring.strongbox.artifact.generator;
 
-import org.carlspring.strongbox.testing.artifact.LicenseConfig;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,10 +44,10 @@ public interface ArtifactGenerator
                           long size)
         throws IOException;
 
-    default void copyLicenseFile(LicenseConfig licenseConfig, OutputStream os)
+    default void copyLicenseFile(LicenseConfiguration licenseConfiguration, OutputStream os)
             throws IOException
     {
-        ClassPathResource resource = new ClassPathResource(licenseConfig.license().getLicenseFileSourcePath(),
+        ClassPathResource resource = new ClassPathResource(licenseConfiguration.license().getLicenseFileSourcePath(),
                                                            this.getClass().getClassLoader());
 
         IOUtils.copy(resource.getInputStream(), os);

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/LicenseConfiguration.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/LicenseConfiguration.java
@@ -10,7 +10,7 @@ import java.lang.annotation.*;
 @Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface LicenseConfig
+public @interface LicenseConfiguration
 {
 
     LicenseType license() default LicenseType.NONE;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/MavenArtifactGeneratorTest.java
@@ -3,7 +3,7 @@ package org.carlspring.strongbox.artifact.generation;
 import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
-import org.carlspring.strongbox.testing.artifact.LicenseConfig;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.testing.artifact.LicenseType;
 import org.carlspring.strongbox.testing.artifact.MavenTestArtifact;
 import org.carlspring.strongbox.testing.repository.MavenRepository;
@@ -55,9 +55,9 @@ public class MavenArtifactGeneratorTest
                                                           id = "org.carlspring.strongbox.testing:matg",
                                                           versions = "1.2.3",
                                                           bytesSize = 2048,
-                                                          licenses = { @LicenseConfig(license = LicenseType.APACHE_2_0,
-                                                                                      destinationPath = "META-INF/LICENSE-Apache-2.0.md"),
-                                                                       @LicenseConfig(license = LicenseType.MIT) })
+                                                          licenses = { @LicenseConfiguration(license = LicenseType.APACHE_2_0,
+                                                                                             destinationPath = "META-INF/LICENSE-Apache-2.0.md"),
+                                                                       @LicenseConfiguration(license = LicenseType.MIT) })
                                        Path artifactPath)
             throws Exception
     {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -4,7 +4,7 @@ import org.carlspring.commons.encryption.EncryptionAlgorithmsEnum;
 import org.carlspring.commons.io.MultipleDigestInputStream;
 import org.carlspring.commons.io.MultipleDigestOutputStream;
 import org.carlspring.strongbox.artifact.MavenArtifactUtils;
-import org.carlspring.strongbox.testing.artifact.LicenseConfig;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
 import org.carlspring.strongbox.util.TestFileUtils;
 
@@ -44,7 +44,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
 
     protected Path basedir;
 
-    private LicenseConfig[] licenses;
+    private LicenseConfiguration[] licenses;
 
 
     public MavenArtifactGenerator()
@@ -188,12 +188,12 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     {
         if (licenses != null && licenses.length > 0)
         {
-            for (LicenseConfig licenseConfig : licenses)
+            for (LicenseConfiguration licenseConfiguration : licenses)
             {
-                JarEntry jarEntry = new JarEntry(licenseConfig.destinationPath());
+                JarEntry jarEntry = new JarEntry(licenseConfiguration.destinationPath());
                 jos.putNextEntry(jarEntry);
 
-                copyLicenseFile(licenseConfig, jos);
+                copyLicenseFile(licenseConfiguration, jos);
                 jos.closeEntry();
             }
         }
@@ -331,11 +331,11 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         {
             List<License> pomLicenses = new ArrayList<>();
 
-            for (LicenseConfig licenseConfig : licenses)
+            for (LicenseConfiguration licenseConfiguration : licenses)
             {
                 License license = new License();
-                license.setName(licenseConfig.license().getName());
-                license.setUrl(licenseConfig.license().getUrl());
+                license.setName(licenseConfiguration.license().getName());
+                license.setUrl(licenseConfiguration.license().getUrl());
 
                 pomLicenses.add(license);
             }
@@ -389,12 +389,12 @@ public class MavenArtifactGenerator implements ArtifactGenerator
         return basedir;
     }
 
-    public LicenseConfig[] getLicenses()
+    public LicenseConfiguration[] getLicenses()
     {
         return licenses;
     }
 
-    public void setLicenses(LicenseConfig[] licenses)
+    public void setLicenses(LicenseConfiguration[] licenses)
     {
         this.licenses = licenses;
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
@@ -22,9 +22,9 @@ public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy
         throws IOException
     {
         Object licenses = attributesMap.get("licenses");
-        if (licenses instanceof LicenseConfig[])
+        if (licenses instanceof LicenseConfiguration[])
         {
-            artifactGenerator.setLicenses((LicenseConfig[]) licenses);
+            artifactGenerator.setLicenses((LicenseConfiguration[]) licenses);
         }
 
         Path result;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -71,6 +71,6 @@ public @interface MavenTestArtifact
     @AliasFor(annotation = TestArtifact.class)
     long bytesSize() default 1000000;
 
-    LicenseConfig[] licenses() default {};
+    LicenseConfiguration[] licenses() default {};
 
 }


### PR DESCRIPTION
Issue 1724: Make it possible to specify the license types of Maven test artifacts

Renamed `LicenseConfig` to `LicenseConfiguration`

# Pull Request Description

This pull request is a cleanup/follow-up of #1724 , #1732 .

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
