### PR TITLE
Issue 1739: Re-work the NugetArtifactControllerTest to not replace the System.out

### DIFF
--- a/strongbox-aql/pom.xml
+++ b/strongbox-aql/pom.xml
@@ -137,6 +137,13 @@
             <artifactId>strongbox-storage-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${version.groovy}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/nuget/NugetArtifactControllerTest.java
@@ -232,37 +232,29 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
 
         // We need to mute `System.out` here manually because response body logging hardcoded in current version of
         // RestAssured, and we can not change it using configuration (@see `RestAssuredResponseOptionsGroovyImpl.peek(...)`).
-        PrintStream originalSysOut = muteSystemOutput();
-        try
-        {
-            // Get1
-            url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/download/{artifactId}/{artifactVersion}";
-            mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
-                   .when()
-                   .get(url, storageId, repositoryId, packageId, packageVersion)
-                   .then()
-                   .log().status()
-                   .log().headers()
-                   .statusCode(HttpStatus.OK.value())
-                   .assertThat()
-                   .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
+        // Get1
+        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/download/{artifactId}/{artifactVersion}";
+        mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
+               .when()
+               .get(url, storageId, repositoryId, packageId, packageVersion)
+               .then()
+               .log().status()
+               .log().headers()
+               .statusCode(HttpStatus.OK.value())
+               .assertThat()
+               .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
 
-            // Get2
-            url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}/{artifactVersion}";
-            mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
-                   .when()
-                   .get(url, storageId, repositoryId, packageId, packageVersion)
-                   .then()
-                   .log().status()
-                   .log().headers()
-                   .statusCode(HttpStatus.OK.value())
-                   .assertThat()
-                   .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
-        }
-        finally
-        {
-            System.setOut(originalSysOut);
-        }
+        // Get2
+        url = getContextBaseUrl() + "/storages/{storageId}/{repositoryId}/{artifactId}/{artifactVersion}";
+        mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
+               .when()
+               .get(url, storageId, repositoryId, packageId, packageVersion)
+               .then()
+               .log().status()
+               .log().headers()
+               .statusCode(HttpStatus.OK.value())
+               .assertThat()
+               .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(packageSize)));
     }
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
@@ -312,25 +304,6 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
                .and()
                .assertThat()
                .body("feed.entry[0].title", equalTo(packageId));
-    }
-
-    /**
-     * Mute the system output to avoid malicious logging (binary content for example).
-     *
-     * @return
-     */
-    private PrintStream muteSystemOutput()
-    {
-        PrintStream original = System.out;
-        System.setOut(new PrintStream(new OutputStream()
-        {
-            public void write(int b)
-            {
-                //DO NOTHING
-            }
-        }));
-
-        return original;
     }
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
@@ -521,24 +494,16 @@ public class NugetArtifactControllerTest extends NugetRestAssuredBaseTest
         assertThat(artifactEntry).isInstanceOf(RemoteArtifactEntry.class);
         assertThat(((RemoteArtifactEntry)artifactEntry).getIsCached()).isFalse();
 
-        PrintStream originalSysOut = muteSystemOutput();
-        try
-        {
-            url = getContextBaseUrl() + "/storages/public/nuget-group/package/{artifactId}/{artifactVersion}";
-            mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
-                   .when()
-                   .get(url, packageId, packageVersion)
-                   .then()
-                   .log().status()
-                   .log().headers()
-                   .statusCode(HttpStatus.OK.value())
-                   .assertThat()
-                   .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(1499857)));
-        }
-        finally
-        {
-            System.setOut(originalSysOut);
-        }
+        url = getContextBaseUrl() + "/storages/public/nuget-group/package/{artifactId}/{artifactVersion}";
+        mockMvc.header(HttpHeaders.USER_AGENT, "NuGet/*")
+               .when()
+               .get(url, packageId, packageVersion)
+               .then()
+               .log().status()
+               .log().headers()
+               .statusCode(HttpStatus.OK.value())
+               .assertThat()
+               .header(HttpHeaders.CONTENT_LENGTH, equalTo(String.valueOf(1499857)));
     }
 
     @Test


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1739 .

* Removed the hijacking of the `System.out`.
* Added the `groovy-all` dependency to the `strongbox-aql`, so that the build in IntelliJ would pass.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
