### PR TITLE
Disabling neo4j health check to fix Actuator End Point Test

### DIFF
--- a/strongbox-commons/src/main/resources/application.yaml
+++ b/strongbox-commons/src/main/resources/application.yaml
@@ -64,6 +64,9 @@ ehcache:
     store:
       dir: ${strongbox.vault}/cache
 management:
+  health:
+    neo4j:
+      enabled: false
   endpoint:
     health:
       show-details: always

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ActuatorEndpointControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/ActuatorEndpointControllerTest.java
@@ -9,7 +9,6 @@ import javax.inject.Inject;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,7 +24,6 @@ import static org.hamcrest.Matchers.notNullValue;
  * @author: adavid9
  */
 @IntegrationTest
-@Disabled
 public class ActuatorEndpointControllerTest
         extends RestAssuredBaseTest
 {
@@ -112,7 +110,6 @@ public class ActuatorEndpointControllerTest
     @ParameterizedTest
     @ValueSource(strings = { "/",
                              "/health",
-                             "/health/db",
                              "/info",
                              "/beans",
                              "/metrics",


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1742

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
