### PR TITLE
Issue 1723/1724: Make it possible to specify the license types of test artifacts

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -44,11 +44,10 @@ public interface ArtifactGenerator
                           long size)
         throws IOException;
 
-    default void copyLicenseFile(LicenseConfiguration licenseConfiguration, OutputStream os)
+    default void copyLicenseFile(String licenseFileSourcePath, OutputStream os)
             throws IOException
     {
-        ClassPathResource resource = new ClassPathResource(licenseConfiguration.license().getLicenseFileSourcePath(),
-                                                           this.getClass().getClassLoader());
+        ClassPathResource resource = new ClassPathResource(licenseFileSourcePath, this.getClass().getClassLoader());
 
         IOUtils.copy(resource.getInputStream(), os);
     }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenArtifactGeneratorStrategy.java
@@ -22,9 +22,9 @@ public class MavenArtifactGeneratorStrategy implements ArtifactGeneratorStrategy
         throws IOException
     {
         Object licenses = attributesMap.get("licenses");
-        if (licenses instanceof LicenseConfiguration[])
+        if (licenses instanceof MavenLicenseConfiguration[])
         {
-            artifactGenerator.setLicenses((LicenseConfiguration[]) licenses);
+            artifactGenerator.setLicenses((MavenLicenseConfiguration[]) licenses);
         }
 
         Path result;

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenLicenseConfiguration.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenLicenseConfiguration.java
@@ -1,0 +1,27 @@
+package org.carlspring.strongbox.testing.artifact;
+
+import java.lang.annotation.*;
+
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * This annotation helps configure license details for test artifacts.
+ *
+ * @author carlspring
+ */
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@LicenseConfiguration
+public @interface MavenLicenseConfiguration
+{
+
+    @AliasFor(annotation = LicenseConfiguration.class)
+    LicenseType license() default LicenseType.NONE;
+
+    @AliasFor(annotation = LicenseConfiguration.class)
+    String destinationPath() default "LICENSE";
+
+    boolean generateManifestEntry() default true;
+
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/MavenTestArtifact.java
@@ -71,6 +71,6 @@ public @interface MavenTestArtifact
     @AliasFor(annotation = TestArtifact.class)
     long bytesSize() default 1000000;
 
-    LicenseConfiguration[] licenses() default {};
+    MavenLicenseConfiguration[] licenses() default {};
 
 }

--- a/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/util/TestFileUtils.java
+++ b/strongbox-testing/strongbox-testing-core/src/main/java/org/carlspring/strongbox/util/TestFileUtils.java
@@ -2,9 +2,7 @@ package org.carlspring.strongbox.util;
 
 import org.carlspring.commons.io.RandomInputStream;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.zip.ZipEntry;
@@ -44,7 +42,7 @@ public class TestFileUtils
         ZipEntry ze = new ZipEntry(name);
         zos.putNextEntry(ze);
 
-        try(RandomInputStream ris = new RandomInputStream(bytesSize))
+        try (RandomInputStream ris = new RandomInputStream(bytesSize))
         {
             byte[] buffer = new byte[4096];
             int len;
@@ -53,6 +51,7 @@ public class TestFileUtils
                 zos.write(buffer, 0, len);
             }
         }
+
         zos.closeEntry();
     }
 
@@ -63,7 +62,7 @@ public class TestFileUtils
         bos.write("data = \"".getBytes(StandardCharsets.UTF_8));
 
         OutputStream dataOut = Base64.getEncoder().wrap(bos);
-        try(RandomInputStream ris = new RandomInputStream(bytesSize))
+        try (RandomInputStream ris = new RandomInputStream(bytesSize))
         {
             byte[] buffer = new byte[4096];
             int len;
@@ -72,6 +71,24 @@ public class TestFileUtils
                 dataOut.write(buffer, 0, len);
             }
         }
+
         bos.write("\";".getBytes(StandardCharsets.UTF_8));
     }
+
+    public static void generateFile(File file,
+                                    long bytesSize)
+            throws IOException
+    {
+        OutputStream os = new FileOutputStream(file);
+        try (RandomInputStream ris = new RandomInputStream(bytesSize))
+        {
+            byte[] buffer = new byte[4096];
+            int len;
+            while ((len = ris.read(buffer)) > 0)
+            {
+                os.write(buffer, 0, len);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
# Pull Request Description

* Maven test artifact improvements.

This pull request relates to #1723 , #1724 .

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
