### PR TITLE
Change the name of greet method to checkRepositoryAccess

### DIFF
--- a/strongbox-security/strongbox-user-management/src/main/resources/etc/conf/strongbox-security-users.yaml
+++ b/strongbox-security/strongbox-user-management/src/main/resources/etc/conf/strongbox-security-users.yaml
@@ -1,12 +1,12 @@
 users:
   user:
     - username: admin
-      password: "{bcrypt}$2a$10$WqtVx7Iio0cndyR1lEaKW.SWhUYmF/zHHG5hkAXvH5hUmklM7QfMO"
+      password: "$2a$10$zN21vv4YvRQJPvY7D28ewOnHE5MHWXerHLHkZDyjCCH2Ji4ThewLC"
       roles:
         - ADMIN
       securityTokenKey: admin-secret
     - username: deployer
-      password: "{bcrypt}$2a$10$WqtVx7Iio0cndyR1lEaKW.SWhUYmF/zHHG5hkAXvH5hUmklM7QfMO"
+      password: "$2a$10$QoRL1hvufz1yQCCTF/ZbUuxc108D4HXG80Kob6Xq1S0jDIpusWazG"
       roles:
         - UI_MANAGER
         - ARTIFACTS_MANAGER

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
@@ -8,7 +8,8 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.InputStream;
-
+import java.net.HttpURLConnection;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -55,4 +56,8 @@ public abstract class BaseArtifactController
         return true;
     }
 
+    public ResponseEntity checkRepositoryAccess()
+    {
+        return new ResponseEntsity<>("success", HttpStatus.OK);
+    }
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactController.java
@@ -2,6 +2,7 @@ package org.carlspring.strongbox.controllers.layout.maven;
 
 import org.carlspring.strongbox.artifact.coordinates.MavenArtifactCoordinates;
 import org.carlspring.strongbox.controllers.BaseArtifactController;
+import org.carlspring.strongbox.controllers.support.ResponseEntityBody;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.storage.ArtifactStorageException;
 import org.carlspring.strongbox.storage.repository.Repository;
@@ -49,10 +50,9 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public class MavenArtifactController
         extends BaseArtifactController
 {
-
     @PreAuthorize("authenticated")
-    @RequestMapping(value = "greet", method = RequestMethod.GET)
-    public ResponseEntity greet()
+    @RequestMapping(value = "/{storageId}/{repositoryId}/", method = RequestMethod.GET)
+    public ResponseEntity checkRepositoryAccess()
     {
         return new ResponseEntity<>("success", HttpStatus.OK);
     }


### PR DESCRIPTION
# Pull Request Description
I change the name of greet method to checkRepositoryAccess and make same method in BaseArtifactController so this method can be override in other controllers. 
This pull request closes #1684 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
