### PR TITLE
Issue 1789: Repositories generated using the @MavenRepository do not set the basedir variable (against issue-1649)

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/repository/RawRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/repository/RawRepositoryManagementTest.java
@@ -1,0 +1,59 @@
+package org.carlspring.strongbox.testing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.carlspring.strongbox.StorageApiTestConfig;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.NullLayoutProvider;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author ankit.tomar
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = StorageApiTestConfig.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class RawRepositoryManagementTest
+{
+
+    private static final String RAW_STORAGE = "raw-storage-to-be-injected";
+
+    private static final String RAW_REPOSITORY = "rwa-repository-to-be-injected";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjected(@NullRepository(repositoryId = RAW_REPOSITORY,
+                                                                    storageId = RAW_STORAGE)
+                                                    Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(RAW_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo(RAW_STORAGE);
+        assertThat(repository.getStorage().getBasedir()).isNotNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NullLayoutProvider.ALIAS);
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjectedWithDefaultStorage(@NullRepository(repositoryId = RAW_REPOSITORY) Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(RAW_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage0");
+        assertThat(repository.getStorage().getBasedir()).isNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NullLayoutProvider.ALIAS);
+    }
+}

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/repository/RawRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/repository/RawRepositoryManagementTest.java
@@ -25,14 +25,14 @@ import org.springframework.test.context.ContextConfiguration;
 public class RawRepositoryManagementTest
 {
 
-    private static final String RAW_STORAGE = "raw-storage-to-be-injected";
+    private static final String RAW_STORAGE = "rrmt-storage";
 
-    private static final String RAW_REPOSITORY = "rwa-repository-to-be-injected";
+    private static final String RAW_REPOSITORY = "rrmt-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testValidRepositoryShouldBeInjected(@NullRepository(repositoryId = RAW_REPOSITORY,
-                                                                    storageId = RAW_STORAGE)
+    public void testValidRepositoryShouldBeInjected(@NullRepository(storageId = RAW_STORAGE,
+                                                                    repositoryId = RAW_REPOSITORY)
                                                     Repository repository)
     {
         assertThat(repository).isNotNull();

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/storage/repository/TestRepositoryContext.java
@@ -1,5 +1,6 @@
 package org.carlspring.strongbox.testing.storage.repository;
 
+import org.carlspring.strongbox.booters.PropertiesBooter;
 import org.carlspring.strongbox.providers.io.RepositoryPath;
 import org.carlspring.strongbox.providers.io.RepositoryPathResolver;
 import org.carlspring.strongbox.repository.RepositoryManagementStrategyException;
@@ -58,8 +59,9 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
 
     private final StorageManagementService storageManagementService;
 
-    private boolean opened;
+    private final PropertiesBooter propertiesBooter;
 
+    private boolean opened;
 
     public TestRepositoryContext(TestRepository testRepository,
                                  Remote remoteRepository,
@@ -68,7 +70,8 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
                                  ConfigurationManagementService configurationManagementService,
                                  RepositoryPathResolver repositoryPathResolver,
                                  RepositoryManagementService repositoryManagementService,
-                                 StorageManagementService storageManagementService)
+                                 StorageManagementService storageManagementService,
+                                 PropertiesBooter propertiesBooter)
             throws IOException,
                    RepositoryManagementStrategyException
     {
@@ -80,6 +83,7 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         this.repositoryPathResolver = repositoryPathResolver;
         this.repositoryManagementService = repositoryManagementService;
         this.storageManagementService = storageManagementService;
+        this.propertiesBooter = propertiesBooter;
 
         open();
     }
@@ -141,6 +145,10 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
         repository.setLayout(testRepository.layout());
         repository.setPolicy(testRepository.policy().toString());
 
+        String storageBaseDir = Optional.ofNullable(storage.getBasedir())
+                                        .orElse(getStorageBaseDirectory(storage.getId()));
+        repository.setBasedir(getRepositoryBaseDirectory(storageBaseDir, repository.getId()));
+
         Optional.ofNullable(remoteRepository).ifPresent(r -> {
             repository.setType(RepositoryTypeEnum.PROXY.getType());
 
@@ -195,6 +203,12 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
                      id(testRepository));
     }
 
+    private String getRepositoryBaseDirectory(String storageBaseDir,
+                                              String repositoryId)
+    {
+        return String.format("%s/%s", storageBaseDir, repositoryId);
+    }
+
     private List<MutableRoutingRuleRepository> routingRepositories(String[] repositories)
     {
         return Arrays.stream(repositories).map(MutableRoutingRuleRepository::new).collect(Collectors.toList());
@@ -219,11 +233,17 @@ public class TestRepositoryContext implements AutoCloseable, Comparable<TestRepo
             throws IOException
     {
         StorageDto newStorage = new StorageDto(testRepository.storageId());
+        newStorage.setBasedir(getStorageBaseDirectory(testRepository.storageId()));
         configurationManagementService.addStorageIfNotExists(newStorage);
 
         storageManagementService.saveStorage(newStorage);
 
         return configurationManagementService.getConfiguration().getStorage(testRepository.storageId());
+    }
+
+    private String getStorageBaseDirectory(String storageId)
+    {
+        return String.format("%s/%s", propertiesBooter.getStorageBooterBasedir(), storageId);
     }
 
     @PreDestroy

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepositoryManagementTest.java
@@ -1,0 +1,59 @@
+package org.carlspring.strongbox.testing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.carlspring.strongbox.config.Maven2LayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.layout.Maven2LayoutProvider;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author ankit.tomar
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = Maven2LayoutProviderTestConfig.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class MavenRepositoryManagementTest
+{
+
+    private static final String MAVEN_STORAGE = "maven-storage-to-be-injected";
+
+    private static final String MAVEN_REPOSITORY = "maven-repository-to-be-injected";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjected(@MavenRepository(repositoryId = MAVEN_REPOSITORY,
+                                                                     storageId = MAVEN_STORAGE)
+                                                    Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(MAVEN_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo(MAVEN_STORAGE);
+        assertThat(repository.getStorage().getBasedir()).isNotNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(Maven2LayoutProvider.ALIAS);
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjectedWithDefaultStorage(@MavenRepository(repositoryId = MAVEN_REPOSITORY) Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(MAVEN_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage0");
+        assertThat(repository.getStorage().getBasedir()).isNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(Maven2LayoutProvider.ALIAS);
+    }
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/MavenRepositoryManagementTest.java
@@ -25,14 +25,14 @@ import org.springframework.test.context.ContextConfiguration;
 public class MavenRepositoryManagementTest
 {
 
-    private static final String MAVEN_STORAGE = "maven-storage-to-be-injected";
+    private static final String MAVEN_STORAGE = "mrmt-storage";
 
-    private static final String MAVEN_REPOSITORY = "maven-repository-to-be-injected";
+    private static final String MAVEN_REPOSITORY = "mrmt-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testValidRepositoryShouldBeInjected(@MavenRepository(repositoryId = MAVEN_REPOSITORY,
-                                                                     storageId = MAVEN_STORAGE)
+    public void testValidRepositoryShouldBeInjected(@MavenRepository(storageId = MAVEN_STORAGE,
+                                                                     repositoryId = MAVEN_REPOSITORY)
                                                     Repository repository)
     {
         assertThat(repository).isNotNull();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NpmRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NpmRepositoryManagementTest.java
@@ -1,0 +1,59 @@
+package org.carlspring.strongbox.testing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.carlspring.strongbox.config.NpmLayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.layout.NpmLayoutProvider;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author ankit.tomar
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = NpmLayoutProviderTestConfig.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class NpmRepositoryManagementTest
+{
+
+    private static final String NPM_STORAGE = "npm-storage-to-be-injected";
+
+    private static final String NPM_REPOSITORY = "npm-repository-to-be-injected";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjected(@NpmRepository(repositoryId = NPM_REPOSITORY,
+                                                                   storageId = NPM_STORAGE)
+                                                    Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(NPM_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo(NPM_STORAGE);
+        assertThat(repository.getStorage().getBasedir()).isNotNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NpmLayoutProvider.ALIAS);
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjectedWithDefaultStorage(@NpmRepository(repositoryId = NPM_REPOSITORY) Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(NPM_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage-npm");
+        assertThat(repository.getStorage().getBasedir()).isNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NpmLayoutProvider.ALIAS);
+    }
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NpmRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NpmRepositoryManagementTest.java
@@ -25,14 +25,14 @@ import org.springframework.test.context.ContextConfiguration;
 public class NpmRepositoryManagementTest
 {
 
-    private static final String NPM_STORAGE = "npm-storage-to-be-injected";
+    private static final String NPM_STORAGE = "nrmt-storage";
 
-    private static final String NPM_REPOSITORY = "npm-repository-to-be-injected";
+    private static final String NPM_REPOSITORY = "nrmt-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testValidRepositoryShouldBeInjected(@NpmRepository(repositoryId = NPM_REPOSITORY,
-                                                                   storageId = NPM_STORAGE)
+    public void testValidRepositoryShouldBeInjected(@NpmRepository(storageId = NPM_STORAGE,
+                                                                   repositoryId = NPM_REPOSITORY)
                                                     Repository repository)
     {
         assertThat(repository).isNotNull();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NugetRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NugetRepositoryManagementTest.java
@@ -25,14 +25,14 @@ import org.springframework.test.context.ContextConfiguration;
 public class NugetRepositoryManagementTest
 {
 
-    private static final String NUGET_STORAGE = "nuget-storage-to-be-injected";
+    private static final String NUGET_STORAGE = "nurmt-storage";
 
-    private static final String NUGET_REPOSITORY = "nuget-repository-to-be-injected";
+    private static final String NUGET_REPOSITORY = "nurmt-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testValidRepositoryShouldBeInjected(@NugetRepository(repositoryId = NUGET_REPOSITORY,
-                                                                     storageId = NUGET_STORAGE)
+    public void testValidRepositoryShouldBeInjected(@NugetRepository(storageId = NUGET_STORAGE,
+                                                                     repositoryId = NUGET_REPOSITORY)
                                                     Repository repository)
     {
         assertThat(repository).isNotNull();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NugetRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/NugetRepositoryManagementTest.java
@@ -1,0 +1,59 @@
+package org.carlspring.strongbox.testing.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.carlspring.strongbox.config.NugetLayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.layout.NugetLayoutProvider;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author ankit.tomar
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@ContextConfiguration(classes = NugetLayoutProviderTestConfig.class)
+@Execution(ExecutionMode.CONCURRENT)
+public class NugetRepositoryManagementTest
+{
+
+    private static final String NUGET_STORAGE = "nuget-storage-to-be-injected";
+
+    private static final String NUGET_REPOSITORY = "nuget-repository-to-be-injected";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjected(@NugetRepository(repositoryId = NUGET_REPOSITORY,
+                                                                     storageId = NUGET_STORAGE)
+                                                    Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(NUGET_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo(NUGET_STORAGE);
+        assertThat(repository.getStorage().getBasedir()).isNotNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NugetLayoutProvider.ALIAS);
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjectedWithDefaultStorage(@NugetRepository(repositoryId = NUGET_REPOSITORY) Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(NUGET_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage-nuget");
+        assertThat(repository.getStorage().getBasedir()).isNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(NugetLayoutProvider.ALIAS);
+    }
+}

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryManagementTest.java
@@ -24,14 +24,14 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ContextConfiguration(classes = PypiLayoutProviderTestConfig.class)
 public class PypiRepositoryManagementTest
 {
-    private static final String PYPI_STORAGE = "pypi-storage-to-be-injected";
+    private static final String PYPI_STORAGE = "prmt-storage";
 
-    private static final String PYPI_REPOSITORY = "pypi-repository-to-be-injected";
+    private static final String PYPI_REPOSITORY = "prmt-releases";
 
     @ExtendWith({ RepositoryManagementTestExecutionListener.class })
     @Test
-    public void testValidRepositoryShouldBeInjected(@PypiTestRepository(repositoryId = PYPI_REPOSITORY,
-                                                                        storageId = PYPI_STORAGE) 
+    public void testValidRepositoryShouldBeInjected(@PypiTestRepository(storageId = PYPI_STORAGE,
+                                                                        repositoryId = PYPI_REPOSITORY) 
                                                     Repository repository)
     {
         assertThat(repository).isNotNull();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryManagementTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryManagementTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 @ActiveProfiles(profiles = "test")
 @Execution(CONCURRENT)
 @ContextConfiguration(classes = PypiLayoutProviderTestConfig.class)
-public class PypiRepositoryTest
+public class PypiRepositoryManagementTest
 {
     private static final String PYPI_STORAGE = "pypi-storage-to-be-injected";
 
@@ -52,7 +52,7 @@ public class PypiRepositoryTest
         assertThat(repository.getBasedir()).isNotNull();
         assertThat(repository.getStorage()).isNotNull();
         assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage0");
-        assertThat(repository.getStorage().getBasedir()).isNull(); // it will be null as storage basedor is present in strongbox.yaml
+        assertThat(repository.getStorage().getBasedir()).isNull(); // it will be null as storage baseDir is not present in strongbox.yaml
         assertThat(repository.getLayout()).isNotNull().isEqualTo(PypiLayoutProvider.ALIAS);
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/repository/PypiRepositoryTest.java
@@ -1,0 +1,58 @@
+package org.carlspring.strongbox.testing.repository;
+
+import org.carlspring.strongbox.config.PypiLayoutProviderTestConfig;
+import org.carlspring.strongbox.providers.layout.PypiLayoutProvider;
+import org.carlspring.strongbox.storage.repository.Repository;
+import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+/**
+ * @author ankit.tomar
+ */
+@SpringBootTest
+@ActiveProfiles(profiles = "test")
+@Execution(CONCURRENT)
+@ContextConfiguration(classes = PypiLayoutProviderTestConfig.class)
+public class PypiRepositoryTest
+{
+    private static final String PYPI_STORAGE = "pypi-storage-to-be-injected";
+
+    private static final String PYPI_REPOSITORY = "pypi-repository-to-be-injected";
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjected(@PypiTestRepository(repositoryId = PYPI_REPOSITORY,
+                                                                        storageId = PYPI_STORAGE) 
+                                                    Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(PYPI_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo(PYPI_STORAGE);
+        assertThat(repository.getStorage().getBasedir()).isNotNull();
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(PypiLayoutProvider.ALIAS);
+    }
+
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class })
+    @Test
+    public void testValidRepositoryShouldBeInjectedWithDefaultStorage(@PypiTestRepository(repositoryId = PYPI_REPOSITORY) Repository repository)
+    {
+        assertThat(repository).isNotNull();
+        assertThat(repository.getId()).isNotNull().isEqualTo(PYPI_REPOSITORY);
+        assertThat(repository.getBasedir()).isNotNull();
+        assertThat(repository.getStorage()).isNotNull();
+        assertThat(repository.getStorage().getId()).isNotNull().isEqualTo("storage0");
+        assertThat(repository.getStorage().getBasedir()).isNull(); // it will be null as storage basedor is present in strongbox.yaml
+        assertThat(repository.getLayout()).isNotNull().isEqualTo(PypiLayoutProvider.ALIAS);
+    }
+}


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1789 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
