### PR TITLE
Fixing RawArtifactControllerTestIT failure due to slackbuild.org outage

### DIFF
--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/raw/RawArtifactControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/layout/raw/RawArtifactControllerTestIT.java
@@ -29,7 +29,7 @@ public class RawArtifactControllerTestIT
 
     private static final String REPOSITORY_GROUP = "ractit-raw-group";
 
-    private static final String REMOTE_URL = "http://slackbuilds.org/slackbuilds/14.2/";
+    private static final String REMOTE_URL = "https://github.com/strongbox/strongbox";
 
     @Override
     @BeforeEach
@@ -79,7 +79,7 @@ public class RawArtifactControllerTestIT
     {
         final String storageId = repository.getStorage().getId();
         final String repositoryId = repository.getId();
-        final String pathStr = "system/alien.tar.gz";
+        final String pathStr = "blob/master/ICLA.md";
 
         String artifactPath = String.format("/storages/%s/%s/%s", storageId, repositoryId, pathStr);
         resolveArtifact(artifactPath);


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1801 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
