### PR TITLE
Issue 1684: Add default impl for checkRepositoryAccess

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/BaseArtifactController.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 public abstract class BaseArtifactController
@@ -53,6 +54,11 @@ public abstract class BaseArtifactController
         }
 
         return true;
+    }
+
+    public ResponseEntity<String> checkRepositoryAccess()
+    {
+        return new ResponseEntity<>("success", HttpStatus.OK);
     }
 
 }

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/maven/MavenArtifactController.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -51,10 +52,10 @@ public class MavenArtifactController
 {
 
     @PreAuthorize("authenticated")
-    @RequestMapping(value = "greet", method = RequestMethod.GET)
-    public ResponseEntity greet()
+    @GetMapping(value = "/{storageId}/{repositoryId}")
+    public ResponseEntity<String> checkRepositoryAccess()
     {
-        return new ResponseEntity<>("success", HttpStatus.OK);
+        return super.checkRepositoryAccess();
     }
 
     @ApiOperation(value = "Used to retrieve an artifact")
@@ -140,7 +141,7 @@ public class MavenArtifactController
 
             RepositoryPath srcPath = repositoryPathResolver.resolve(srcRepository, path);
             RepositoryPath destPath = repositoryPathResolver.resolve(destRepository, path);
-            
+
             artifactManagementService.copy(srcPath, destPath);
         }
         catch (ArtifactStorageException e)


### PR DESCRIPTION
# Pull Request Description

Things made:
- new endpoint `/{storageId}/{repositoryId}` instead of `greet` in `MavenArtifactController`
- default implementation of endpoint in `BaseArtifactController`

This pull request closes #1684

Other PR's which can be closes after this PR: #1805, #1770 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
