### PR TITLE
Issue/1683 Remove unsed greet method in NPM layer

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/controllers/layout/npm/NpmArtifactController.java
@@ -125,13 +125,6 @@ public class NpmArtifactController
     @Inject
     private NpmUnpublishService npmUnpublishService;
 
-    @GetMapping(path = { "{storageId}/{repositoryId}/npm" })
-    public ResponseEntity<String> greet()
-    {
-        // TODO: find out what NPM expect to receive here
-        return ResponseEntity.ok("");
-    }
-
     @GetMapping(path = "{storageId}/{repositoryId}/-/v1/search")
     @PreAuthorize("hasAuthority('ARTIFACTS_VIEW')")
     public void search(@RepositoryMapping Repository repository,


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1683 
Remove the unused greet method under the NPM layer.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
