### PR TITLE
Issue-1785 Pass jvm parameters to spring-boot and maven-compiler-plugin for JDK11

### DIFF
--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -288,7 +288,19 @@
                             <jvmSettings>
                                 <initialMemorySize>256</initialMemorySize>
                                 <maxMemorySize>1024</maxMemorySize>
-
+                                <extraArguments>
+                                    <extraArgument>
+                                        -Djdk.attach.allowAttachSelf=true
+                                    </extraArgument>
+                                    <extraArgument>--add-opens=java.base/java.lang.module=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.math=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.module=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=java.base/jdk.internal.util.jar=ALL-UNNAMED</extraArgument>
+                                    <extraArgument>--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED</extraArgument>
+                                </extraArguments>
                                 <systemProperties>
                                     <systemProperty>appserver.home=.</systemProperty>
                                     <systemProperty>appserver.base=%STRONGBOX_HOME%</systemProperty>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/ParallelDownloadRemoteArtifactTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/ParallelDownloadRemoteArtifactTest.java
@@ -23,7 +23,6 @@ import org.carlspring.strongbox.testing.repository.MavenRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 import org.carlspring.strongbox.testing.storage.repository.TestRepository.Remote;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.core.io.Resource;
@@ -32,7 +31,6 @@ import org.springframework.core.io.Resource;
  * @author sbespalov
  *
  */
-@Disabled
 public class ParallelDownloadRemoteArtifactTest
         extends MockedRestArtifactResolverTestBase
         implements ArtifactResolverContext

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -114,6 +114,9 @@
                         <logging.config>${project.build.directory}/strongbox/etc/logback-spring.xml</logging.config>
                         <logging.debug>true</logging.debug>
                     </systemPropertyVariables>
+                    <jvmArguments>
+                        -Djdk.attach.allowAttachSelf=true --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED --add-exports java.sql/java.sql=ALL-UNNAMED  --add-opens java.base/java.lang.module=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                    </jvmArguments>
                 </configuration>
 
                 <executions>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -51,6 +51,34 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <target>
+                        1.9
+                    </target>
+                    <compilerArgs>
+                        <arg>
+                            --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED 
+                        </arg>
+                        <arg>
+                            --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
+                        </arg>
+                        <arg>
+                            --add-exports=java.base/sun.nio.ch=ALL-UNNAMED 
+                        </arg>
+                        <arg>
+                            --add-exports=java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED 
+                        </arg>
+                        <arg>
+                            --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED 
+                        </arg>
+                        <arg>
+                            --add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED 
+                        </arg>
+                        <arg>
+                            --add-exports=java.sql/java.sql=ALL-UNNAMED 
+                        </arg>
+                    </compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -148,7 +176,6 @@
                 </plugins>
             </build>
         </profile>
-
         <profile>
             <id>java-11-build</id>
             <activation>
@@ -171,7 +198,7 @@
                             </systemPropertyVariables>
 
                             <jvmArguments>
-                                -Djdk.attach.allowAttachSelf=true --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED --add-exports java.sql/java.sql=ALL-UNNAMED  --add-opens java.base/java.lang.module=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                                --add-opens java.base/java.lang.module=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
                             </jvmArguments>
                         </configuration>
 
@@ -193,6 +220,7 @@
                 </plugins>
             </build>
         </profile>
+ 
     </profiles>
 
     <dependencies>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -103,39 +103,97 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
-                    <systemPropertyVariables>
-                        <strongbox.basedir>${project.build.directory}</strongbox.basedir>
-                        <logging.config>${project.build.directory}/strongbox/etc/logback-spring.xml</logging.config>
-                        <logging.debug>true</logging.debug>
-                    </systemPropertyVariables>
-                    <jvmArguments>
-                        -Djdk.attach.allowAttachSelf=true --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED --add-exports java.sql/java.sql=ALL-UNNAMED  --add-opens java.base/java.lang.module=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-                    </jvmArguments>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>spring-boot-repackage</id>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                        <phase>package</phase>
-
-                        <configuration>
-                            <classifier>spring-boot</classifier>
-                            <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>java-8-build</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>8</value>
+                </property>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
+                            <systemPropertyVariables>
+                                <strongbox.basedir>${project.build.directory}</strongbox.basedir>
+                                <logging.config>${project.build.directory}/strongbox/etc/logback-spring.xml</logging.config>
+                                <logging.debug>true</logging.debug>
+                            </systemPropertyVariables>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>spring-boot-repackage</id>
+                                <goals>
+                                    <goal>repackage</goal>
+                                </goals>
+                                <phase>package</phase>
+
+                                <configuration>
+                                    <classifier>spring-boot</classifier>
+                                    <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>java-11-build</id>
+            <activation>
+                <property>
+                    <name>jdk.version</name>
+                    <value>11</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
+                            <systemPropertyVariables>
+                                <strongbox.basedir>${project.build.directory}</strongbox.basedir>
+                                <logging.config>${project.build.directory}/strongbox/etc/logback-spring.xml</logging.config>
+                                <logging.debug>true</logging.debug>
+                            </systemPropertyVariables>
+
+                            <jvmArguments>
+                                -Djdk.attach.allowAttachSelf=true --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED --add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports java.rmi/sun.rmi.server=ALL-UNNAMED --add-exports java.sql/java.sql=ALL-UNNAMED  --add-opens java.base/java.lang.module=ALL-UNNAMED --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-opens java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED --add-opens java.base/jdk.internal.math=ALL-UNNAMED --add-opens java.base/jdk.internal.module=ALL-UNNAMED --add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                            </jvmArguments>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>spring-boot-repackage</id>
+                                <goals>
+                                    <goal>repackage</goal>
+                                </goals>
+                                <phase>package</phase>
+
+                                <configuration>
+                                    <classifier>spring-boot</classifier>
+                                    <mainClass>org.carlspring.strongbox.app.StrongboxSpringBootApplication</mainClass>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <dependencies>
         <!-- Strongbox dependencies -->


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1785 

Based on the issue, currently the web server needs extra parameter to run. This PR put those parameters in the `pom.xml` file.

1. Those `--add-exports` parameters are compiler parameters - so they are placed under `maven-compiler-plugin`.
2. Those `--add-opens` parameters are jvm arguments and should be used at run-time, so they are placed under the `spring-boot` and `appassembler-maven-plugin` 

So now, we can start the web server directly by using `mvn spring-boot:run -P java-11-build`. 

One issue this is causing is the assembled script is getting the following errors, not sure what is the cause atm:
![Clipboard - August 29, 2020 9_15 PM](https://user-images.githubusercontent.com/29245119/91637179-e42eb580-ea49-11ea-8199-e3c98e09edd4.png)


/cc @anki2189 @steve-todorov 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
