### PR TITLE
Fixed `hibernate-validator` error message evaluation vulnerability

### DIFF
--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/validation/cron/CronTaskConfigurationFormValidator.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/validation/cron/CronTaskConfigurationFormValidator.java
@@ -13,7 +13,10 @@ import org.carlspring.strongbox.validation.cron.type.CronTaskConfigurationFormFi
 import javax.inject.Inject;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.quartz.CronExpression;
@@ -133,7 +136,7 @@ public class CronTaskConfigurationFormValidator
             if (!cronTaskConfigurationFormFieldTypeValidator.isValid(formFieldValue))
             {
                 context.buildConstraintViolationWithTemplate(
-                        String.format("Invalid value [%s] type provided. [%s] was expected.", formFieldValue,
+                        String.format("Invalid value [%s] type provided. [%s] was expected.", escapeMessageValue(formFieldValue),
                                       definitionFieldType))
                        .addPropertyNode("fields")
                        .addPropertyNode("value")
@@ -152,7 +155,7 @@ public class CronTaskConfigurationFormValidator
                 {
                     context.buildConstraintViolationWithTemplate(
                             String.format("Invalid value [%s] provided. Possible values do not contain this value.",
-                                          formFieldValue))
+                                          escapeMessageValue(formFieldValue)))
                            .addPropertyNode("fields")
                            .addPropertyNode("value")
                            .inIterable().atIndex(correspondingFormFieldIndex)
@@ -165,6 +168,11 @@ public class CronTaskConfigurationFormValidator
         }
 
         return isValid;
+    }
+
+    private String escapeMessageValue(String value)
+    {
+        return Arrays.stream(value.split("\\$")).collect(Collectors.joining("\\$"));
     }
 
     private CronJobDefinition getCorrespondingCronJobDefinition(CronTaskConfigurationForm form,


### PR DESCRIPTION
# Pull Request Description

Fixed possible vulnerability with validation error messages evaluation.

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
