### PR TITLE
Issue 1835: Add documentation on how to upgrade dependencies and plugins

### DIFF
--- a/.github/ISSUE_TEMPLATE/dependency-or-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/dependency-or-plugin-upgrade.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Task Description
 
-We need to upgrade `` to version ``.
+We need to upgrade `com.foo:bar` to version `1.2.3`.
 
 # Tasks
 

--- a/.github/ISSUE_TEMPLATE/dependency-or-plugin-upgrade.md
+++ b/.github/ISSUE_TEMPLATE/dependency-or-plugin-upgrade.md
@@ -1,0 +1,46 @@
+---
+name: Dependency or Plugin Upgrade Task
+about: Template for creating dependency, or plugin upgrade tasks
+title: ''
+labels: 'dependency-upgrade'
+assignees: ''
+
+---
+
+# Task Description
+
+We need to upgrade `` to version ``.
+
+# Tasks
+
+The following tasks will need to be carried out:
+* [ ] Update the version in the [strongbox-parent] project.
+* [ ] Test and confirm that there are no issues with the core projects ([strongbox], [strongbox-web-integration-tests], etc) after upgrading.
+
+# Task Relationships
+
+This task:
+* Is a sub-task of: 
+* Depends on: 
+* Is a follow-up of: 
+* Relates to:
+
+# Useful Links
+
+* [link1]()
+* [link2]()
+* [link3]()
+
+# Help
+
+* Check our article on [how to upgrade dependencies and plugins].
+* [Our chat](https://chat.carlspring.org/)
+* Points of contact:
+  * @carlspring
+  * @sbespalov
+  * @steve-todorov
+
+[strongbox]: https://github.com/strongbox/strongbox/
+[strongbox-parent]: https://github.com/strongbox/strongbox-parent/
+[strongbox-web-integration-tests]: https://github.com/strongbox/strongbox-web-integration-tests/
+[how to upgrade dependencies and plugins]: https://strongbox.github.io/developer-guide/upgrading-dependencies-and-plugins.html


### PR DESCRIPTION
Added a template.

# Pull Request Description

This pull request closes #1835 .

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
