### PR TITLE
Upgrade maven-assembly plugin from 3.1.1 to 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-aql/pom.xml
+++ b/strongbox-aql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-client/pom.xml
+++ b/strongbox-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-configuration/pom.xml
+++ b/strongbox-configuration/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/pom.xml
+++ b/strongbox-cron/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/strongbox-cron-api/pom.xml
+++ b/strongbox-cron/strongbox-cron-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/strongbox-cron-tasks/pom.xml
+++ b/strongbox-cron/strongbox-cron-tasks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-data-service/pom.xml
+++ b/strongbox-data-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-event-api/pom.xml
+++ b/strongbox-event-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-resources/pom.xml
+++ b/strongbox-resources/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
     

--- a/strongbox-resources/strongbox-common-resources/pom.xml
+++ b/strongbox-resources/strongbox-common-resources/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-resources/strongbox-storage-api-resources/pom.xml
+++ b/strongbox-resources/strongbox-storage-api-resources/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-rest-client/pom.xml
+++ b/strongbox-rest-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/pom.xml
+++ b/strongbox-security/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-api/pom.xml
+++ b/strongbox-security/strongbox-authentication-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-registry/pom.xml
+++ b/strongbox-security/strongbox-authentication-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-support/pom.xml
+++ b/strongbox-security/strongbox-authentication-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-security-api/pom.xml
+++ b/strongbox-security/strongbox-security-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-user-management/pom.xml
+++ b/strongbox-security/strongbox-user-management/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/pom.xml
+++ b/strongbox-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-api/pom.xml
+++ b/strongbox-storage/strongbox-storage-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-core/pom.xml
+++ b/strongbox-storage/strongbox-storage-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/pom.xml
@@ -7,7 +7,7 @@
 <parent>
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
     <relativePath/>
 </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-testing/pom.xml
+++ b/strongbox-testing/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
     

--- a/strongbox-testing/strongbox-testing-core/pom.xml
+++ b/strongbox-testing/strongbox-testing-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
     

--- a/strongbox-testing/strongbox-testing-web/pom.xml
+++ b/strongbox-testing/strongbox-testing-web/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
     

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-web-forms/pom.xml
+++ b/strongbox-web-forms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1877-upgd-dep-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1877 

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see strongbox/strongbox-parent#81
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No
