### PR TITLE
Issue 1856: Upgrade awaitility dependencies from 3.1.2 to 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -98,7 +98,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>checkstyle</id>
 

--- a/strongbox-aql/pom.xml
+++ b/strongbox-aql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>
-            <scope>provided</scope>   
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/strongbox-client/pom.xml
+++ b/strongbox-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-commons/pom.xml
+++ b/strongbox-commons/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-configuration/pom.xml
+++ b/strongbox-configuration/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/pom.xml
+++ b/strongbox-cron/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/strongbox-cron-api/pom.xml
+++ b/strongbox-cron/strongbox-cron-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-cron/strongbox-cron-tasks/pom.xml
+++ b/strongbox-cron/strongbox-cron-tasks/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
     <artifactId>strongbox-cron-tasks</artifactId>
     <version>1.0-SNAPSHOT</version>
-    
+
     <name>Strongbox: Cron [Tasks]</name>
 
     <inceptionYear>2019</inceptionYear>
@@ -147,7 +147,7 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>spring-mock-mvc</artifactId>
@@ -170,7 +170,7 @@
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-protocol-ldap</artifactId>
         </dependency>
-        
+
     </dependencies>
 
 </project>

--- a/strongbox-data-service/pom.xml
+++ b/strongbox-data-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -89,7 +89,7 @@
             <version>1.0-SNAPSHOT</version>
             <classifier>schema</classifier>
         </dependency>
-        
+
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
@@ -129,7 +129,7 @@
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-        </dependency>        
+        </dependency>
 
         <dependency>
             <groupId>net.sf.ehcache</groupId>
@@ -176,7 +176,7 @@
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-jdbc</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
@@ -210,7 +210,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>

--- a/strongbox-distribution/pom.xml
+++ b/strongbox-distribution/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -210,7 +210,7 @@
 
                 <configuration>
                     <preWrapperConf>${project.basedir}/src/main/resources/setenv.conf</preWrapperConf>
-                    
+
                     <configurationDirectory>etc</configurationDirectory>
 
                     <repositoryLayout>flat</repositoryLayout>
@@ -378,7 +378,7 @@
                     <tarLongFileMode>gnu</tarLongFileMode>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <artifactId>jdeb</artifactId>
                 <groupId>org.vafer</groupId>
@@ -393,7 +393,7 @@
                             <controlDir>${basedir}/src/main/resources/deb</controlDir>
                             <skipPOMs>false</skipPOMs>
                             <dataSet>
-                            
+
                                 <data>
                                     <src>${basedir}/target/assembly/strongbox-${project.version}/bin</src>
                                     <type>directory</type>
@@ -472,7 +472,7 @@
                                         <dirmode>775</dirmode>
                                     </mapper>
                                 </data>
-                                
+
                                 <data>
                                     <linkName>/etc/systemd/system/strongbox.service</linkName>
                                         <linkTarget>/opt/strongbox/strongbox.service</linkTarget>
@@ -484,7 +484,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
         </plugins>
     </build>
 
@@ -512,7 +512,7 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            
+
             <properties>
                 <strongbox.log.file>logback-spring.xml</strongbox.log.file>
             </properties>
@@ -522,7 +522,7 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            
+
             <properties>
                 <strongbox.log.file>logback-spring-debug.xml</strongbox.log.file>
             </properties>

--- a/strongbox-event-api/pom.xml
+++ b/strongbox-event-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -107,7 +107,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
         </dependency>
-        
+
     </dependencies>
 
 </project>

--- a/strongbox-resources/pom.xml
+++ b/strongbox-resources/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
-    
+
     <artifactId>strongbox-resources</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>Strongbox: Resources</name>
 
     <inceptionYear>2019</inceptionYear>
@@ -29,5 +29,5 @@
         <module>strongbox-common-resources</module>
         <module>strongbox-storage-api-resources</module>
     </modules>
-    
+
 </project>

--- a/strongbox-resources/strongbox-common-resources/pom.xml
+++ b/strongbox-resources/strongbox-common-resources/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-resources/strongbox-storage-api-resources/pom.xml
+++ b/strongbox-resources/strongbox-storage-api-resources/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-rest-client/pom.xml
+++ b/strongbox-rest-client/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/pom.xml
+++ b/strongbox-security/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-api/pom.xml
+++ b/strongbox-security/strongbox-authentication-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-default-authentication-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
+++ b/strongbox-security/strongbox-authentication-providers/strongbox-ldap-authentication-provider/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-authentication-registry/pom.xml
+++ b/strongbox-security/strongbox-authentication-registry/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -67,7 +67,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-user-management</artifactId>
             <version>${project.version}</version>
-        </dependency>        
+        </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/strongbox-security/strongbox-authentication-support/pom.xml
+++ b/strongbox-security/strongbox-authentication-support/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-security-api/pom.xml
+++ b/strongbox-security/strongbox-security-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-security/strongbox-user-management/pom.xml
+++ b/strongbox-security/strongbox-user-management/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -122,7 +122,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>

--- a/strongbox-storage/pom.xml
+++ b/strongbox-storage/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-api/pom.xml
+++ b/strongbox-storage/strongbox-storage-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -179,7 +179,7 @@
             <groupId>org.javatuples</groupId>
             <artifactId>javatuples</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>
@@ -189,7 +189,7 @@
             <groupId>com.github.ThoughtWire</groupId>
             <artifactId>hazelcast-locks</artifactId>
         </dependency>
-        
+
     </dependencies>
-    
+
 </project>

--- a/strongbox-storage/strongbox-storage-core/pom.xml
+++ b/strongbox-storage/strongbox-storage-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/pom.xml
@@ -7,7 +7,7 @@
 <parent>
     <groupId>org.carlspring.strongbox</groupId>
     <artifactId>strongbox-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-issue-1856-SNAPSHOT</version>
     <relativePath/>
 </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-maven-metadata-api/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -125,7 +125,7 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -86,7 +86,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>            
+            </plugin>
         </plugins>
     </build>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-p2-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/pom.xml
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-raw-layout-provider/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>

--- a/strongbox-testing/pom.xml
+++ b/strongbox-testing/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
-    
+
     <artifactId>strongbox-testing</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>Strongbox: Testing</name>
 
     <inceptionYear>2019</inceptionYear>
@@ -29,5 +29,5 @@
         <module>strongbox-testing-core</module>
         <module>strongbox-testing-web</module>
     </modules>
-    
+
 </project>

--- a/strongbox-testing/strongbox-testing-core/pom.xml
+++ b/strongbox-testing/strongbox-testing-core/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
-    
+
     <artifactId>strongbox-testing-core</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    
+
     <name>Strongbox: Testing [Core]</name>
 
     <licenses>
@@ -73,10 +73,10 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>            
+            </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -113,7 +113,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
              <artifactId>jul-to-slf4j</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -145,7 +145,7 @@
         </dependency>
 
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>run-it-tests</id>

--- a/strongbox-testing/strongbox-testing-web/pom.xml
+++ b/strongbox-testing/strongbox-testing-web/pom.xml
@@ -2,20 +2,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
-    
+
     <artifactId>strongbox-testing-web</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    
+
     <name>Strongbox: Testing [Web]</name>
 
     <licenses>
@@ -69,7 +69,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -89,7 +89,7 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>strongbox-testing-core</artifactId>
@@ -165,7 +165,7 @@
             <artifactId>spring-mock-mvc</artifactId>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>run-it-tests</id>

--- a/strongbox-web-core/pom.xml
+++ b/strongbox-web-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.carlspring.strongbox</groupId>
         <artifactId>strongbox-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -212,7 +212,7 @@
             <artifactId>strongbox-storage-npm-layout-provider</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
-            <scope>test</scope>            
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -361,7 +361,7 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-analysis</artifactId>
         </dependency>
-        
+
         <!-- Spring security dependencies -->
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -427,7 +427,7 @@
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
         </dependency>
-        
+
         <!-- Other utils: swagger, .. -->
         <dependency>
             <groupId>io.swagger</groupId>
@@ -476,7 +476,7 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>javax.transaction-api</artifactId>

--- a/strongbox-web-forms/pom.xml
+++ b/strongbox-web-forms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>strongbox-parent</artifactId>
         <groupId>org.carlspring.strongbox</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.0-issue-1856-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1856 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
