### PR TITLE
Issue 1865: Added profiles to enforce JDK 1.8.0-241 or 11.3 and up.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-			
+            
             <build>
                 <plugins>
                     <plugin>
@@ -127,71 +127,69 @@
                 </plugins>
             </build>
         </profile>
-		<profile>
-			<id>java11</id>
-			<activation>
-				<jdk>11</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-enforcer-plugin</artifactId>
-						<version>3.0.0-M3</version>
-						<executions>
-							<execution>
-								<id>enforce-versions</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>enforce</goal>
-								</goals>
-								<configuration>
-									<rules>
-										<requireJavaVersion>
-											<version>[11.3,)</version>
-											<message>Strongbox only supports JDK 11.3 and up.</message>
-											<level>ERROR</level>
-										</requireJavaVersion>
-									</rules>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
-			<id>java8</id>
-			<activation>
-				<jdk>1.8</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-enforcer-plugin</artifactId>
-						<version>3.0.0-M3</version>
-						<executions>
-							<execution>
-								<id>enforce-versions</id>
-								<phase>validate</phase>
-								<goals>
-									<goal>enforce</goal>
-								</goals>
-								<configuration>
-									<rules>
-										<requireJavaVersion>
-											<version>[1.8.0-241,)</version>
-											<message>Strongbox only supports JDK 1.8.0-241 and up.</message>
-											<level>ERROR</level>
-										</requireJavaVersion>
-									</rules>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>Enforce-Java-11</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <!--<version>3.0.0-M3</version>-->
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[11.3,)</version>
+                                            <message>Strongbox only supports JDK 11.3 and up.</message>
+                                            <level>ERROR</level>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>Enforce-Java-8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.0.0-M3</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-versions</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[1.8,)</version>
+                                            <message>Strongbox only supports JDK 1.8.0-241 and up.</message>
+                                            <level>ERROR</level>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-
+			
             <build>
                 <plugins>
                     <plugin>
@@ -119,7 +119,7 @@
                                 <version>8.29</version>
                             </dependency>
                         </dependencies>
-                        <configuration>
+                        <configuration>     
                             <configLocation>strongbox-checks.xml</configLocation>
                             <consoleOutput>true</consoleOutput>
                         </configuration>
@@ -127,5 +127,71 @@
                 </plugins>
             </build>
         </profile>
+		<profile>
+			<id>java11</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<executions>
+							<execution>
+								<id>enforce-versions</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<requireJavaVersion>
+											<version>[11.3,)</version>
+											<message>Strongbox only supports JDK 11.3 and up.</message>
+											<level>ERROR</level>
+										</requireJavaVersion>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>java8</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<version>3.0.0-M3</version>
+						<executions>
+							<execution>
+								<id>enforce-versions</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>enforce</goal>
+								</goals>
+								<configuration>
+									<rules>
+										<requireJavaVersion>
+											<version>[1.8.0-241,)</version>
+											<message>Strongbox only supports JDK 1.8.0-241 and up.</message>
+											<level>ERROR</level>
+										</requireJavaVersion>
+									</rules>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
     </profiles>
 </project>


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1865

# Acceptance Test

* [X] Building the code with `mvn clean install -Dintegration.tests` still works.
* [X] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [X] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [X] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [X] No
