### PR TITLE
Use openjdk8 for travis-ci macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,19 @@ install: true
 before_script:
   - while sleep 120; do printf "[ %ss ] maven is still running...\n" `date +%H:%M:%S`; done &
 
-script: $HOME/mvn -V clean install -Dintegration.tests -T 2 -Daether.connector.resumeDownloads=false --log-file=build.log
+# Use openjdk8 for this build (version should be >= u222)
+script:
+  - wget https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_mac_hotspot_8u275b01.tar.gz
+  - tar -xf OpenJDK8U-jdk_x64_mac_hotspot_8u275b01.tar.gz
+  - export JAVA_HOME="$PWD/jdk8u275-b01/Contents/Home"
+  - java -version
+  - $HOME/mvn -V clean install -Dintegration.tests -T 2 -Daether.connector.resumeDownloads=false --log-file=build.log
 
 after_failure:
   # Killing sleep loop
   - kill %1 2>&1
   - echo "Build has failed!"
-  - cat build.log
+  - tail -n 1000 build.log
 
 after_success:
   # Killing sleep loop

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenProxyRepositoryProviderTestIT.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/providers/repository/MavenProxyRepositoryProviderTestIT.java
@@ -46,7 +46,8 @@ public class MavenProxyRepositoryProviderTestIT
 
     private static final String REPOSITORY_ID = "spring-libs-release-it";
 
-    private static final String REMOTE_URL = "https://repo.spring.io/libs-release/";
+    // using jcenter as repositories at https://repo.spring.io now expect you to be logged in to access artifacts
+    private static final String REMOTE_URL = "https://jcenter.bintray.com/";
 
     private static final String CENTRAL_REPOSITORY_ID = "central-release-it";
 


### PR DESCRIPTION
@steve-todorov 

I've fixed the failing integration tests in #1958 by replacing the remote url from `repo.spring.io` to `jcenter.bintray.com` as recommended by @carlspring.

Travis CI build: https://travis-ci.org/github/j4ckofalltrades/strongbox/jobs/743752372

# Pull Request Description

This pull request closes #1956
This pull request also closes #1958

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No

# Code Review And Pre-Merge Checklist

* [x] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [x] My changes generate no new warnings.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.
