### PR TITLE
Added support of license types in Pypi test artifacts

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -43,6 +43,8 @@ public interface ArtifactGenerator
     Path generateArtifact(URI uri,
                           long size)
         throws IOException;
+    
+    void setLicenses(LicenseConfiguration[] licenses);
 
     default void copyLicenseFile(String licenseFileSourcePath,
                                  OutputStream os)
@@ -53,6 +55,12 @@ public interface ArtifactGenerator
         IOUtils.copy(resource.getInputStream(), os);
     }
 
-    void setLicenses(LicenseConfiguration[] licenses);
+    default byte[] getLicenseFileContent(String licenseFileSourcePath) 
+            throws IOException
+    {
+        ClassPathResource resource = new ClassPathResource(licenseFileSourcePath, this.getClass().getClassLoader());
+
+        return IOUtils.toByteArray(resource.getInputStream());
+    }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -44,7 +44,8 @@ public interface ArtifactGenerator
                           long size)
         throws IOException;
     
-    void setLicenses(LicenseConfiguration[] licenses);
+    void setLicenses(LicenseConfiguration[] licenses)
+        throws IOException;
 
     default void copyLicenseFile(String licenseFileSourcePath,
                                  OutputStream os)

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -44,12 +44,15 @@ public interface ArtifactGenerator
                           long size)
         throws IOException;
 
-    default void copyLicenseFile(String licenseFileSourcePath, OutputStream os)
+    default void copyLicenseFile(String licenseFileSourcePath,
+                                 OutputStream os)
             throws IOException
     {
         ClassPathResource resource = new ClassPathResource(licenseFileSourcePath, this.getClass().getClassLoader());
 
         IOUtils.copy(resource.getInputStream(), os);
     }
+
+    void setLicenses(LicenseConfiguration[] licenses);
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/RawArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/RawArtifactGenerator.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
 import org.carlspring.strongbox.io.LayoutOutputStream;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.util.MessageDigestUtils;
 import org.carlspring.strongbox.util.TestFileUtils;
 
@@ -83,6 +84,12 @@ public class RawArtifactGenerator implements ArtifactGenerator
     {
         String md5 = layoutOutputStream.getDigestMap().get(MessageDigestAlgorithms.MD5);
         MessageDigestUtils.writeChecksum(artifactPath, ".md5", md5);
+    }
+
+    @Override
+    public void setLicenses(LicenseConfiguration[] licenses)
+    {
+        
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
@@ -22,7 +22,8 @@ public interface ArtifactGeneratorStrategy<T extends ArtifactGenerator>
         throws IOException;
     
     default void setLicenses(ArtifactGenerator artifactGenerator,
-                             Map<String, Object> attributesMap)
+                             Map<String, Object> attributesMap) 
+        throws IOException
     {
         Object licenses = attributesMap.get("licenses");
         if (licenses instanceof LicenseConfiguration[])

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
@@ -1,10 +1,10 @@
 package org.carlspring.strongbox.testing.artifact;
 
+import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
-
-import org.carlspring.strongbox.artifact.generator.ArtifactGenerator;
 
 /**
  * @author sbespalov
@@ -20,5 +20,16 @@ public interface ArtifactGeneratorStrategy<T extends ArtifactGenerator>
                           long size,
                           Map<String, Object> attributesMap)
         throws IOException;
+    
+    default void setLicenses(ArtifactGenerator artifactGenerator,
+                             Map<String, Object> attributesMap)
+    {
+
+        Object licenses = attributesMap.get("licenses");
+        if (licenses instanceof LicenseConfiguration[])
+        {
+            artifactGenerator.setLicenses((LicenseConfiguration[]) licenses);
+        }
+    }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/ArtifactGeneratorStrategy.java
@@ -24,7 +24,6 @@ public interface ArtifactGeneratorStrategy<T extends ArtifactGenerator>
     default void setLicenses(ArtifactGenerator artifactGenerator,
                              Map<String, Object> attributesMap)
     {
-
         Object licenses = attributesMap.get("licenses");
         if (licenses instanceof LicenseConfiguration[])
         {

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/DefaultArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/DefaultArtifactGeneratorStrategy.java
@@ -18,6 +18,8 @@ public class DefaultArtifactGeneratorStrategy
                                  Map<String, Object> attributesMap)
             throws IOException
     {
+        setLicenses(artifactGenerator, attributesMap);
+
         return artifactGenerator.generateArtifact(id, version, size);
     }
 

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -169,6 +169,13 @@ public class TestArtifactContext implements AutoCloseable
     private Path generateArtifact(String resource, long size)
             throws IOException
     {
+        
+        Object licenses = attributesMap.get("licenses");
+        if (licenses instanceof LicenseConfiguration[])
+        {
+            artifactGenerator.setLicenses((LicenseConfiguration[]) licenses);
+        }
+
         Path artifactPathLocal = artifactGenerator.generateArtifact(URI.create(resource), size);
         if (testArtifact.repositoryId().isEmpty())
         {

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/testing/artifact/TestArtifactContext.java
@@ -169,7 +169,6 @@ public class TestArtifactContext implements AutoCloseable
     private Path generateArtifact(String resource, long size)
             throws IOException
     {
-        
         Object licenses = attributesMap.get("licenses");
         if (licenses instanceof LicenseConfiguration[])
         {

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -433,7 +433,7 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     @Override
     public void setLicenses(LicenseConfiguration[] licenses)
     {
-
+        this.licenses = (MavenLicenseConfiguration[]) licenses;
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-maven-layout/strongbox-storage-maven-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/MavenArtifactGenerator.java
@@ -4,6 +4,7 @@ import org.carlspring.commons.encryption.EncryptionAlgorithmsEnum;
 import org.carlspring.commons.io.MultipleDigestInputStream;
 import org.carlspring.commons.io.MultipleDigestOutputStream;
 import org.carlspring.strongbox.artifact.MavenArtifactUtils;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.testing.artifact.MavenArtifactTestUtils;
 import org.carlspring.strongbox.testing.artifact.MavenLicenseConfiguration;
 import org.carlspring.strongbox.util.TestFileUtils;
@@ -427,6 +428,12 @@ public class MavenArtifactGenerator implements ArtifactGenerator
     public void setLicenses(MavenLicenseConfiguration[] licenses)
     {
         this.licenses = licenses;
+    }
+
+    @Override
+    public void setLicenses(LicenseConfiguration[] licenses)
+    {
+
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.artifact.generator;
 import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
 import org.carlspring.strongbox.npm.metadata.Dist;
 import org.carlspring.strongbox.npm.metadata.PackageVersion;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.util.TestFileUtils;
 
 import java.io.BufferedOutputStream;
@@ -251,6 +252,13 @@ public class NpmArtifactGenerator
         }
 
         return publishJsonPath;
+    }
+
+    @Override
+    public void setLicenses(LicenseConfiguration[] licenses)
+    {
+        // set NPM licenses
+
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-nuget-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NugetArtifactGenerator.java
@@ -7,6 +7,7 @@ import org.carlspring.strongbox.storage.metadata.nuget.Dependencies;
 import org.carlspring.strongbox.storage.metadata.nuget.Dependency;
 import org.carlspring.strongbox.storage.metadata.nuget.NugetFormatException;
 import org.carlspring.strongbox.storage.metadata.nuget.Nuspec;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.util.MessageDigestUtils;
 import org.carlspring.strongbox.util.TestFileUtils;
 
@@ -359,6 +360,12 @@ public class NugetArtifactGenerator
     public String getBasedir()
     {
         return basePath.normalize().toAbsolutePath().toString();
+    }
+
+    @Override
+    public void setLicenses(LicenseConfiguration[] licenses)
+    {
+        // set Nuget licenses
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
@@ -3,6 +3,7 @@ package org.carlspring.strongbox.artifact.generator;
 import com.google.common.hash.Hashing;
 import org.apache.commons.io.FilenameUtils;
 import org.carlspring.strongbox.artifact.coordinates.PypiArtifactCoordinates;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.util.TestFileUtils;
 
 import java.io.IOException;
@@ -20,7 +21,7 @@ import static java.nio.file.StandardOpenOption.CREATE;
 public class PypiArtifactGenerator
         implements ArtifactGenerator
 {
-
+    
     private static final String METADATA_CONTENT = "Metadata-Version: 2.1\n" +
                                                    "Name: %s\n" +
                                                    "Version: %s\n" +
@@ -68,7 +69,10 @@ public class PypiArtifactGenerator
                                                   "%s\n" +
                                                   "%s\n" +
                                                   "%s";
+
     private Path basedir;
+
+    private LicenseConfiguration[] licenses;
     
     public PypiArtifactGenerator(Path basedir)
     {
@@ -78,6 +82,12 @@ public class PypiArtifactGenerator
     public PypiArtifactGenerator(String basedir)
     {
         this.basedir = Paths.get(basedir);
+    }
+
+    @Override
+    public void setLicenses(LicenseConfiguration[] licenses)
+    {
+        this.licenses = licenses;
     }
 
     @Override
@@ -190,9 +200,20 @@ public class PypiArtifactGenerator
                                               dependencyLinksPath,
                                               topLevelPath).getBytes();
         createZipEntry(zos, sourcesPath, sourcesContent);
+        
+        copyLicenseFiles(zos);
 
         String randomPath = eggDirectory + "/RANDOM.txt";
         TestFileUtils.generateFile(zos, byteSize, randomPath);
+    }
+
+    private void copyLicenseFiles(ZipOutputStream zos)
+    {
+
+        if (licenses != null && licenses.length > 0)
+        {
+            
+        }
     }
 
     private void createWheelPackageFiles(ZipOutputStream zos,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
@@ -221,7 +221,7 @@ public class PypiArtifactGenerator
         {
             if (licenses.length > 1)
             {
-                throw new IOException("Pypi packages doesn't support multiple licence");
+                throw new IOException("PyPi doesn't support multiple licenses!");
             }
 
             return licenses[0].license().getName();
@@ -237,7 +237,7 @@ public class PypiArtifactGenerator
         {
             if (licenses.length > 1)
             {
-                throw new IOException("Pypi packages doesn't support multiple licence");
+                throw new IOException("PyPi doesn't support multiple licenses!");
             }
 
             return licenses[0].destinationPath();
@@ -253,7 +253,7 @@ public class PypiArtifactGenerator
         {
             if (licenses.length > 1)
             {
-                throw new IOException("Pypi packages doesn't support multiple licence");
+                throw new IOException("PyPi doesn't support multiple licenses!");
             }
 
             return licenses[0].license().getLicenseFileSourcePath();

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGenerator.java
@@ -223,7 +223,7 @@ public class PypiArtifactGenerator
                 throw new IOException("Pypi packages doesn't support multiple licence");
             }
 
-            return licenses[0].license().name();
+            return licenses[0].license().getName();
         }
 
         return "LICENCE";

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/PypiArtifactGeneratorTest.java
@@ -5,8 +5,6 @@ import static org.carlspring.strongbox.util.MessageDigestUtils.calculateChecksum
 import static org.carlspring.strongbox.util.MessageDigestUtils.readChecksumFile;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import org.carlspring.strongbox.config.PypiLayoutProviderTestConfig;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
@@ -17,10 +15,11 @@ import org.carlspring.strongbox.testing.repository.PypiTestRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Enumeration;
+import java.security.NoSuchAlgorithmException;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -80,7 +79,7 @@ public class PypiArtifactGeneratorTest
                     .isNotNull();
 
             try (InputStreamReader streamReader = new InputStreamReader(zipFile.getInputStream(metadataFile));
-                    BufferedReader bufferedReader = new BufferedReader(streamReader);)
+                 BufferedReader bufferedReader = new BufferedReader(streamReader);)
             {
                 String metadataContent = bufferedReader.lines().collect(Collectors.joining("\n"));
                 assertThat(metadataContent).contains("License: MIT License");
@@ -117,7 +116,7 @@ public class PypiArtifactGeneratorTest
                     .isNotNull();
             
             try (InputStreamReader streamReader = new InputStreamReader(zipFile.getInputStream(metadataFile));
-                    BufferedReader bufferedReader = new BufferedReader(streamReader);)
+                 BufferedReader bufferedReader = new BufferedReader(streamReader);)
             {
                 String metadataContent = bufferedReader.lines().collect(Collectors.joining("\n"));
                 assertThat(metadataContent).contains("License: Apache 2.0");
@@ -127,14 +126,14 @@ public class PypiArtifactGeneratorTest
 
     
     @ExtendWith({ RepositoryManagementTestExecutionListener.class,
-        ArtifactManagementTestExecutionListener.class })
+                  ArtifactManagementTestExecutionListener.class })
     @Test
     public void testArtifactWithoutLicense(@PypiTestRepository(repositoryId = "repositoryId")
-                      Repository repository,
-                      @PypiTestArtifact(repositoryId = "repositoryId",
-                                        resource = "strongbox-testing-without-license-1.0.tar.gz",
-                                        bytesSize = 4096)
-                      Path artifactPath)
+                                           Repository repository,
+                                           @PypiTestArtifact(repositoryId = "repositoryId",
+                                                             resource = "strongbox-testing-without-license-1.0.tar.gz",
+                                                             bytesSize = 4096)
+                                           Path artifactPath)
             throws Exception
     {
         assertArtifactAndHash(artifactPath);
@@ -153,7 +152,7 @@ public class PypiArtifactGeneratorTest
                     .isNull();
             
             try (InputStreamReader streamReader = new InputStreamReader(zipFile.getInputStream(metadataFile));
-                    BufferedReader bufferedReader = new BufferedReader(streamReader);)
+                 BufferedReader bufferedReader = new BufferedReader(streamReader);)
             {
                 String metadataContent = bufferedReader.lines().collect(Collectors.joining("\n"));
                 assertThat(metadataContent).contains("License: Unlicense");

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiArtifactGeneratorStrategy.java
@@ -29,6 +29,9 @@ public class PypiArtifactGeneratorStrategy
                                                                           "none",
                                                                           "any",
                                                                           (String) attributesMap.get("packaging"));
+        
+        setLicenses(artifactGenerator, attributesMap);
+        
         return artifactGenerator.generateArtifact(coordinates, byteSize);
     }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-pypi-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/PypiTestArtifact.java
@@ -65,4 +65,6 @@ public @interface PypiTestArtifact
      */
     @AliasFor(annotation = TestArtifact.class)
     long bytesSize() default 1000000;
+
+    LicenseConfiguration[] licenses() default {};
 }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1727 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No

# Code Review And Pre-Merge Checklist

* [x] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in hard-to-understand areas.
* [x] My changes generate no new warnings.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.
