### PR TITLE
Added support of license types in NPM test artifacts 

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.ClassPathResource;
@@ -62,6 +63,22 @@ public interface ArtifactGenerator
         ClassPathResource resource = new ClassPathResource(licenseFileSourcePath, this.getClass().getClassLoader());
 
         return IOUtils.toByteArray(resource.getInputStream());
+    }
+    
+    /**
+     * Added this to handle instantiation of TarArchiveEntry with only file name.
+     * When TarArchiveEntry is created with only file name it considers it's size as zero, so size has to be set explicitly.
+     * @param licenseConfiguration
+     * @return size of the license file in bytes
+     * @throws IOException
+     */
+    default long getLicenseFileSize(LicenseConfiguration licenseConfiguration)
+            throws IOException
+    {
+        ClassPathResource resource = new ClassPathResource(licenseConfiguration.license().getLicenseFileSourcePath(),
+                                                           this.getClass().getClassLoader());
+
+        return Paths.get(resource.getURI()).toFile().length();
     }
 
 }

--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -78,7 +78,7 @@ public interface ArtifactGenerator
         ClassPathResource resource = new ClassPathResource(licenseConfiguration.license().getLicenseFileSourcePath(),
                                                            this.getClass().getClassLoader());
 
-        return Paths.get(resource.getURI()).toFile().length();
+        return IOUtils.toByteArray(resource.getInputStream()).length;
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/NpmArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/NpmArtifactGeneratorTest.java
@@ -67,9 +67,9 @@ class NpmArtifactGeneratorTest
         assertArtifactAndHash(path);
         
         try (InputStream is = Files.newInputStream(path);
-                BufferedInputStream bis = new BufferedInputStream(is);
-                GzipCompressorInputStream gzInputStream = new GzipCompressorInputStream(bis);
-                TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzInputStream))
+             BufferedInputStream bis = new BufferedInputStream(is);
+             GzipCompressorInputStream gzInputStream = new GzipCompressorInputStream(bis);
+             TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzInputStream))
         {
             PackageVersion packageJson = null;
             TarArchiveEntry entry = null;
@@ -118,7 +118,7 @@ class NpmArtifactGeneratorTest
     void testArtifactGenerationWithLicense(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
                                            Repository repository,
                                            @NpmTestArtifact(repositoryId = REPOSITORY_RELEASES,
-                                                            id = "npm-test-view",
+                                                            id = "npm-test-view-with-license",
                                                             versions = "1.0.0",
                                                             scope = "@carlspring",
                                                             bytesSize = 2048,

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/NpmArtifactGeneratorTest.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generation/NpmArtifactGeneratorTest.java
@@ -1,26 +1,43 @@
 package org.carlspring.strongbox.artifact.generation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.carlspring.strongbox.util.MessageDigestUtils.calculateChecksum;
+import static org.carlspring.strongbox.util.MessageDigestUtils.readChecksumFile;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
 import org.carlspring.strongbox.config.NpmLayoutProviderTestConfig;
+import org.carlspring.strongbox.npm.metadata.License;
+import org.carlspring.strongbox.npm.metadata.PackageVersion;
 import org.carlspring.strongbox.storage.repository.Repository;
 import org.carlspring.strongbox.testing.artifact.ArtifactManagementTestExecutionListener;
+import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
+import org.carlspring.strongbox.testing.artifact.LicenseType;
 import org.carlspring.strongbox.testing.artifact.NpmTestArtifact;
 import org.carlspring.strongbox.testing.repository.NpmRepository;
 import org.carlspring.strongbox.testing.storage.repository.RepositoryManagementTestExecutionListener;
 
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.codec.digest.MessageDigestAlgorithms;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.carlspring.strongbox.util.MessageDigestUtils.calculateChecksum;
-import static org.carlspring.strongbox.util.MessageDigestUtils.readChecksumFile;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Wojciech Pater
@@ -46,6 +63,130 @@ class NpmArtifactGeneratorTest
                                                  bytesSize = 2048)
                                 Path path)
             throws Exception
+    {
+        assertArtifactAndHash(path);
+        
+        try (InputStream is = Files.newInputStream(path);
+                BufferedInputStream bis = new BufferedInputStream(is);
+                GzipCompressorInputStream gzInputStream = new GzipCompressorInputStream(bis);
+                TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzInputStream))
+        {
+            PackageVersion packageJson = null;
+            TarArchiveEntry entry = null;
+            TarArchiveEntry apacheLicenseEntry = null;
+            TarArchiveEntry licenseEntry = null;
+            TarArchiveEntry packageJsonEntry = null;
+            while ((entry = (TarArchiveEntry) tarArchiveInputStream.getNextEntry()) != null)
+            {
+                if (entry.getName().equals("LICENSE-Apache-2.0.md"))
+                {
+                    apacheLicenseEntry = entry;
+                }
+                else if (entry.getName().equals("LICENSE"))
+                {
+                    licenseEntry = entry;
+                }
+                else if (entry.getName().equals("package.json"))
+                {
+                    packageJsonEntry = entry;
+                    packageJson = new ObjectMapper().readValue(new String(IOUtils.toByteArray(tarArchiveInputStream)),
+                                                               PackageVersion.class);
+                }
+            }
+
+            assertThat(packageJsonEntry)
+                    .as("Did not find a license file package.json was expected at the default location in the TAR source package!")
+                    .isNotNull();
+
+            assertThat(apacheLicenseEntry)
+                    .as("Found license file LICENSE-Apache-2.0.md that was not expected at the default location in the TAR source package!")
+                    .isNull();
+
+            assertThat(licenseEntry)
+                    .as("Found license file LICENSE that was expected at the default location in the TAR source package!")
+                     .isNull();
+
+            assertThat(packageJson.getLicenses().size())
+                    .isEqualTo(0);
+        }
+    }
+    
+    
+    @ExtendWith({ RepositoryManagementTestExecutionListener.class,
+                  ArtifactManagementTestExecutionListener.class })
+    @Test
+    void testArtifactGenerationWithLicense(@NpmRepository(repositoryId = REPOSITORY_RELEASES)
+                                           Repository repository,
+                                           @NpmTestArtifact(repositoryId = REPOSITORY_RELEASES,
+                                                            id = "npm-test-view",
+                                                            versions = "1.0.0",
+                                                            scope = "@carlspring",
+                                                            bytesSize = 2048,
+                                                            licenses = { @LicenseConfiguration(license = LicenseType.APACHE_2_0,
+                                                                                               destinationPath = "LICENSE-Apache-2.0.md"),
+                                                                         @LicenseConfiguration(license = LicenseType.MIT,
+                                                                                               destinationPath = "LICENSE-MIT-License.md")})
+                                           Path path)
+            throws Exception
+    {
+        assertArtifactAndHash(path);
+        
+        try (InputStream is = Files.newInputStream(path);
+             BufferedInputStream bis = new BufferedInputStream(is);
+             GzipCompressorInputStream gzInputStream = new GzipCompressorInputStream(bis);
+             TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzInputStream))
+        {
+            PackageVersion packageJson = null;
+            TarArchiveEntry entry = null;
+            TarArchiveEntry apacheLicenseEntry = null;
+            TarArchiveEntry mitLicenseEntry = null;
+            TarArchiveEntry packageJsonEntry = null;
+            while ((entry = (TarArchiveEntry) tarArchiveInputStream.getNextEntry()) != null)
+            {
+                if (entry.getName().equals("LICENSE-Apache-2.0.md"))
+                {
+                    apacheLicenseEntry = entry;
+                }
+                else if (entry.getName().equals("LICENSE-MIT-License.md"))
+                {
+                    mitLicenseEntry = entry;
+                }
+                else if (entry.getName().equals("package.json"))
+                {
+                    packageJsonEntry = entry;
+                    packageJson = new ObjectMapper().readValue(new String(IOUtils.toByteArray(tarArchiveInputStream)),
+                                                               PackageVersion.class);
+                }
+            }
+
+            assertThat(packageJsonEntry)
+                    .as("Did not find a license file package.json was expected at the default location in the TAR source package!")
+                    .isNotNull();
+            
+            assertThat(apacheLicenseEntry)
+                    .as("Did not find a license file LICENSE-Apache-2.0.md that was expected at the default location in the TAR source package!")
+                    .isNotNull();
+            
+            assertThat(mitLicenseEntry)
+                    .as("Did not find a license file LICENSE-MIT-License.md that was expected at the default location in the TAR source package!")
+                    .isNotNull();
+            
+            assertThat(packageJson.getLicenses())
+                    .isNotNull()
+                    .as("licenses key value not present in package.json!");
+            
+            List<String> licenses = packageJson.getLicenses()
+                                               .stream()
+                                               .map(License::getType)
+                                               .collect(Collectors.toList());
+            
+            assertThat(licenses).contains("Apache 2.0", "MIT License");
+        }
+    }
+
+    private void assertArtifactAndHash(Path path)
+            throws IOException,
+                   NoSuchAlgorithmException
     {
         assertThat(Files.exists(path)).as("Failed to generate NPM package.").isTrue();
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -181,6 +181,10 @@ public class NpmArtifactGenerator
         tarOut.closeArchiveEntry();
     }
 
+    /**
+     * NPM packages store license information in package.json metadata file
+     * @see {https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license}
+     */
     private void populateNpmLicensesinPackageJson()
     {
         if (!ArrayUtils.isEmpty(licenses))

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -129,7 +129,6 @@ public class NpmArtifactGenerator
         {
             for (LicenseConfiguration licenseConfiguration : licenses)
             {
-
                 TarArchiveEntry entry = new TarArchiveEntry(licenseConfiguration.destinationPath());
                 entry.setSize(getLicenseFileSize(licenseConfiguration));
                 tarOut.putArchiveEntry(entry);
@@ -137,7 +136,6 @@ public class NpmArtifactGenerator
                 copyLicenseFile(licenseConfiguration.license().getLicenseFileSourcePath(), tarOut);
                 tarOut.closeArchiveEntry();
             }
-
         }
     }
 

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -2,6 +2,7 @@ package org.carlspring.strongbox.artifact.generator;
 
 import org.carlspring.strongbox.artifact.coordinates.NpmArtifactCoordinates;
 import org.carlspring.strongbox.npm.metadata.Dist;
+import org.carlspring.strongbox.npm.metadata.License;
 import org.carlspring.strongbox.npm.metadata.PackageVersion;
 import org.carlspring.strongbox.testing.artifact.LicenseConfiguration;
 import org.carlspring.strongbox.util.TestFileUtils;
@@ -16,7 +17,10 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -25,7 +29,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.http.MediaType;
+import org.springframework.util.CollectionUtils;
 
 public class NpmArtifactGenerator
         implements ArtifactGenerator
@@ -40,6 +46,8 @@ public class NpmArtifactGenerator
     private Path packagePath;
 
     private ObjectMapper mapper = new ObjectMapper();
+
+    private LicenseConfiguration[] licenses;
 
     public NpmArtifactGenerator(String basedir)
     {
@@ -100,11 +108,31 @@ public class NpmArtifactGenerator
         {
             writeContent(tarOut, bytesSize);
             writePackageJson(tarOut);
+            copyLicenseFiles(tarOut);
         }
 
         calculateChecksum();
 
         return packagePath;
+    }
+
+    private void copyLicenseFiles(TarArchiveOutputStream tarOut)
+            throws IOException
+    {
+        if (!ArrayUtils.isEmpty(licenses))
+        {
+            for (LicenseConfiguration licenseConfiguration : licenses)
+            {
+
+                TarArchiveEntry entry = new TarArchiveEntry(licenseConfiguration.destinationPath());
+                entry.setSize(getLicenseFileSize(licenseConfiguration));
+                tarOut.putArchiveEntry(entry);
+
+                copyLicenseFile(licenseConfiguration.license().getLicenseFileSourcePath(), tarOut);
+                tarOut.closeArchiveEntry();
+            }
+
+        }
     }
 
     private void calculateChecksum()
@@ -132,9 +160,15 @@ public class NpmArtifactGenerator
             throws IOException
     {
         Path packageJsonPath = packagePath.getParent().resolve("package.json");
-        try (OutputStream out = new BufferedOutputStream(
-                Files.newOutputStream(packageJsonPath, StandardOpenOption.CREATE)))
+        
+        try (OutputStream outputStream = Files.newOutputStream(packageJsonPath, StandardOpenOption.CREATE);
+             BufferedOutputStream out = new BufferedOutputStream(outputStream))
         {
+            List<License> licenses = getNpmLicenses();
+            if (!CollectionUtils.isEmpty(licenses))
+            {
+                packageJson.setLicenses(licenses);
+            }
             out.write(mapper.writeValueAsBytes(packageJson));
         }
 
@@ -144,6 +178,24 @@ public class NpmArtifactGenerator
         Files.copy(packageJsonPath, tarOut);
 
         tarOut.closeArchiveEntry();
+    }
+
+    private List<License> getNpmLicenses()
+    {
+        if (!ArrayUtils.isEmpty(licenses))
+        {
+            return Arrays.asList(licenses)
+                         .stream()
+                         .map(licenseConfig -> {
+
+                             License npmLicense = new License();
+                             npmLicense.setType(licenseConfig.license().getName());
+                             npmLicense.setUrl(licenseConfig.license().getUrl());
+                             return npmLicense;
+                         })
+                         .collect(Collectors.toList());
+        }
+        return null;
     }
 
     private void writeContent(TarArchiveOutputStream tarOut,
@@ -257,8 +309,7 @@ public class NpmArtifactGenerator
     @Override
     public void setLicenses(LicenseConfiguration[] licenses)
     {
-        // set NPM licenses
-
+        this.licenses = licenses;
     }
 
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmArtifactGeneratorStrategy.java
@@ -27,6 +27,9 @@ public class NpmArtifactGeneratorStrategy implements ArtifactGeneratorStrategy<N
                                                                         id,
                                                                         version,
                                                                         (String) attributesMap.get("extension"));
+        
+        setLicenses(artifactGenerator, attributesMap);
+
         Path packagePath = artifactGenerator.generateArtifact(coordinates, bytesSize);
         if (!Optional.ofNullable(attributesMap.get("repositoryId"))
                      .filter(repositoryId -> ((String) repositoryId).trim().length() > 0)

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
@@ -69,4 +69,9 @@ public @interface NpmTestArtifact
      */
     String scope() default "";
     
+    /**
+     * License Configuration for test artifact
+     */
+    LicenseConfiguration[] licenses() default {};
+    
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/testing/artifact/NpmTestArtifact.java
@@ -71,6 +71,7 @@ public @interface NpmTestArtifact
     
     /**
      * License Configuration for test artifact
+     * @see {https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license}
      */
     LicenseConfiguration[] licenses() default {};
     


### PR DESCRIPTION
# Pull Request Description

This pull request closes #1725 

# Acceptance Test

* [x] Building the code with `mvn clean install -Dintegration.tests` still works.
* [x] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [x] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [x] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No

# Code Review And Pre-Merge Checklist

* [x] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code in hard-to-understand areas.
* [x] My changes generate no new warnings.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] New and existing unit tests pass locally with my changes.
