### PR TITLE
issues/1981: fixed `strongbox-security-users.yaml` compatibility with UserDto

### DIFF
--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/dto/UserDto.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/dto/UserDto.java
@@ -2,6 +2,7 @@ package org.carlspring.strongbox.users.dto;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -11,6 +12,7 @@ import org.carlspring.strongbox.domain.SecurityRole;
 import org.carlspring.strongbox.domain.SecurityRoleEntity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author mtodorov
@@ -29,7 +31,6 @@ public class UserDto
 
     private String securityTokenKey;
 
-    @JsonIgnore
     private LocalDateTime lastUpdate;
 
     private String sourceId;
@@ -63,6 +64,7 @@ public class UserDto
     }
 
     @Override
+    @JsonIgnore
     public Set<SecurityRole> getRoles()
     {
         return roles != null ? roles.stream()
@@ -71,11 +73,28 @@ public class UserDto
                              : new HashSet<>();
     }
 
-    public void setRoles(Set<String> roles)
+    public void setRoles(Set<SecurityRole> roles)
+    {
+        if (roles == null)
+        {
+            this.roles = new HashSet<>();
+            return;
+        }
+        this.roles = roles.stream().map(SecurityRole::getRoleName).collect(Collectors.toSet());
+    }
+
+    public void setRoleNames(Set<String> roles)
     {
         this.roles = roles != null ? new HashSet<>(roles) : new HashSet<>();
     }
 
+    @JsonProperty("roles")
+    public Set<String> getRoleNames()
+    {
+        return Collections.unmodifiableSet(roles);
+    }
+
+    
     public void addRole(String role)
     {
         roles.add(role);
@@ -119,6 +138,7 @@ public class UserDto
     }
 
     @Override
+    @JsonIgnore
     public LocalDateTime getLastUpdated()
     {
         return lastUpdate;
@@ -130,6 +150,7 @@ public class UserDto
     }
 
     @Override
+    @JsonIgnore
     public String getSourceId()
     {
         return sourceId;

--- a/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/service/impl/InMemoryUserService.java
+++ b/strongbox-security/strongbox-user-management/src/main/java/org/carlspring/strongbox/users/service/impl/InMemoryUserService.java
@@ -122,10 +122,7 @@ public class InMemoryUserService implements UserService
 
             userDto.setUsername(user.getUsername());
             userDto.setEnabled(user.isEnabled());
-            userDto.setRoles(user.getRoles()
-                                 .stream()
-                                 .map(SecurityRole::getRoleName)
-                                 .collect(Collectors.toSet()));
+            userDto.setRoles(user.getRoles());
             userDto.setSecurityTokenKey(user.getSecurityTokenKey());
             userDto.setLastUpdate(LocalDateTimeInstance.now());
 

--- a/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
+++ b/strongbox-security/strongbox-user-management/src/test/java/org/carlspring/strongbox/users/service/YamlUserServiceTest.java
@@ -206,7 +206,7 @@ public class YamlUserServiceTest
         userUpdate.setPassword("another-password");
         userUpdate.setSecurityTokenKey("after");
         userUpdate.setEnabled(false);
-        userUpdate.setRoles(new HashSet<>(Arrays.asList("a", "b")));
+        userUpdate.setRoleNames(new HashSet<>(Arrays.asList("a", "b")));
 
         userService.updateAccountDetailsByUsername(userUpdate);
 

--- a/strongbox-web-core/src/main/java/org/carlspring/strongbox/converters/users/UserFormToUserDtoConverter.java
+++ b/strongbox-web-core/src/main/java/org/carlspring/strongbox/converters/users/UserFormToUserDtoConverter.java
@@ -22,7 +22,7 @@ public enum UserFormToUserDtoConverter
         user.setUsername(userForm.getUsername());
         user.setPassword(userForm.getPassword());
         user.setEnabled(userForm.isEnabled());
-        user.setRoles(userForm.getRoles());
+        user.setRoleNames(userForm.getRoles());
         user.setSecurityTokenKey(userForm.getSecurityTokenKey());
 
         return user;

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/login/LoginControllerTest.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/login/LoginControllerTest.java
@@ -197,7 +197,7 @@ public class LoginControllerTest
         UserDto cacheEvictionTestUser = new UserDto();
         cacheEvictionTestUser.setUsername("admin-cache-eviction-test");
         cacheEvictionTestUser.setPassword("password");
-        cacheEvictionTestUser.setRoles(ImmutableSet.of("ADMIN"));
+        cacheEvictionTestUser.setRoleNames(ImmutableSet.of("ADMIN"));
         cacheEvictionTestUser.setEnabled(true);
         cacheEvictionTestUser.setSecurityTokenKey("admin-cache-eviction-test-secret");
         userService.save(new EncodedPasswordUser(cacheEvictionTestUser, passwordEncoder));

--- a/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/UserControllerTestIT.java
+++ b/strongbox-web-core/src/test/java/org/carlspring/strongbox/controllers/users/UserControllerTestIT.java
@@ -439,7 +439,7 @@ public class UserControllerTestIT
         user.setUsername(username);
         user.setPassword(newPassword);
         user.setSecurityTokenKey("some-security-token");
-        user.setRoles(ImmutableSet.of(SystemRole.UI_MANAGER.name()));
+        user.setRoleNames(ImmutableSet.of(SystemRole.UI_MANAGER.name()));
         userService.save(user);
 
         UserForm admin = buildUser(username, newPassword);


### PR DESCRIPTION


# Pull Request Description

This pull request closes #1981

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [ ] No

# Code Review And Pre-Merge Checklist

* [ ] My code follows the [coding convention](https://strongbox.github.io/developer-guide/coding-convention.html) of this project.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code in hard-to-understand areas.
* [ ] My changes generate no new warnings.
* [ ] I have added tests that prove my fix is effective or that my feature works.
* [ ] New and existing unit tests pass locally with my changes.
